### PR TITLE
Build as a release with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM elixir:1.6 as builder
+
+ENV MIX_ENV=prod
+
+WORKDIR /root
+ADD . .
+
+# Configure Git to use HTTPS in order to avoid issues with the internal MBTA network
+RUN git config --global url.https://github.com/.insteadOf git://github.com/
+
+# Install hex and rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force && \
+    mix do deps.get --only prod, compile --force
+
+WORKDIR /root/assets/
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g npm@latest && \
+    npm install -g brunch
+
+RUN npm install
+RUN brunch build --production
+
+WORKDIR /root
+RUN mix phx.digest
+RUN mix release --verbose
+
+# the one the elixir image was built with
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl1.1 libsctp1 curl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+EXPOSE 4000
+ENV MIX_ENV=prod TERM=xterm LANG="C.UTF-8" PORT=4000
+
+COPY --from=builder /root/_build/prod/rel/signs_ui/releases/current/signs_ui.tar.gz .
+RUN mkdir gtfs
+RUN tar -xzf signs_ui.tar.gz
+CMD ["bin/signs_ui", "foreground"]

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,8 +15,7 @@ config :signs_ui, SignsUiWeb.Endpoint,
 
 # Internal configuration
 config :signs_ui,
-  http_client: HTTPoison,
-  signs_url: System.get_env("SIGNS_URL")
+  http_client: HTTPoison
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -58,7 +58,3 @@ config :phoenix, :serve_endpoints, true
 #
 #     config :signs_ui, SignsUiWeb.Endpoint, server: true
 #
-
-# Finally import the config/prod.secret.exs
-# which should be versioned separately.
-import_config "prod.secret.exs"

--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -1,8 +1,12 @@
 defmodule SignsUi.Application do
   use Application
 
+  alias SignsUi.Utilities.Config
+
   def start(_type, _args) do
     import Supervisor.Spec
+
+    set_runtime_config()
 
     # Define workers and child supervisors to be supervised
     children = [
@@ -24,5 +28,9 @@ defmodule SignsUi.Application do
   def config_change(changed, _new, removed) do
     SignsUiWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp set_runtime_config do
+    Config.update_env(:s3_bucket, System.get_env("SIGNS_URL"))
   end
 end

--- a/lib/utilities/config.ex
+++ b/lib/utilities/config.ex
@@ -1,0 +1,7 @@
+defmodule SignsUi.Utilities.Config do
+  def update_env(key, val) do
+    if is_nil(Application.get_env(:signs_ui, key)) do
+      Application.put_env(:signs_ui, key, val)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,11 @@ defmodule SignsUi.Mixfile do
   def application do
     [
       mod: {SignsUi.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [
+        :logger,
+        :parse_trans,
+        :runtime_tools,
+      ]
     ]
   end
 
@@ -32,6 +36,7 @@ defmodule SignsUi.Mixfile do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      {:distillery, "~> 1.5", runtime: false},
       {:phoenix, "~> 1.3.2"},
       {:phoenix_pubsub, "~> 1.0"},
       {:phoenix_html, "~> 2.10"},

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
+  "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.5", "a3060f063b116daf56c044c273f65202e36f75ec42e678dc10653056d3366054", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.15.0", "40a2b8ce33a80ced7727e36768499fc9286881c43ebafccae6bab731e2b2b8ce", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -1,0 +1,53 @@
+# Import all plugins from `rel/plugins`
+# They can then be used by adding `plugin MyPlugin` to
+# either an environment, or release definition, where
+# `MyPlugin` is the name of the plugin module.
+Path.join(["rel", "plugins", "*.exs"])
+|> Path.wildcard()
+|> Enum.map(&Code.eval_file(&1))
+
+use Mix.Releases.Config,
+    # This sets the default release built by `mix release`
+    default_release: :default,
+    # This sets the default environment used by `mix release`
+    default_environment: Mix.env()
+
+# For a full list of config options for both releases
+# and environments, visit https://hexdocs.pm/distillery/configuration.html
+
+
+# You may define one or more environments in this file,
+# an environment's settings will override those of a release
+# when building in that environment, this combination of release
+# and environment configuration is called a profile
+
+environment :dev do
+  # If you are running Phoenix, you should make sure that
+  # server: true is set and the code reloader is disabled,
+  # even in dev mode.
+  # It is recommended that you build with MIX_ENV=prod and pass
+  # the --env flag to Distillery explicitly if you want to use
+  # dev mode.
+  set dev_mode: true
+  set include_erts: false
+  set cookie: :"enj7(zuMT9(q,8h0CbDR}b9HL4zuDB/hD&O4jU`Z.&4;1JHKq_%bO&wY$o5)J~cZ"
+end
+
+environment :prod do
+  set include_erts: true
+  set include_src: false
+  set cookie: :"j[qo:HRrra$r]BfLHr[1VTv=u9I)3cs{Y_?!Lecuij9/xqq?dYFhgg<e,h%T7!,^"
+end
+
+# You may define one or more releases in this file.
+# If you have not set a default release, or selected one
+# when running `mix release`, the first release in the file
+# will be used by default
+
+release :signs_ui do
+  set version: "current"
+  set applications: [
+    :runtime_tools
+  ]
+end
+

--- a/test/utilities/config_test.exs
+++ b/test/utilities/config_test.exs
@@ -1,0 +1,17 @@
+defmodule SignsUi.Utilities.ConfigTest do
+  use ExUnit.Case
+  import SignsUi.Utilities.Config
+
+  describe "update_env/2" do
+    test "Does not change config if it exists already" do
+      Application.put_env(:signs_ui, :test_config, 1)
+      update_env(:test_config, 2)
+      assert Application.get_env(:signs_ui, :test_config) == 1
+    end
+
+    test "Sets new config value if it didn't exist" do
+      update_env(:test_config2, 10)
+      assert Application.get_env(:signs_ui, :test_config2) == 10
+    end
+  end
+end


### PR DESCRIPTION
This changes the way we handle runtime config, by bumping the `System.get_env` call into the application start callback, as [recommended by the docs](https://hexdocs.pm/distillery/runtime-configuration.html#configuration-conventions).

It adds the `distillery` package and configuration to build the release, and a Dockerfile for Docker to build the release in an image.