### PR TITLE
Basic auth

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,9 @@ config :signs_ui, SignsUiWeb.Endpoint,
 config :signs_ui,
   signs_external_post_mod: SignsUI.Mock.Write,
   local_write_path: "test/mock_write.json",
-  aws_requestor: SignsUI.Mock.AwsRequest
+  aws_requestor: SignsUI.Mock.AwsRequest,
+  username: "username",
+  password: "password"
 
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -33,5 +33,7 @@ defmodule SignsUi.Application do
   defp set_runtime_config do
     Config.update_env(:aws_signs_bucket, System.get_env("AWS_SIGNS_BUCKET"))
     Config.update_env(:aws_signs_path, System.get_env("AWS_SIGNS_PATH"))
+    Config.update_env(:username, System.get_env("USERNAME"))
+    Config.update_env(:password, System.get_env("PASSWORD"))
   end
 end

--- a/lib/signs_ui_web/plugs/basic_auth.ex
+++ b/lib/signs_ui_web/plugs/basic_auth.ex
@@ -5,7 +5,6 @@ defmodule BasicAuth do
   def init(opts), do: opts
 
   def call(conn, _) do
-
     case get_req_header(conn, "authorization") do
       ["Basic " <> attempted_auth] -> verify(conn, attempted_auth, correct_auth())
       _ -> unauthorized(conn)

--- a/lib/signs_ui_web/plugs/basic_auth.ex
+++ b/lib/signs_ui_web/plugs/basic_auth.ex
@@ -1,0 +1,37 @@
+defmodule BasicAuth do
+  import Plug.Conn
+  @realm "Basic realm=\"Realtime Signs\""
+
+  def init(opts), do: opts
+
+  def call(conn, _) do
+
+    case get_req_header(conn, "authorization") do
+      ["Basic " <> attempted_auth] -> verify(conn, attempted_auth, correct_auth())
+      _ -> unauthorized(conn)
+    end
+  end
+
+  def verify(conn, attempted_auth, [username: username, password: password]) do
+    case encode(username, password) do
+      ^attempted_auth -> conn
+      _ -> unauthorized(conn)
+    end
+  end
+
+  defp encode(username, password), do: Base.encode64(username <> ":" <> password)
+
+  defp unauthorized(conn) do
+    conn
+    |> put_resp_header("www-authenticate", @realm)
+    |> send_resp(401, "unauthorized")
+    |> halt()
+  end
+
+  defp correct_auth() do
+    [
+      username: Application.get_env(:signs_ui, :username),
+      password: Application.get_env(:signs_ui, :password)
+    ]
+  end
+end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -13,8 +13,13 @@ defmodule SignsUiWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :basic_auth do
+    plug BasicAuth, username: Application.get_env(:signs_ui, :username), password: Application.get_env(:signs_ui, :password)
+    #plug BasicAuth, username: "admin", password: "password"
+  end
+
   scope "/", SignsUiWeb do
-    pipe_through :browser # Use the default browser stack
+    pipe_through [:browser, :basic_auth] # Use the default browser stack
 
     get "/", SignsController, :index
     post "/", SignsController, :update

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -14,7 +14,7 @@ defmodule SignsUiWeb.Router do
   end
 
   pipeline :basic_auth do
-    plug BasicAuth, username: Application.get_env(:signs_ui, :username), password: Application.get_env(:signs_ui, :password)
+    plug BasicAuth
   end
 
   scope "/", SignsUiWeb do

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -15,7 +15,6 @@ defmodule SignsUiWeb.Router do
 
   pipeline :basic_auth do
     plug BasicAuth, username: Application.get_env(:signs_ui, :username), password: Application.get_env(:signs_ui, :password)
-    #plug BasicAuth, username: "admin", password: "password"
   end
 
   scope "/", SignsUiWeb do

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -18,7 +18,7 @@ defmodule SignsUiWeb.Router do
   end
 
   scope "/", SignsUiWeb do
-    pipe_through [:browser, :basic_auth] # Use the default browser stack
+    pipe_through [:browser, :basic_auth]
 
     get "/", SignsController, :index
     post "/", SignsController, :update

--- a/test/signs_ui_web/controllers/signs_controller_test.exs
+++ b/test/signs_ui_web/controllers/signs_controller_test.exs
@@ -2,13 +2,28 @@ defmodule SignsUiWeb.SignsControllerTest do
   use SignsUiWeb.ConnCase
 
   test "GET /", %{conn: conn} do
-    conn = get conn, "/"
+    conn = conn |> add_req_header |> get("/")
     assert html_response(conn, 200) =~ "Countdown Signs"
   end
 
   test "POST /", %{conn: conn} do
-    conn = post conn, "/", %{"signs" => %{"sign1" => "true"}}
+    conn = conn |> add_req_header |> post("/", %{"signs" => %{"sign1" => "true"}})
     assert redirected_to(conn, 302) =~ "/"
     assert conn.private.phoenix_flash == %{"success" => "Signs updated successfully"}
+  end
+
+  test "Receives unauthorized if no auth given", %{conn: conn} do
+    conn = get conn, "/"
+    assert response(conn, 401) =~ "unauthorized"
+  end
+
+  test "Receives unauthorized if wrong auth given", %{conn: conn} do
+    conn = %{conn | req_headers: [{"authorization", "Basic wrong:auth="}]}
+    conn = post(conn, "/", %{"signs" => %{"sign1" => "true"}})
+    assert response(conn, 401) =~ "unauthorized"
+  end
+
+  defp add_req_header(conn) do
+    %{conn | req_headers: [{"authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ="}]}
   end
 end


### PR DESCRIPTION
Asana Ticket: [Use Basic HTTP Authentication for Signs UI](https://app.asana.com/0/584764604969369/677813949394791)

Adds in Basic authentication for GETs and POSTs to the signs app. A single username/password login is set through environment variables