### PR TITLE
Force HTTPS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,9 @@ config :signs_ui,
   signs_external_post_mod: SignsUI.Signs.S3,
   aws_requestor: ExAws
 
+# HTTP config
+config :signs_ui, :redirect_http?, false
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,6 +18,8 @@ config :signs_ui, SignsUiWeb.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
+config :signs_ui, :redirect_http?, false
+
 # Do not print debug messages in production
 config :logger, level: :info
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,7 @@ config :signs_ui, SignsUiWeb.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
-config :signs_ui, :redirect_http?, false
+config :signs_ui, :redirect_http?, true
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/lib/signs_ui_web/controllers/health_controller.ex
+++ b/lib/signs_ui_web/controllers/health_controller.ex
@@ -1,0 +1,11 @@
+defmodule SignsUiWeb.HealthController do
+  @moduledoc """
+  Simple controller to return 200 OK when website is running. This
+  is used by the AWS ALB to determine the health of the target.
+  """
+  use SignsUiWeb, :controller
+
+  def index(conn, _params) do
+    send_resp(conn, 200, "")
+  end
+end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -17,11 +17,21 @@ defmodule SignsUiWeb.Router do
     plug BasicAuth
   end
 
+  pipeline :redirect_prod_http do
+    if Application.get_env(:signs_ui, :redirect_http?) do
+      plug Plug.SSL, rewrite_on: [:x_forwarded_proto]
+    end
+  end
+
   scope "/", SignsUiWeb do
-    pipe_through [:browser, :basic_auth]
+    pipe_through [:redirect_prod_http, :browser, :basic_auth]
 
     get "/", SignsController, :index
     post "/", SignsController, :update
+  end
+
+  scope "/", SignsUiWeb do
+    get "/_health", HealthController, :index
   end
 
   # Other scopes may use custom stacks.

--- a/test/signs_ui_web/controllers/health_controller_test.exs
+++ b/test/signs_ui_web/controllers/health_controller_test.exs
@@ -1,0 +1,9 @@
+defmodule SignsUiWeb.HealthControllerTest do
+  use SignsUiWeb.ConnCase, async: true
+
+  describe "index/2" do
+    test "returns 200", %{conn: conn} do
+      assert %{status: 200} = get conn, "/_health"
+    end
+  end
+end


### PR DESCRIPTION
Asana Ticket: [S: Signs deployment: force HTTPS](https://app.asana.com/0/584764604969369/679137043054072)

Adds the `/_health` route outside of HTTPS, and redirects prod to https