### PR TITLE
Build and deploy from semaphore

### DIFF
--- a/semaphore/Dockerrun.aws.json
+++ b/semaphore/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "434035161053.dkr.ecr.us-east-1.amazonaws.com/signs-ui:git-GITHASH",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "4000"
+    }
+  ]
+}

--- a/semaphore/build_push.sh
+++ b/semaphore/build_push.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e -x -u
+
+# bash script should be called with aws environment (dev / dev-green / prod)
+# other required configuration:
+# * APP
+# * DOCKER_REPO
+
+awsenv=$1
+
+# build docker image and tag it with git hash and aws environment
+githash=$(git rev-parse --short HEAD)
+docker build -t $APP:latest .
+docker tag $APP:latest $DOCKER_REPO/$APP:$awsenv
+docker tag $APP:latest $DOCKER_REPO/$APP:git-$githash
+
+# retrieve the `docker login` command from AWS ECR and execute it
+logincmd=$(aws ecr get-login --no-include-email --region us-east-1)
+eval $logincmd
+
+# push images to ECS image repo
+docker push $DOCKER_REPO/$APP:$awsenv
+docker push $DOCKER_REPO/$APP:git-$githash

--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e -x -u
+
+# bash script should be called with aws environment (dev / dev-green / prod)
+# other required configuration:
+# * APP
+# * DOCKER_REPO
+# * S3_BUCKET_NAME
+
+awsenv=$1
+appenv=$APP-$awsenv
+
+githash=$(git rev-parse --short HEAD)
+gitmsg=$(git log -1 --pretty=%s)
+
+# Create Dockerrun file pointing to ECR image, and zip it up
+mkdir $githash
+sed "s/GITHASH/$githash/g" ./semaphore/Dockerrun.aws.json > $githash/Dockerrun.aws.json
+pushd $githash
+zip -r ../$githash.zip .
+popd
+
+# Put zip on S3 and use to create application version
+aws s3 cp $githash.zip s3://$S3_BUCKET_NAME/$APP/$githash.zip
+aws elasticbeanstalk delete-application-version --application-name $APP --version-label $githash --delete-source-bundle
+aws elasticbeanstalk create-application-version --application-name $APP --version-label $githash --source-bundle S3Bucket=$S3_BUCKET_NAME,S3Key=$APP/$githash.zip --description "$gitmsg"
+
+# Deploy application version
+aws elasticbeanstalk update-environment --environment-name $appenv --version-label $githash
+echo "Environment status: `aws elasticbeanstalk describe-environments --environment-names $appenv | grep '"Status"' | cut -d: -f2  | sed -e 's/^[^"]*"//' -e 's/".*$//'`"
+echo "Your environment is currently updating"; while [[ `aws elasticbeanstalk describe-environments --environment-names $appenv | grep '"Status"' | cut -d: -f2  | sed -e 's/^[^"]*"//' -e 's/".*$//'` = "Updating" ]]; do sleep 2; printf "."; done
+if [[ `aws elasticbeanstalk describe-environments --environment-names $appenv | grep VersionLabel | cut -d: -f2 | sed -e 's/^[^"]*"//' -e 's/".*$//'` = $githash ]]; then echo "The version of application code on Elastic Beanstalk matches the version that Semaphore sent in this deployment."; echo "Your environment info:"; aws elasticbeanstalk describe-environments --environment-names $appenv; else echo "The version of application code on Elastic Beanstalk does not match the version that Semaphore sent in this deployment. Please check your AWS Elastic Beanstalk Console for more information."; echo "Your environment info:"; aws elasticbeanstalk describe-environments --environment-names $appenv; false; fi
+sleep 5; a="0"; echo "Waiting for environment health to turn Green"; while [[ `aws elasticbeanstalk describe-environments --environment-names $appenv | grep '"Health":' | cut -d: -f2  | sed -e 's/^[^"]*"//' -e 's/".*$//'` != "Green" && $a -le 30 ]]; do sleep 2; a=$[$a+1]; printf "."; done; if [[ `aws elasticbeanstalk describe-environments --environment-names $appenv | grep '"Health":' | cut -d: -f2 | sed -e 's/^[^"]*"//' -e 's/".*$//'` = "Green" ]]; then echo "Your environment status is Green, congrats!"; else echo "Your environment status is not Green, sorry."; false; fi;
+echo "Your environment info:"; aws elasticbeanstalk describe-environments --environment-names $appenv


### PR DESCRIPTION
This code allows semaphore to build the app and deploy it to AWS. It's sort of a combination approach of RTR and dotcom.

1. Semaphore builds the app as a docker image and uploads the image to ECR, tagging it with its git hash.
2. That image is specified in Elastic Beanstalk's `Dockerrun.aws.json` file, by using `sed` to replace `GITHASH` with the branch's git hash.
3. The Dockerrun file is zipped up and pushed to ElasticBeanstalk, where the app is deployed and restarted.

I've deployed this branch from Semaphore to Dev by clicking "Deploy manually" and specifying Dev. Once this branch is merged to master, I will update Semaphore to deploy master to dev automatically. Like, dotcom, API, and the other Elastic Beanstalk apps, deploying to production is done from AWS by choosing a previously deployed version and putting it on the Prod server.