### PR TITLE
Gray out inactive signs

### DIFF
--- a/lib/signs_ui_web/templates/signs/index.html.eex
+++ b/lib/signs_ui_web/templates/signs/index.html.eex
@@ -4,7 +4,10 @@
     <%= for {sign_id, sign} <- @signs do %>
       <div>
         <%= checkbox(f, sign_id, value: sign.enabled?, id: sign_id) %>
-        &nbsp<label for=<%= sign_id %>><%= sign_id %></label>
+        &nbsp
+        <%= content_tag :label, sign_id,
+        for: sign_id,
+        class: if !sign.enabled?, do: "text-muted" %>
       </div>
     <% end %>
     <%= submit "Submit", class: "btn btn-primary" %>


### PR DESCRIPTION
Asana Ticket: [Grey text for sign if it's turned off](https://app.asana.com/0/584764604969369/683023916934073)

Loads inactive signs with gray text. Uses javascript to toggle gray text on checkbox change. Added jQuery to the app.