### PR TITLE
Add JFK/UMass Mezzanine sign

### DIFF
--- a/lib/signs_ui/signs/names.ex
+++ b/lib/signs_ui/signs/names.ex
@@ -212,6 +212,7 @@ defmodule SignsUI.Signs.Names do
       {"jfk_umass_braintree_platform_southbound", "JFK/UMass (Braintree Platform) Southbound"},
       {"jfk_umass_ashmont_platform_northbound", "JFK/UMass (Ashmont Platform) Northbound"},
       {"jfk_umass_braintree_platform_northbound", "JFK/UMass (Braintree Platform) Northbound"},
+      {"jfk_umass_mezzanine", "JFK/UMass Mezzanine"},
       {"broadway_mezzanine_northbound", "Broadway Mezzanine Northbound"},
       {"broadway_mezzanine_southbound", "Broadway Mezzanine Southbound"},
       {"broadway_northbound", "Broadway Northbound"},


### PR DESCRIPTION
Adds the upcoming JFK Mezzanine sign. It's the first mezzanine that's just a single sign, rather than two Single's stitched together!

It does mean that PIOs can't turn off just a single line of it, though. Not sure if that's a feature we'll want to add back to signs-ui.