### PR TITLE
send expiration time to react and then dont display the line if its e…

### DIFF
--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -1,20 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+function displayLine(duration, currentTime) {
+  return (Date.parse(duration) - currentTime) > 0;
+}
+
 function Sign({
   signId, lineOne, lineOneDuration, lineTwo, lineTwoDuration, currentTime,
 }) {
-  const remainingTimeOne = Date.parse(lineOneDuration) - currentTime;
-  const remainingTimeTwo = Date.parse(lineTwoDuration) - currentTime;
-  let topLine = null;
-  let bottomLine = null;
-  if (remainingTimeOne > 0) {
-    topLine = lineOne;
-  }
-  if (remainingTimeTwo > 0) {
-    bottomLine = lineTwo;
-  }
-
   return (
     <div className="viewer--sign">
       <div className="viewer--sign-id">
@@ -22,10 +15,10 @@ function Sign({
       </div>
       <div className="viewer--sign-lines">
         <div className="viewer--sign-line">
-          {topLine}
+          { displayLine(lineOneDuration, currentTime) ? lineOne : null }
         </div>
         <div className="viewer--sign-line">
-          {bottomLine}
+          { displayLine(lineTwoDuration, currentTime) ? lineTwo : null }
         </div>
       </div>
     </div>

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -41,4 +41,11 @@ Sign.propTypes = {
   currentTime: PropTypes.number.isRequired,
 };
 
+Sign.defaultProps = {
+  lineOne: null,
+  lineOneDuration: '0',
+  lineTwo: null,
+  lineTwoDuration: '0',
+};
+
 export default Sign;

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -1,7 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Sign({ signId, lineOne, lineTwo }) {
+function Sign({ signId, lineOne, lineOneDuration, lineTwo, lineTwoDuration, currentTime }) {
+  let remainingTimeOne = Date.parse(lineOneDuration) - currentTime
+  let remainingTimeTwo = Date.parse(lineTwoDuration) - currentTime
+  let topLine = null
+  let bottomLine = null
+  if(remainingTimeOne > 0) {
+    topLine = lineOne
+  }
+  if(remainingTimeTwo > 0) {
+    bottomLine = lineTwo
+  }
+
   return (
     <div className="viewer--sign">
       <div className="viewer--sign-id">
@@ -9,10 +20,10 @@ function Sign({ signId, lineOne, lineTwo }) {
       </div>
       <div className="viewer--sign-lines">
         <div className="viewer--sign-line">
-          {lineOne}
+          {topLine}
         </div>
         <div className="viewer--sign-line">
-          {lineTwo}
+          {bottomLine}
         </div>
       </div>
     </div>
@@ -21,8 +32,10 @@ function Sign({ signId, lineOne, lineTwo }) {
 
 Sign.propTypes = {
   signId: PropTypes.string.isRequired,
-  lineOne: PropTypes.string.isRequired,
-  lineTwo: PropTypes.string.isRequired,
+  lineOne: PropTypes.string,
+  lineOneExpiration: PropTypes.instanceOf(Date),
+  lineTwo: PropTypes.string,
+  lineTwoExpiration: PropTypes.instanceOf(Date),
 };
 
 export default Sign;

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Sign({ signId, lineOne, lineOneDuration, lineTwo, lineTwoDuration, currentTime }) {
-  let remainingTimeOne = Date.parse(lineOneDuration) - currentTime
-  let remainingTimeTwo = Date.parse(lineTwoDuration) - currentTime
-  let topLine = null
-  let bottomLine = null
-  if(remainingTimeOne > 0) {
-    topLine = lineOne
+function Sign({
+  signId, lineOne, lineOneDuration, lineTwo, lineTwoDuration, currentTime,
+}) {
+  const remainingTimeOne = Date.parse(lineOneDuration) - currentTime;
+  const remainingTimeTwo = Date.parse(lineTwoDuration) - currentTime;
+  let topLine = null;
+  let bottomLine = null;
+  if (remainingTimeOne > 0) {
+    topLine = lineOne;
   }
-  if(remainingTimeTwo > 0) {
-    bottomLine = lineTwo
+  if (remainingTimeTwo > 0) {
+    bottomLine = lineTwo;
   }
 
   return (
@@ -33,9 +35,10 @@ function Sign({ signId, lineOne, lineOneDuration, lineTwo, lineTwoDuration, curr
 Sign.propTypes = {
   signId: PropTypes.string.isRequired,
   lineOne: PropTypes.string,
-  lineOneExpiration: PropTypes.instanceOf(Date),
+  lineOneDuration: PropTypes.string,
   lineTwo: PropTypes.string,
-  lineTwoExpiration: PropTypes.instanceOf(Date),
+  lineTwoDuration: PropTypes.string,
+  currentTime: PropTypes.number.isRequired,
 };
 
 export default Sign;

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -20,7 +20,17 @@ class Viewer extends Component {
           const { signs } = this.props;
           const { currentTime } = this.props;
           const lines = signs[key];
-          return <Sign key={key} signId={key} lineOne={lines[0]["text"]} lineOneDuration={lines[0]["duration"]} lineTwo={lines[1]["text"]} lineTwoDuration={lines[1]["duration"]} currentTime={currentTime} />;
+          return (
+            <Sign
+              key={key}
+              signId={key}
+              lineOne={lines[0].text}
+              lineOneDuration={lines[0].duration}
+              lineTwo={lines[1].text}
+              lineTwoDuration={lines[1].duration}
+              currentTime={currentTime}
+            />
+          );
         })}
       </div>
     );
@@ -29,7 +39,7 @@ class Viewer extends Component {
 
 Viewer.propTypes = {
   signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
-  currentTime: PropTypes.number
+  currentTime: PropTypes.number.isRequired,
 };
 
 export default Viewer;

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -37,7 +37,9 @@ class Viewer extends Component {
 }
 
 Viewer.propTypes = {
-  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({text: PropTypes.string, duration: PropTypes.string}))).isRequired,
+  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string, duration: PropTypes.string,
+  }))).isRequired,
   currentTime: PropTypes.number.isRequired,
 };
 

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -18,8 +18,9 @@ class Viewer extends Component {
       <div>
         {this.sortedKeys().map((key) => {
           const { signs } = this.props;
+          const { currentTime } = this.props;
           const lines = signs[key];
-          return <Sign key={key} signId={key} lineOne={lines[0]} lineTwo={lines[1]} />;
+          return <Sign key={key} signId={key} lineOne={lines[0]["text"]} lineOneDuration={lines[0]["duration"]} lineTwo={lines[1]["text"]} lineTwoDuration={lines[1]["duration"]} currentTime={currentTime} />;
         })}
       </div>
     );
@@ -27,7 +28,8 @@ class Viewer extends Component {
 }
 
 Viewer.propTypes = {
-  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+  currentTime: PropTypes.number
 };
 
 export default Viewer;

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -17,8 +17,7 @@ class Viewer extends Component {
     return (
       <div>
         {this.sortedKeys().map((key) => {
-          const { signs } = this.props;
-          const { currentTime } = this.props;
+          const { signs, currentTime } = this.props;
           const lines = signs[key];
           return (
             <Sign
@@ -38,7 +37,7 @@ class Viewer extends Component {
 }
 
 Viewer.propTypes = {
-  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({text: PropTypes.string, duration: PropTypes.string}))).isRequired,
   currentTime: PropTypes.number.isRequired,
 };
 

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -8,16 +8,11 @@ class Viewer extends Component {
     this.sortedKeys = this.sortedKeys.bind(this);
   }
 
-  sortedKeys() {
-    const { signs } = this.props;
-    return Object.keys(signs).sort();
-  }
-
   render() {
+    const { signs, currentTime } = this.props;
     return (
       <div>
-        {this.sortedKeys().map((key) => {
-          const { signs, currentTime } = this.props;
+        { Object.keys(signs).sort().map((key) => {
           const lines = signs[key];
           return (
             <Sign

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -45,9 +45,9 @@ class ViewerApp extends Component {
   }
 
   updateTime() {
-    this.setState(({
+    this.setState({
       currentTime: Date.now(),
-    }));
+    });
   }
 
   render() {

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -34,7 +34,14 @@ class ViewerApp extends Component {
       }));
     });
 
-    window.setInterval(this.updateTime, 1000);
+    this.timerID = setInterval(
+      () => this.updateTime(),
+      1000
+    );
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timerID);
   }
 
   updateTime() {
@@ -44,8 +51,7 @@ class ViewerApp extends Component {
   }
 
   render() {
-    const { signs } = this.state;
-    const { currentTime } = this.state;
+    const { signs, currentTime } = this.state;
     return (
       <div className="viewer">
         <Viewer signs={signs} currentTime={currentTime} />
@@ -55,7 +61,7 @@ class ViewerApp extends Component {
 }
 
 ViewerApp.propTypes = {
-  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({text: PropTypes.string, duration: PropTypes.string}))).isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -36,7 +36,7 @@ class ViewerApp extends Component {
 
     this.timerID = setInterval(
       () => this.updateTime(),
-      1000
+      1000,
     );
   }
 
@@ -61,7 +61,9 @@ class ViewerApp extends Component {
 }
 
 ViewerApp.propTypes = {
-  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({text: PropTypes.string, duration: PropTypes.string}))).isRequired,
+  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string, duration: PropTypes.string,
+  }))).isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -8,8 +8,10 @@ class ViewerApp extends Component {
   constructor(props) {
     super(props);
 
+    this.updateTime = this.updateTime.bind(this);
     this.state = {
       signs: props.initialSigns,
+      currentTime: Date.now()
     };
   }
 
@@ -22,26 +24,34 @@ class ViewerApp extends Component {
       .join()
       .receive('ok', () => {});
 
-    channel.on('sign_update', ({ sign_id: signId, line_number: lineNumber, text: content }) => {
+    channel.on('sign_update', ({ sign_id: signId, duration: duration, line_number: lineNumber, text: content }) => {
       this.setState(prevState => ({
-        signs: updateSigns(prevState.signs, { signId, lineNumber, content }),
+        signs: updateSigns(prevState.signs, { signId, duration, lineNumber, content }),
       }));
     });
+
+    window.setInterval(this.updateTime, 1000);
+  }
+
+  updateTime() {
+    this.setState(prevState => ({
+      currentTime: Date.now()
+    }));
   }
 
   render() {
     const { signs } = this.state;
-
+    const { currentTime } = this.state;
     return (
       <div className="viewer">
-        <Viewer signs={signs} />
+        <Viewer signs={signs} currentTime={currentTime} />
       </div>
     );
   }
 }
 
 ViewerApp.propTypes = {
-  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -11,7 +11,7 @@ class ViewerApp extends Component {
     this.updateTime = this.updateTime.bind(this);
     this.state = {
       signs: props.initialSigns,
-      currentTime: Date.now()
+      currentTime: Date.now(),
     };
   }
 
@@ -24,9 +24,13 @@ class ViewerApp extends Component {
       .join()
       .receive('ok', () => {});
 
-    channel.on('sign_update', ({ sign_id: signId, duration: duration, line_number: lineNumber, text: content }) => {
+    channel.on('sign_update', ({
+      sign_id: signId, duration, line_number: lineNumber, text: content,
+    }) => {
       this.setState(prevState => ({
-        signs: updateSigns(prevState.signs, { signId, duration, lineNumber, content }),
+        signs: updateSigns(prevState.signs, {
+          signId, duration, lineNumber, content,
+        }),
       }));
     });
 
@@ -34,8 +38,8 @@ class ViewerApp extends Component {
   }
 
   updateTime() {
-    this.setState(prevState => ({
-      currentTime: Date.now()
+    this.setState(({
+      currentTime: Date.now(),
     }));
   }
 

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,8 +1,8 @@
 function updateSigns(oldSigns, {
   signId, lineNumber, content, duration,
 }) {
-  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{ content: '', duration: '0' }, { content: '', duration: '0' }];
-  newValues[lineNumber - 1] = { content, duration };
+  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{ text: '', duration: '0' }, { text: '', duration: '0' }];
+  newValues[lineNumber - 1] = { text: content, duration };
 
   return {
     ...oldSigns,

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,6 +1,8 @@
-function updateSigns(oldSigns, { signId, lineNumber, content, duration }) {
-  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{text: "", duration: "0"}, {text: "", duration: "0"}];
-  newValues[lineNumber - 1] = {"text": content, "duration": duration};
+function updateSigns(oldSigns, {
+  signId, lineNumber, content, duration,
+}) {
+  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{ text: '', duration: '0' }, { text: '', duration: '0' }];
+  newValues[lineNumber - 1] = { content, duration };
 
   return {
     ...oldSigns,

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,7 +1,7 @@
 function updateSigns(oldSigns, {
   signId, lineNumber, content, duration,
 }) {
-  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{ text: '', duration: '0' }, { text: '', duration: '0' }];
+  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{ content: '', duration: '0' }, { content: '', duration: '0' }];
   newValues[lineNumber - 1] = { content, duration };
 
   return {

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,6 +1,6 @@
-function updateSigns(oldSigns, { signId, lineNumber, content }) {
-  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : ['', ''];
-  newValues[lineNumber - 1] = content;
+function updateSigns(oldSigns, { signId, lineNumber, content, duration }) {
+  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{text: "", duration: "0"}, {text: "", duration: "0"}];
+  newValues[lineNumber - 1] = {"text": content, "duration": duration};
 
   return {
     ...oldSigns,

--- a/assets/js/helpers.test.js
+++ b/assets/js/helpers.test.js
@@ -6,12 +6,12 @@ test('updateSigns returns a new map with changed values for the ID', () => {
     signId: 'id1', lineNumber: 2, duration: 2, content: 'TWO',
   });
   expect(oldSigns).toEqual({ id1: ['one', 'two'] });
-  expect(newSigns).toEqual({ id1: ['one', { duration: 2, content: 'TWO' }] });
+  expect(newSigns).toEqual({ id1: ['one', { duration: 2, text: 'TWO' }] });
 });
 
 test('updateSigns returns a new map adding a new sign if not present before', () => {
   const signs = updateSigns({}, {
     signId: 'newSign', lineNumber: 1, duration: 2, content: 'ONE',
   });
-  expect(signs).toEqual({ newSign: [{ duration: 2, content: 'ONE' }, { duration: '0', content: '' }] });
+  expect(signs).toEqual({ newSign: [{ duration: 2, text: 'ONE' }, { duration: '0', text: '' }] });
 });

--- a/assets/js/helpers.test.js
+++ b/assets/js/helpers.test.js
@@ -2,12 +2,12 @@ import { updateSigns } from './helpers';
 
 test('updateSigns returns a new map with changed values for the ID', () => {
   const oldSigns = { id1: ['one', 'two'] };
-  const newSigns = updateSigns(oldSigns, { signId: 'id1', lineNumber: 2, content: 'TWO' });
+  const newSigns = updateSigns(oldSigns, { signId: 'id1', lineNumber: 2, duration: 2, content: 'TWO' });
   expect(oldSigns).toEqual({ id1: ['one', 'two'] });
-  expect(newSigns).toEqual({ id1: ['one', 'TWO'] });
+  expect(newSigns).toEqual({ id1: ['one', {"duration": 2, "text": 'TWO'}] });
 });
 
 test('updateSigns returns a new map adding a new sign if not present before', () => {
-  const signs = updateSigns({}, { signId: 'newSign', lineNumber: 1, content: 'ONE' });
-  expect(signs).toEqual({ newSign: ['ONE', ''] });
+  const signs = updateSigns({}, { signId: 'newSign', lineNumber: 1, duration: 2, content: 'ONE' });
+  expect(signs).toEqual({ newSign: [{"duration": 2, text: "ONE"}, {"duration": "0", "text": ""}]});
 });

--- a/assets/js/helpers.test.js
+++ b/assets/js/helpers.test.js
@@ -6,12 +6,12 @@ test('updateSigns returns a new map with changed values for the ID', () => {
     signId: 'id1', lineNumber: 2, duration: 2, content: 'TWO',
   });
   expect(oldSigns).toEqual({ id1: ['one', 'two'] });
-  expect(newSigns).toEqual({ id1: ['one', { duration: 2, text: 'TWO' }] });
+  expect(newSigns).toEqual({ id1: ['one', { duration: 2, content: 'TWO' }] });
 });
 
 test('updateSigns returns a new map adding a new sign if not present before', () => {
   const signs = updateSigns({}, {
     signId: 'newSign', lineNumber: 1, duration: 2, content: 'ONE',
   });
-  expect(signs).toEqual({ newSign: [{ duration: 2, text: 'ONE' }, { duration: '0', text: '' }] });
+  expect(signs).toEqual({ newSign: [{ duration: 2, content: 'ONE' }, { duration: '0', content: '' }] });
 });

--- a/assets/js/helpers.test.js
+++ b/assets/js/helpers.test.js
@@ -2,12 +2,16 @@ import { updateSigns } from './helpers';
 
 test('updateSigns returns a new map with changed values for the ID', () => {
   const oldSigns = { id1: ['one', 'two'] };
-  const newSigns = updateSigns(oldSigns, { signId: 'id1', lineNumber: 2, duration: 2, content: 'TWO' });
+  const newSigns = updateSigns(oldSigns, {
+    signId: 'id1', lineNumber: 2, duration: 2, content: 'TWO',
+  });
   expect(oldSigns).toEqual({ id1: ['one', 'two'] });
-  expect(newSigns).toEqual({ id1: ['one', {"duration": 2, "text": 'TWO'}] });
+  expect(newSigns).toEqual({ id1: ['one', { duration: 2, text: 'TWO' }] });
 });
 
 test('updateSigns returns a new map adding a new sign if not present before', () => {
-  const signs = updateSigns({}, { signId: 'newSign', lineNumber: 1, duration: 2, content: 'ONE' });
-  expect(signs).toEqual({ newSign: [{"duration": 2, text: "ONE"}, {"duration": "0", "text": ""}]});
+  const signs = updateSigns({}, {
+    signId: 'newSign', lineNumber: 1, duration: 2, content: 'ONE',
+  });
+  expect(signs).toEqual({ newSign: [{ duration: 2, text: 'ONE' }, { duration: '0', text: '' }] });
 });

--- a/assets/package.json
+++ b/assets/package.json
@@ -37,6 +37,7 @@
     "webpack-cli": "^3.1.0"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./scripts/jestSetup.js"
+    "setupTestFrameworkScriptFile": "./scripts/jestSetup.js",
+    "testURL": "http://localhost/"
   }
 }

--- a/lib/signs_ui/signs/messages.ex
+++ b/lib/signs_ui/signs/messages.ex
@@ -83,13 +83,19 @@ defmodule SignsUi.Signs.Messages do
     sign_lines
     |> Enum.each(fn {sign_id, lines} ->
       lines
-      |> Enum.each(fn {number, line} ->
+      |> Enum.each(fn {number, %{text: line, duration: duration}} ->
         SignsUiWeb.Endpoint.broadcast!("signs:all", "sign_update", %{
           sign_id: sign_id,
           line_number: number,
-          text: line
+          text: line,
+          duration: duration
         })
       end)
     end)
+  end
+
+  defp expiration_time(current_time, duration) do
+    {duration, _} = Integer.parse(duration)
+    Timex.shift(current_time, seconds: duration)
   end
 end

--- a/lib/signs_ui/signs/messages.ex
+++ b/lib/signs_ui/signs/messages.ex
@@ -1,5 +1,6 @@
 defmodule SignsUi.Signs.Messages do
   use GenServer
+  import Timex
 
   @type message :: String.t()
 
@@ -23,8 +24,9 @@ defmodule SignsUi.Signs.Messages do
     message_list =
       messages
       |> Enum.map(fn {sign_id, line_map} ->
-        line_one = line_map[1] || ""
-        line_two = line_map[2] || ""
+        current_time = Timex.now()
+        line_one = line_map[1] || %{text: "", duration: expiration_time(current_time, "0")}
+        line_two = line_map[2] || %{text: "", duration: expiration_time(current_time, "0")}
         lines = [line_one, line_two]
         {sign_id, lines}
       end)
@@ -40,14 +42,16 @@ defmodule SignsUi.Signs.Messages do
     sign_lines =
       Enum.reduce(commands, %{}, fn {duration, zone, line_no, text}, acc ->
         sign_id = "#{sta}-#{zone}"
+        current_time = Timex.now()
+        expiration = expiration_time(current_time, duration)
 
         acc =
           if acc[sign_id] do
-            lines = Map.merge(acc[sign_id], %{line_no => text})
+            lines = Map.merge(acc[sign_id], %{line_no => %{text: text, duration: expiration}})
 
             Map.replace!(acc, sign_id, lines)
           else
-            Map.put(acc, sign_id, %{line_no => text})
+            Map.put(acc, sign_id, %{line_no => %{text: text, duration: expiration}})
           end
       end)
 
@@ -60,6 +64,8 @@ defmodule SignsUi.Signs.Messages do
     commands
     |> Enum.map(fn command ->
       [duration, zone_line, text] = String.split(command, ["~", "-"])
+      duration_regex = ~r/([a-z])([\d]+)/
+      [_original, _expires?, duration] = Regex.run(duration_regex, duration)
 
       text =
         text

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule SignsUi.Mixfile do
       app: :signs_ui,
       version: "0.0.1",
       elixir: "~> 1.4",
-      elixirc_paths: elixirc_paths(Mix.env),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers,
-      start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end
@@ -31,7 +31,7 @@ defmodule SignsUi.Mixfile do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.
   #
@@ -48,7 +48,8 @@ defmodule SignsUi.Mixfile do
       {:poison, "~> 3.1"},
       {:httpoison, "~> 1.0"},
       {:ex_aws, "~> 2.0"},
-      {:ex_aws_s3, "~> 2.0"}
+      {:ex_aws_s3, "~> 2.0"},
+      {:timex, "~> 3.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
@@ -22,5 +23,7 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "timex": {:hex, :timex, "3.3.0", "e0695aa0ddb37d460d93a2db34d332c2c95a40c27edf22fbfea22eb8910a9c8d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.17", "50793e3d85af49736701da1a040c415c97dc1caf6464112fd9bd18f425d3053b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/test/signs_ui/signs/messages_test.exs
+++ b/test/signs_ui/signs/messages_test.exs
@@ -11,6 +11,7 @@ defmodule SignsUi.Signs.MessagesTest do
       "uid" => "616722"
     })
 
-    assert SignsUi.Signs.Messages.list_messages(pid) == %{"RDTC-n" => ["", "Alewife 12 min"]}
+    assert %{"RDTC-n" => [%{duration: _, text: ""}, %{duration: _, text: "Alewife 12 min"}]} =
+             SignsUi.Signs.Messages.list_messages(pid)
   end
 end


### PR DESCRIPTION
[M: handle expiration time in countdown viewer](https://app.asana.com/0/584764604969369/753278615983449)

the idea with this app is we want to as closely replicate what is on actual signs as possible.  to do this, we need to also replicate how the signs expire messages after a given expiration time.  As of right now, our realtime_signs app will only ever pass expiration times as the argument `e###`, meaning expires after ### seconds.  technically it is possible to pass `t###`, which will be "expires at time ###" but we never use that so it is unimplemented here.

signs-dev.mbtace.com/messages
pm me for username/password