### PR TITLE
Fix bug where we couldn't disable signs.

### DIFF
--- a/lib/signs_ui/signs/messages.ex
+++ b/lib/signs_ui/signs/messages.ex
@@ -62,6 +62,7 @@ defmodule SignsUi.Signs.Messages do
 
   defp parse_commands(commands) do
     commands
+    |> List.wrap
     |> Enum.map(fn command ->
       [duration, zone_line_text] = String.split(command, ["~"])
       duration_regex = ~r/([a-z])([\d]+)/

--- a/lib/signs_ui_web/realtime_signs_body_reader.ex
+++ b/lib/signs_ui_web/realtime_signs_body_reader.ex
@@ -14,8 +14,24 @@ defmodule RealtimeSignsBodyReader do
           vals -> Map.put(acc, name, [value | vals])
         end
       end)
-      |> Plug.Conn.Query.encode()
+      |> paramify()
 
     {:ok, body_params, conn}
+  end
+
+  defp paramify(map) do
+    map
+    |> Enum.flat_map(fn {key, value} ->
+        case value do
+          vs when is_list(vs) ->
+            Enum.map(vs, fn v ->
+              "#{key}[]=#{v}"
+            end)
+
+          v ->
+            ["#{key}=#{v}"]
+        end
+      end)
+    |> Enum.join("&")
   end
 end

--- a/lib/signs_ui_web/realtime_signs_body_reader.ex
+++ b/lib/signs_ui_web/realtime_signs_body_reader.ex
@@ -9,8 +9,9 @@ defmodule RealtimeSignsBodyReader do
         [name, value] = String.split(arg, "=")
 
         case acc[name] do
-          nil -> Map.put(acc, name, [value])
-          _ -> Map.put(acc, name, [value | acc[name]])
+          nil -> Map.put(acc, name, value)
+          old_val when not is_list(old_val) -> Map.put(acc, name, [value, old_val])
+          vals -> Map.put(acc, name, [value | vals])
         end
       end)
       |> Plug.Conn.Query.encode()

--- a/test/signs_ui_web/realtime_signs_body_reader_test.exs
+++ b/test/signs_ui_web/realtime_signs_body_reader_test.exs
@@ -5,14 +5,29 @@ defmodule SignsUiWeb.RealtimeSignsBodyReaderTest do
   describe "read_body/2" do
     test "changes repeated elements to an array" do
       conn = build_conn(:put, "/", "foo=bar&foo=baz")
-      {:ok, params, conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
       assert params == "foo[]=baz&foo[]=bar"
     end
 
     test "leaves single elements alone" do
       conn = build_conn(:put, "/", "foo=bar")
-      {:ok, params, conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
       assert params == "foo=bar"
+    end
+
+    test "handles both single elements and list elements" do
+      conn = build_conn(:put, "/", "foo=bar&baz=1&baz=2")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      elements = String.split(params, "&")
+      assert "baz[]=1" in elements
+      assert "baz[]=2" in elements
+      assert "foo=bar" in elements
+    end
+
+    test "doesn't double encode equals signs for base64-encoded tokens" do
+      conn = build_conn(:put, "/", "_csrf_token=2rJcUflcfXZ9%2FiA%3D%3D")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "_csrf_token=2rJcUflcfXZ9%2FiA%3D%3D"
     end
   end
 end

--- a/test/signs_ui_web/realtime_signs_body_reader_test.exs
+++ b/test/signs_ui_web/realtime_signs_body_reader_test.exs
@@ -1,0 +1,18 @@
+defmodule SignsUiWeb.RealtimeSignsBodyReaderTest do
+  use ExUnit.Case, async: true
+  use Phoenix.ConnTest
+
+  describe "read_body/2" do
+    test "changes repeated elements to an array" do
+      conn = build_conn(:put, "/", "foo=bar&foo=baz")
+      {:ok, params, conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "foo[]=baz&foo[]=bar"
+    end
+
+    test "leaves single elements alone" do
+      conn = build_conn(:put, "/", "foo=bar")
+      {:ok, params, conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "foo=bar"
+    end
+  end
+end


### PR DESCRIPTION
Asana: [Bug: prod Signs UI shows "forbidden" when you try to turn on/off a sign](https://app.asana.com/0/584764604969369/792472905559025)

From testing deploys on signs-ui-dev, I confirmed that it was #36 that introduced the issue. In that PR we pre-parse the body to prevent Phoenix from "eating" duplicate params, by putting them in the syntax that will later cause the `params` to be a list. However, we do that even for singular params, which was interfering with the CSRF token, preventing us from submitting forms.

I changed the pre-parsing to leave singular params alone, only put them in a list if there's multiple values for the same param.