### PR TITLE
Fix bug preventing us from disabling signs.

### DIFF
--- a/lib/signs_ui_web/realtime_signs_body_reader.ex
+++ b/lib/signs_ui_web/realtime_signs_body_reader.ex
@@ -5,15 +5,14 @@ defmodule RealtimeSignsBodyReader do
     body_params =
       body
       |> String.split("&")
-      |> Enum.reduce(%{}, fn arg, acc ->
-        [name, value] = String.split(arg, "=")
-
-        case acc[name] do
-          nil -> Map.put(acc, name, [value])
-          _ -> Map.put(acc, name, [value | acc[name]])
+      |> Enum.reduce([], fn arg, acc ->
+        case String.split(arg, "=") do
+          ["c", value] -> ["c[]=#{value}" | acc]
+          _ -> [arg | acc]
         end
       end)
-      |> Plug.Conn.Query.encode()
+      |> Enum.reverse()
+      |> Enum.join("&")
 
     {:ok, body_params, conn}
   end

--- a/lib/signs_ui_web/realtime_signs_body_reader.ex
+++ b/lib/signs_ui_web/realtime_signs_body_reader.ex
@@ -5,13 +5,10 @@ defmodule RealtimeSignsBodyReader do
     body_params =
       body
       |> String.split("&")
-      |> Enum.reduce([], fn arg, acc ->
-        case String.split(arg, "=") do
-          ["c", value] -> ["c[]=#{value}" | acc]
-          _ -> [arg | acc]
-        end
+      |> Enum.map(fn
+        "c=" <> rest -> "c[]=" <> rest
+        value -> value
       end)
-      |> Enum.reverse()
       |> Enum.join("&")
 
     {:ok, body_params, conn}

--- a/test/signs_ui_web/realtime_signs_body_reader_test.exs
+++ b/test/signs_ui_web/realtime_signs_body_reader_test.exs
@@ -1,0 +1,39 @@
+defmodule SignsUiWeb.RealtimeSignsBodyReaderTest do
+  use ExUnit.Case, async: true
+  use Phoenix.ConnTest
+
+  describe "read_body/2" do
+    test "changes c params to c[]" do
+      conn = build_conn(:put, "/", "c=bar&c=baz")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "c[]=bar&c[]=baz"
+    end
+
+    test "leaves single elements alone" do
+      conn = build_conn(:put, "/", "foo=bar")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "foo=bar"
+    end
+
+    test "handles both c's and other elements" do
+      conn = build_conn(:put, "/", "foo=bar&c=1&c=2")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      elements = String.split(params, "&")
+      assert "c[]=1" in elements
+      assert "c[]=2" in elements
+      assert "foo=bar" in elements
+    end
+
+    test "leaves other duplicates (e.g. Phoenix checkboxes) in the same order" do
+      conn = build_conn(:put, "/", "foo=false&foo=true")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "foo=false&foo=true"
+    end
+
+    test "doesn't double encode equals signs for base64-encoded tokens" do
+      conn = build_conn(:put, "/", "_csrf_token=2rJcUflcfXZ9%2FiA%3D%3D")
+      {:ok, params, _conn} = RealtimeSignsBodyReader.read_body(conn, [])
+      assert params == "_csrf_token=2rJcUflcfXZ9%2FiA%3D%3D"
+    end
+  end
+end


### PR DESCRIPTION
Asana: [Bug: prod Signs UI shows "forbidden" when you try to turn on/off a sign](https://app.asana.com/0/584764604969369/792472905559025).

To recap, ARINC's API allows you to send one request that updates multiple lines of a sign at the same time, by including multiple "commands", in the form `c=...&c=...&c=...`. However, SignsUI couldn't handle that, since by the time it got to the Phoenix controller, the params were distilled down to `%{"c" =>...}` and the earlier commands were eaten.

We fixed this by adding a custom body reader to the Endpoint to transform those `c=` params into `c[]=`, which will then show up in the controller as `%{"c" => [...]}`, containing all the commands.

However, that change broke our `_csrf_token` protection, since that got transformed into `_csrf_token[]=`, since we were doing the transformation on _all_ params for _all_ pages (since it happens at the Endpoint, before even the router).

This was causing us to see "503 Forbidden" when trying to update the signs.

One earlier approach I used to fix this ran into the issue that Phoenix, in order to handle turning on checkboxes and turning them off, always has two form elements, which get posted something like `check1=false&check1=true`. That way, if the checkbox isn't checked, it still sends something, and the backend can update the value, but if the checkbox is checked, the latter value overrules the first.

So I changed custom body reader to leave all the params alone in their same order, except for `c=`, which simply gets transformed to `c[]=`. This seems to work.