### PR TITLE
Add GKEN mezzanine to config

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -553,7 +553,7 @@ const stationConfig = {
       id: 'GKEN',
       name: 'Kenmore',
       zones: {
-        n: 'C/D East', s: 'C/D West', e: 'B East', w: 'B West', c: false, m: false,
+        n: 'C/D East', s: 'C/D West', e: 'B East', w: 'B West', c: false, m: true,
       },
     },
     {


### PR DESCRIPTION
Realized when working on the multiple berths for Kenmore ticket that the station actually has a mezzanine sign as well, which was missing from the Signs UI dashboard.