### PR TITLE
Reads old/new format config, saves to new (backwards compatible) format

### DIFF
--- a/lib/signs_ui/signs/request.ex
+++ b/lib/signs_ui/signs/request.ex
@@ -17,7 +17,7 @@ defmodule SignsUI.Signs.Request do
     case Poison.decode(json) do
       {:ok, response} ->
         {:ok,
-         Map.new(response, fn {sign_id, values} -> {sign_id, Sign.from_json(sign_id, values)} end)}
+         Map.new(response, fn {sign_id, config} -> {sign_id, Sign.from_json(sign_id, config)} end)}
 
       {:error, reason} ->
         Logger.warn("Could not decode response: #{inspect(reason)}")

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -1,18 +1,144 @@
 defmodule SignsUI.Signs.Sign do
-  defstruct id: "",
-            enabled?: false
+  @enforce_keys [:id, :config]
+  defstruct @enforce_keys
 
   @type id :: String.t()
 
-  @type t :: %__MODULE__{
-          id: id(),
-          enabled?: boolean()
+  # ISO 8601 in UTC
+  @type expires_on :: String.t()
+
+  @type auto :: %{
+          mode: :auto
         }
 
-  def from_json(sign_id, values) do
+  @type headway :: %{
+          mode: :headway,
+          expires: expires_on() | nil
+        }
+
+  @type off :: %{
+          mode: :off,
+          expires: expires_on() | nil
+        }
+
+  @type static_text :: %{
+          mode: :static_text,
+          line1: String.t(),
+          line2: String.t(),
+          expires: expires_on() | nil
+        }
+
+  @type t :: %__MODULE__{
+          id: id(),
+          config: auto() | headway() | off() | static_text()
+        }
+
+  @spec enabled?(t()) :: boolean()
+  def enabled?(sign) do
+    sign.config.mode == :auto
+  end
+
+  @spec new(String.t(), boolean()) :: t()
+  def new(sign_id, enabled?)
+
+  def new(id, true) do
+    %__MODULE__{id: id, config: %{mode: :auto}}
+  end
+
+  def new(id, false) do
+    %__MODULE__{id: id, config: %{mode: :off, expires: nil}}
+  end
+
+  @spec from_json(String.t(), map()) :: t()
+  def from_json(sign_id, %{"mode" => "auto"}) do
+    %__MODULE__{id: sign_id, config: %{mode: :auto}}
+  end
+
+  def from_json(sign_id, %{"mode" => "headway"} = config) do
     %__MODULE__{
       id: sign_id,
-      enabled?: Map.get(values, "enabled")
+      config: %{
+        mode: :headway,
+        expires: config["expires"]
+      }
+    }
+  end
+
+  def from_json(sign_id, %{"mode" => "off"} = config) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :off,
+        expires: config["expires"]
+      }
+    }
+  end
+
+  def from_json(sign_id, %{"mode" => "static_text"} = config) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :static_text,
+        line1: config["line1"],
+        line2: config["line2"],
+        expires: config["expires"]
+      }
+    }
+  end
+
+  def from_json(sign_id, %{"enabled" => true}) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :auto
+      }
+    }
+  end
+
+  def from_json(sign_id, %{"enabled" => false}) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :off,
+        expires: nil
+      }
+    }
+  end
+
+  def to_json(%{config: %{mode: :auto}} = sign) do
+    %{
+      "id" => sign.id,
+      "mode" => "auto",
+      "enabled" => true
+    }
+  end
+
+  def to_json(%{config: %{mode: :off}} = sign) do
+    %{
+      "id" => sign.id,
+      "mode" => "off",
+      "enabled" => false,
+      "expires" => sign.config.expires
+    }
+  end
+
+  def to_json(%{config: %{mode: :headway}} = sign) do
+    %{
+      "id" => sign.id,
+      "mode" => "headway",
+      "enabled" => false,
+      "expires" => sign.config.expires
+    }
+  end
+
+  def to_json(%{config: %{mode: :static_text}} = sign) do
+    %{
+      "id" => sign.id,
+      "mode" => "static_text",
+      "enabled" => false,
+      "line1" => sign.config.line1,
+      "line2" => sign.config.line2,
+      "expires" => sign.config.expires
     }
   end
 end

--- a/lib/signs_ui/signs/signs.ex
+++ b/lib/signs_ui/signs/signs.ex
@@ -1,5 +1,8 @@
 defmodule SignsUI.Signs.Signs do
+  alias SignsUI.Signs.Sign
+
+  @spec format_signs_for_json(%{Sign.id() => Sign.t()}) :: map()
   def format_signs_for_json(signs) do
-    Map.new(signs, fn {sign_id, sign} -> {sign_id, %{"enabled" => sign.enabled?}} end)
+    Map.new(signs, fn {sign_id, sign} -> {sign_id, Sign.to_json(sign)} end)
   end
 end

--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -19,8 +19,9 @@ defmodule SignsUI.Signs.State do
     GenServer.call(pid, :get_all)
   end
 
-  def update(pid \\ __MODULE__, enabled_values) do
-    GenServer.call(pid, {:update, enabled_values})
+  @spec update(atom() | pid() | {atom(), any()} | {:via, atom(), any()}, any()) :: any()
+  def update(_pid \\ __MODULE__, _enabled_values) do
+    :ok
   end
 
   @spec update_some(GenServer.server(), %{Signs.Sign.id() => boolean()}) :: :ok
@@ -28,11 +29,16 @@ defmodule SignsUI.Signs.State do
     GenServer.call(pid, {:update_some, changes})
   end
 
-  @spec init(any()) :: {:ok, t()} | {:error, any()}
+  @spec init(any()) :: {:ok, t()} | {:stop, any()}
   def init(_) do
     case Signs.Request.get_signs() do
-      {:ok, state} -> {:ok, state}
-      {:error, reason} -> {:stop, reason}
+      {:ok, state} ->
+        # re-save state, since format was updated
+        save_changes(%{}, state)
+        {:ok, state}
+
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 
@@ -40,35 +46,21 @@ defmodule SignsUI.Signs.State do
     {:reply, signs, signs}
   end
 
-  def handle_call({:update, updated_signs}, _from, old_signs) do
-    external_post_mod = Application.get_env(:signs_ui, :signs_external_post_mod)
-
-    {status, new_sign_state} =
-      updated_signs
-      |> external_post_mod.update()
-      |> handle_response(old_signs, updated_signs)
-
-    {:reply, status, new_sign_state}
-  end
-
   def handle_call({:update_some, changes}, _from, old_state) do
-    external_post_mod = Application.get_env(:signs_ui, :signs_external_post_mod)
-
-    new_state_changes =
-      changes
-      |> Enum.map(fn {id, enabled?} -> {id, %Signs.Sign{id: id, enabled?: enabled?}} end)
-      |> Enum.into(%{})
-
-    new_state = Map.merge(old_state, new_state_changes)
-    {:ok, _} = external_post_mod.update(new_state)
+    new_state = save_changes(changes, old_state)
     {:reply, {:ok, new_state}, new_state}
   end
 
-  defp handle_response({:error, _reason}, old_signs, _updated_signs) do
-    {:error, old_signs}
-  end
+  defp save_changes(changes, old_state) do
+    external_post_mod = Application.get_env(:signs_ui, :signs_external_post_mod)
 
-  defp handle_response({:ok, _}, _old_signs, updated_signs) do
-    {:ok, updated_signs}
+    new_signs =
+      changes
+      |> Enum.map(fn {id, enabled?} -> {id, Signs.Sign.new(id, enabled?)} end)
+      |> Enum.into(%{})
+
+    signs = Map.merge(old_state, new_signs)
+    {:ok, _} = external_post_mod.update(signs)
+    signs
   end
 end

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -9,7 +9,7 @@ defmodule SignsUiWeb.MessagesController do
     enabled_signs =
       SignsUI.Signs.State.get_all()
       |> Enum.map(fn {_id, sign} ->
-        {sign.id, sign.enabled?}
+        {sign.id, SignsUI.Signs.Sign.enabled?(sign)}
       end)
       |> Enum.into(%{})
 

--- a/lib/signs_ui_web/controllers/signs_controller.ex
+++ b/lib/signs_ui_web/controllers/signs_controller.ex
@@ -16,12 +16,8 @@ defmodule SignsUiWeb.SignsController do
 
   def update(conn, params) do
     signs = params_to_signs(params)
-    {status, conn} = perform_update(conn, signs)
-
-    case status do
-      :ok -> redirect(conn, to: "/")
-      :error -> render(conn, "index.html", signs: signs)
-    end
+    {:ok, conn} = perform_update(conn, signs)
+    redirect(conn, to: "/")
   end
 
   def sign_names(%{"route" => "mattapan"}), do: Signs.Names.mattapan()
@@ -44,10 +40,6 @@ defmodule SignsUiWeb.SignsController do
 
   defp handle_update_response(:ok, conn) do
     {:ok, put_flash(conn, :success, "Signs updated successfully")}
-  end
-
-  defp handle_update_response(:error, conn) do
-    {:error, put_flash(conn, :error, "Signs could not be updated, please try again.")}
   end
 
   defp get_enabled_map(%{"signs" => signs}) do

--- a/lib/signs_ui_web/templates/signs/index.html.eex
+++ b/lib/signs_ui_web/templates/signs/index.html.eex
@@ -15,8 +15,8 @@
     <div class="row">
       <%= for {id, label} <- @sign_names do %>
         <%= if @signs[id] do %>
-            <%= sign_checkbox(id, @signs[id].enabled?, f) %>
-            <%= sign_label(id, label, @signs[id].enabled?) %>
+            <%= sign_checkbox(id, @signs[id].config.mode == :auto, f) %>
+            <%= sign_label(id, label, @signs[id].config.mode == :auto) %>
         <% end %>
       <% end %>
     </div>

--- a/test/signs_ui/signs/s3_test.exs
+++ b/test/signs_ui/signs/s3_test.exs
@@ -5,7 +5,11 @@ defmodule SignsUI.Signs.S3Test do
 
   describe "update/1" do
     test "sends_update" do
-      signs = %{"sign1" => %Sign{id: "sign1"}, "sign2" => %Sign{id: "sign2"}}
+      signs = %{
+        "sign1" => %Sign{id: "sign1", config: %{mode: :auto}},
+        "sign2" => %Sign{id: "sign2", config: %{mode: :auto}}
+      }
+
       {:ok, object} = update(signs)
       assert object.body =~ "sign1"
       assert object.body =~ "sign2"

--- a/test/signs_ui/signs/sign_test.exs
+++ b/test/signs_ui/signs/sign_test.exs
@@ -4,10 +4,100 @@ defmodule SignsUI.Signs.SignTest do
   alias SignsUI.Signs.Sign
 
   describe "from_json" do
-    test "builds a Sign struct from json" do
+    test "builds a Sign struct in 'auto' mode from legacy json" do
       values = %{"enabled" => true}
-      expected = %Sign{id: "Sign", enabled?: true}
+      expected = %Sign{id: "Sign", config: %{mode: :auto}}
       assert from_json("Sign", values) == expected
+    end
+
+    test "builds a Sign struct in 'off' mode from legacy json" do
+      values = %{"enabled" => false}
+      expected = %Sign{id: "Sign", config: %{mode: :off, expires: nil}}
+      assert from_json("Sign", values) == expected
+    end
+
+    test "builds a Sign struct in 'auto' mode from json" do
+      values = %{"mode" => "auto"}
+      expected = %Sign{id: "Sign", config: %{mode: :auto}}
+      assert from_json("Sign", values) == expected
+    end
+
+    test "builds a Sign struct in 'off' mode from json" do
+      values = %{"mode" => "off", "expires" => "2018-08-10"}
+      expected = %Sign{id: "Sign", config: %{mode: :off, expires: "2018-08-10"}}
+      assert from_json("Sign", values) == expected
+    end
+
+    test "builds a Sign struct in 'headway' mode from json" do
+      values = %{"mode" => "headway", "expires" => "2018-08-10"}
+      expected = %Sign{id: "Sign", config: %{mode: :headway, expires: "2018-08-10"}}
+      assert from_json("Sign", values) == expected
+    end
+
+    test "builds a Sign struct in 'static text' mode from json" do
+      values = %{
+        "mode" => "static_text",
+        "line1" => "line1 text",
+        "line2" => "line2 text",
+        "expires" => "2018-08-10"
+      }
+
+      expected = %Sign{
+        id: "Sign",
+        config: %{
+          mode: :static_text,
+          expires: "2018-08-10",
+          line1: "line1 text",
+          line2: "line2 text"
+        }
+      }
+
+      assert from_json("Sign", values) == expected
+    end
+  end
+
+  describe "to_json" do
+    test "serializes an Auto sign" do
+      sign = %Sign{id: "sign", config: %{mode: :auto}}
+      assert to_json(sign) == %{"id" => "sign", "mode" => "auto", "enabled" => true}
+    end
+
+    test "serializes a Headway sign" do
+      sign = %Sign{id: "sign", config: %{mode: :headway, expires: "2018-10-10"}}
+
+      assert to_json(sign) == %{
+               "id" => "sign",
+               "mode" => "headway",
+               "expires" => "2018-10-10",
+               "enabled" => false
+             }
+    end
+
+    test "serializes an Off sign" do
+      sign = %Sign{id: "sign", config: %{mode: :off, expires: "2018-10-10"}}
+
+      assert to_json(sign) == %{
+               "id" => "sign",
+               "mode" => "off",
+               "expires" => "2018-10-10",
+               "enabled" => false
+             }
+    end
+
+    test "serializes a Static Text sign" do
+      sign = %Sign{
+        id: "sign",
+        config: %{mode: :static_text, expires: "2018-10-10", line1: "l1", line2: "l2"}
+      }
+
+      assert to_json(sign) == %{
+               "id" => "sign",
+               "mode" => "static_text",
+               "expires" => "2018-10-10",
+               "line1" => "l1",
+               "line2" => "l2",
+               "enabled" => false
+             }
     end
   end
 end

--- a/test/signs_ui/signs/signs_test.exs
+++ b/test/signs_ui/signs/signs_test.exs
@@ -4,17 +4,17 @@ defmodule SignsUI.Signs.SignsTest do
   alias SignsUI.Signs.Sign
 
   @signs %{
-    "sign1" => %Sign{id: "sign1", enabled?: true},
-    "sign2" => %Sign{id: "sign2", enabled?: false},
-    "sign3" => %Sign{id: "sign3", enabled?: true}
+    "sign1" => Sign.new("sign1", true),
+    "sign2" => Sign.new("sign2", false),
+    "sign3" => Sign.new("sign3", true)
   }
 
   describe "format_signs_for_json/1" do
     test "puts all signs in json format" do
       expected = %{
-        "sign1" => %{"enabled" => true},
-        "sign2" => %{"enabled" => false},
-        "sign3" => %{"enabled" => true}
+        "sign1" => %{"id" => "sign1", "enabled" => true, "mode" => "auto"},
+        "sign2" => %{"id" => "sign2", "enabled" => false, "mode" => "off", "expires" => nil},
+        "sign3" => %{"id" => "sign3", "enabled" => true, "mode" => "auto"}
       }
 
       assert format_signs_for_json(@signs) == expected

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -2,30 +2,14 @@ defmodule SignsUI.Signs.StateTest do
   use ExUnit.Case
   import SignsUI.Signs.State
   alias SignsUI.Signs
+  alias SignsUI.Signs.Sign
 
   describe "get_all/1" do
     test "Returns all signs" do
       {:ok, signs_server} = start_supervised({Signs.State, [name: :sign_test]})
-      signs = %{"sign_1" => %Signs.Sign{}, "sign2" => %Signs.Sign{}}
+      signs = %{"sign1" => Sign.new("sign1", true), "sign2" => Sign.new("sign2", true)}
       :sys.replace_state(signs_server, fn _state -> signs end)
       assert get_all(signs_server) == signs
-    end
-  end
-
-  describe "update/2" do
-    test "updates signs based on enabled_values" do
-      {:ok, signs_server} = start_supervised({Signs.State, [name: :sign_test]})
-      signs = %{"sign_1" => %Signs.Sign{enabled?: false}, "sign2" => %Signs.Sign{}}
-      :sys.replace_state(signs_server, fn _state -> signs end)
-
-      enabled_signs = %{
-        "sign_1" => %Signs.Sign{enabled?: true}
-      }
-
-      status = update(signs_server, enabled_signs)
-      state = :sys.get_state(signs_server)
-      assert Map.get(state, "sign_1").enabled?
-      assert status == :ok
     end
   end
 
@@ -34,24 +18,24 @@ defmodule SignsUI.Signs.StateTest do
       {:ok, pid} = GenServer.start_link(SignsUI.Signs.State, [], [])
 
       assert %{
-               "maverick_westbound" => %Signs.Sign{enabled?: true},
-               "maverick_eastbound" => %Signs.Sign{enabled?: true},
-               "forest_hills_southbound" => %Signs.Sign{enabled?: true}
+               "maverick_westbound" => %Signs.Sign{config: %{mode: :auto}},
+               "maverick_eastbound" => %Signs.Sign{config: %{mode: :auto}},
+               "forest_hills_southbound" => %Signs.Sign{config: %{mode: :auto}}
              } = get_all(pid)
 
       {:ok, new_state} =
         update_some(pid, %{"maverick_eastbound" => false, "maverick_westbound" => false})
 
       assert %{
-               "maverick_westbound" => %Signs.Sign{enabled?: false},
-               "maverick_eastbound" => %Signs.Sign{enabled?: false},
-               "forest_hills_southbound" => %Signs.Sign{enabled?: true}
+               "maverick_westbound" => %Signs.Sign{config: %{mode: :off}},
+               "maverick_eastbound" => %Signs.Sign{config: %{mode: :off}},
+               "forest_hills_southbound" => %Signs.Sign{config: %{mode: :auto}}
              } = new_state
 
       assert %{
-               "maverick_westbound" => %Signs.Sign{enabled?: false},
-               "maverick_eastbound" => %Signs.Sign{enabled?: false},
-               "forest_hills_southbound" => %Signs.Sign{enabled?: true}
+               "maverick_westbound" => %Signs.Sign{config: %{mode: :off}},
+               "maverick_eastbound" => %Signs.Sign{config: %{mode: :off}},
+               "forest_hills_southbound" => %Signs.Sign{config: %{mode: :auto}}
              } = get_all(pid)
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** A little piece of [[8] PIOs can put static text on a sign](https://app.asana.com/0/584764604969369/831665421652437)

This PR updates `signs_ui` to use the new config format we decided on. In particular, when the app is on this branch, it can read _either_ the old or the new format, but when it saves, it saves to the new format. (Note that the new format is backwards compatible, so `realtime_signs` will continue to work, even when we've saved with the new format.)

In addition, when it starts up, after reading in the JSON config file, it then immediately saves its state. This will update the format of all the signs.

Lastly, there's the legacy signs listing and control page (from before the react app). That will need to be removed eventually, since it doesn't support the different sign types, but for now I basically just prevented it from updating any state, rather than dealing with converting it to handle the new format.


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
