### PR TITLE
Static Text controls on the viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log
 # secrets files as long as you replace their contents by environment
 # variables.
 /config/*.secret.exs
+test/mock_write.json

--- a/assets/css/viewer.css
+++ b/assets/css/viewer.css
@@ -39,3 +39,7 @@
   padding-top: 10px;
   white-space: pre;
 }
+
+.viewer--static-text-form {
+  margin-bottom: 1em;
+}

--- a/assets/css/viewer.css
+++ b/assets/css/viewer.css
@@ -41,5 +41,16 @@
 }
 
 .viewer--static-text-form {
+  background-color: rgb(206, 206, 206);
   margin-bottom: 1em;
+  /* margin-left: 0.5em; */
+  margin-top: -1em;
+  padding: 0.25em 0.5em 0.5em 0.5em;
+  width: 20em;
+}
+
+.viewer--line-input {
+  margin-bottom: 0.25em;
+  /* margin-left: 1em; */
+  padding-left: 0.25em;
 }

--- a/assets/css/viewer.css
+++ b/assets/css/viewer.css
@@ -43,7 +43,6 @@
 .viewer--static-text-form {
   background-color: rgb(206, 206, 206);
   margin-bottom: 1em;
-  /* margin-left: 0.5em; */
   margin-top: -1em;
   padding: 0.25em 0.5em 0.5em 0.5em;
   width: 20em;
@@ -51,6 +50,5 @@
 
 .viewer--line-input {
   margin-bottom: 0.25em;
-  /* margin-left: 1em; */
   padding-left: 0.25em;
 }

--- a/assets/css/viewer.css
+++ b/assets/css/viewer.css
@@ -52,3 +52,7 @@
   margin-bottom: 0.25em;
   padding-left: 0.25em;
 }
+
+.viewer--error-text {
+  color: #ff0000;
+}

--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Station from './Station';
 import { stationConfig, arincToRealtimeId } from './mbta';
+import { signConfigType } from './types';
 
 function name(line) {
   if (line === 'Red') { return 'Red Line'; }
@@ -82,7 +83,7 @@ Line.propTypes = {
   }))).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  signConfigs: PropTypes.object.isRequired,
+  signConfigs: PropTypes.objectOf(signConfigType).isRequired,
   setConfigs: PropTypes.func.isRequired,
 };
 

--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -23,9 +23,9 @@ function setEnabledStations(setConfigFn, stations, line, enabled) {
       const realtimeId = arincToRealtimeId(`${station.id}-${zone}`, line);
       if (realtimeId) {
         if (enabled) {
-          statuses[realtimeId] = { "mode": "auto" };
+          statuses[realtimeId] = { mode: 'auto' };
         } else {
-          statuses[realtimeId] = { "mode": "off", "expires": null };
+          statuses[realtimeId] = { mode: 'off', expires: null };
         }
       }
     });

--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -30,7 +30,7 @@ function setEnabledStations(enablerFn, stations, line, val) {
 }
 
 function Line({
-  signs, currentTime, line, enabledSigns, setEnabled,
+  signs, currentTime, line, signConfigs, setConfigs,
 }) {
   const stations = stationConfig[line] || [];
 
@@ -44,7 +44,7 @@ function Line({
         <button
           type="button"
           className="btn btn-outline-secondary"
-          onClick={() => { setEnabledStations(setEnabled, stations, line, true); }}
+          onClick={() => { setEnabledStations(setConfigs, stations, line, true); }}
         >
           Enable all
         </button>
@@ -54,7 +54,7 @@ function Line({
         <button
           type="button"
           className="btn btn-outline-secondary"
-          onClick={() => { setEnabledStations(setEnabled, stations, line, false); }}
+          onClick={() => { setEnabledStations(setConfigs, stations, line, false); }}
         >
           Disable all
         </button>
@@ -67,8 +67,8 @@ function Line({
             signs={signs}
             currentTime={currentTime}
             line={line}
-            enabledSigns={enabledSigns}
-            setEnabled={setEnabled}
+            signConfigs={signConfigs}
+            setConfigs={setConfigs}
           />
         ))
       }
@@ -82,8 +82,8 @@ Line.propTypes = {
   }))).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  enabledSigns: PropTypes.objectOf(PropTypes.bool.isRequired).isRequired,
-  setEnabled: PropTypes.func.isRequired,
+  signConfigs: PropTypes.object.isRequired,
+  setConfigs: PropTypes.func.isRequired,
 };
 
 export default Line;

--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -15,19 +15,23 @@ function name(line) {
   return '';
 }
 
-function setEnabledStations(enablerFn, stations, line, val) {
+function setEnabledStations(setConfigFn, stations, line, enabled) {
   const statuses = {};
 
   stations.forEach((station) => {
     ['n', 's', 'e', 'w', 'm', 'c'].forEach((zone) => {
       const realtimeId = arincToRealtimeId(`${station.id}-${zone}`, line);
       if (realtimeId) {
-        statuses[realtimeId] = val;
+        if (enabled) {
+          statuses[realtimeId] = { "mode": "auto" };
+        } else {
+          statuses[realtimeId] = { "mode": "off", "expires": null };
+        }
       }
     });
   });
 
-  enablerFn(statuses);
+  setConfigFn(statuses);
 }
 
 function Line({

--- a/assets/js/Line.test.js
+++ b/assets/js/Line.test.js
@@ -10,11 +10,11 @@ test('Shows all signs for a line', () => {
 
   const currentTime = now + 2000;
   const line = 'Red';
-  const enabledSigns = {};
-  const setEnabled = () => {};
+  const signConfigs = {};
+  const setConfigs = () => { };
 
   const wrapper = mount(React.createElement(Line, {
-    signs, currentTime, line, enabledSigns, setEnabled,
+    signs, currentTime, line, signConfigs, setConfigs,
   }, null));
 
   expect(wrapper.text()).toMatch('Alewife (RALE)');

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -130,7 +130,7 @@ class Sign extends Component {
 
         {signConfig['mode'] == 'static_text' &&
           <div className="viewer--static-text-form">
-            <div><strong>Set custom text</strong></div>
+            <div><strong>Set custom message</strong></div>
             {this.state.tipText && <small>Only allowed letters, numbers, and: ,.!@'</small>}
             <div>
               <input

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import lineToColor from './colors';
+import { signConfigType } from './types';
 
 function displayLine(duration, currentTime) {
   return (Date.parse(duration) - currentTime) > 0;
@@ -14,19 +15,23 @@ function fontSize(signId) {
 }
 
 function makeConfig(mode) {
-  if (mode == 'auto') {
+  if (mode === 'auto') {
     return { mode: 'auto' };
   }
 
-  if (mode == 'off') {
-    return { mode: 'off', expires: null };
-  }
-
-  if (mode == 'static_text') {
+  if (mode === 'static_text') {
     return {
       mode: 'static_text', expires: null, line1: '', line2: '',
     };
   }
+
+  if (mode === 'headway') {
+    return {
+      mode: 'headway', expires: null,
+    };
+  }
+
+  return { mode: 'off', expires: null };
 }
 
 function isValidText(text) {
@@ -99,6 +104,13 @@ class Sign extends Component {
       realtimeId,
     } = this.props;
 
+    const {
+      tipText,
+      staticLine1,
+      staticLine2,
+      customChanges,
+    } = this.state;
+
     return (
       <div>
         <div className="viewer--sign">
@@ -111,19 +123,19 @@ class Sign extends Component {
                 id={realtimeId}
                 value={signConfig.mode}
                 onChange={
-                (event) => {
-                  setConfigs({ [realtimeId]: makeConfig(event.target.value) });
+                  (event) => {
+                    setConfigs({ [realtimeId]: makeConfig(event.target.value) });
+                  }
                 }
-              }
               >
                 <option value="auto">
-On
+                  On
                 </option>
                 <option value="off">
-Off
+                  Off
                 </option>
                 <option value="static_text">
-Text
+                  Text
                 </option>
               </select>
               {/* eslint-disable-next-line jsx-a11y/label-has-for */}
@@ -140,50 +152,50 @@ Text
           </div>
         </div>
 
-        {signConfig.mode == 'static_text'
+        {signConfig.mode === 'static_text'
           && (
-          <div className="viewer--static-text-form">
-            <div>
-              <strong>
-Set custom message
-              </strong>
+            <div className="viewer--static-text-form">
+              <div>
+                <strong>
+                  Set custom message
+                </strong>
+              </div>
+              {tipText && (
+                <small>
+                  Only allowed letters, numbers, and: ,.!@&quot;
+                </small>
+              )}
+              <div>
+                <input
+                  className="viewer--line-input"
+                  type="text"
+                  maxLength={18}
+                  size={18}
+                  value={staticLine1}
+                  onChange={this.handleInputLine1}
+                />
+              </div>
+              <div>
+                <input
+                  className="viewer--line-input"
+                  type="text"
+                  maxLength={24}
+                  size={24}
+                  value={staticLine2}
+                  onChange={this.handleInputLine2}
+                />
+              </div>
+              <div>
+                <input
+                  className="viewer--apply-button"
+                  disabled={!customChanges}
+                  type="submit"
+                  value="Apply"
+                  onClick={this.saveStaticText}
+                />
+                {customChanges ? '*' : ''}
+              </div>
             </div>
-            {this.state.tipText && (
-            <small>
-Only allowed letters, numbers, and: ,.!@'
-            </small>
-            )}
-            <div>
-              <input
-                className="viewer--line-input"
-                type="text"
-                maxLength={18}
-                size={18}
-                value={this.state.staticLine1}
-                onChange={this.handleInputLine1}
-              />
-            </div>
-            <div>
-              <input
-                className="viewer--line-input"
-                type="text"
-                maxLength={24}
-                size={24}
-                value={this.state.staticLine2}
-                onChange={this.handleInputLine2}
-              />
-            </div>
-            <div>
-              <input
-                className="viewer--apply-button"
-                disabled={!this.state.customChanges}
-                type="submit"
-                value="Apply"
-                onClick={this.saveStaticText}
-              />
-              {this.state.customChanges ? '*' : ''}
-            </div>
-          </div>
           )
         }
       </div>
@@ -200,13 +212,7 @@ Sign.propTypes = {
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
   setConfigs: PropTypes.func.isRequired,
-  signConfig: PropTypes.oneOfType([
-    PropTypes.exact({ mode: PropTypes.oneOf(['off']), expires: PropTypes.string }),
-    PropTypes.exact({ mode: PropTypes.oneOf(['auto']) }),
-    PropTypes.exact({
-      mode: PropTypes.oneOf(['static_text']), line1: PropTypes.string.isRequired, line2: PropTypes.string.isRequired, expires: PropTypes.string,
-    }),
-  ]).isRequired,
+  signConfig: signConfigType.isRequired,
   realtimeId: PropTypes.string.isRequired,
 };
 

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -27,20 +27,43 @@ function makeConfig(mode) {
   }
 }
 
+function isValidText(text) {
+  return !(/[^a-zA-Z0-9,.!@' ]/.test(text))
+}
+
 class Sign extends Component {
   constructor(props) {
     super(props);
 
     this.saveStaticText = this.saveStaticText.bind(this);
+    this.handleInputLine1 = this.handleInputLine1.bind(this);
+    this.handleInputLine2 = this.handleInputLine2.bind(this);
 
-    if (props.signConfig.mode === 'static_text') {
-      this.state = {
-        staticLine1: props.signConfig.line1,
-        staticLine2: props.signConfig.line2,
-        customChanges: false
-      }
+    this.state = {
+      staticLine1: props.signConfig.line1 || '',
+      staticLine2: props.signConfig.line2 || '',
+      customChanges: false,
+      tipText: false
+    }
+  }
+
+  handleInputLine1(evt) {
+    const text = evt.target.value;
+
+    if (isValidText(text)) {
+      this.setState({ staticLine1: text, customChanges: true });
     } else {
-      this.state = { staticLine1: '', staticLine2: '', customChanges: false }
+      this.setState({ tipText: true })
+    }
+  }
+
+  handleInputLine2(evt) {
+    const text = evt.target.value;
+
+    if (isValidText(text)) {
+      this.setState({ staticLine2: text, customChanges: true });
+    } else {
+      this.setState({ tipText: true })
     }
   }
 
@@ -107,26 +130,37 @@ class Sign extends Component {
 
         {signConfig['mode'] == 'static_text' &&
           <div className="viewer--static-text-form">
-            <div>Set custom text:</div>
+            <div><strong>Set custom text</strong></div>
+            {this.state.tipText && <small>Only allowed letters, numbers, and: ,.!@'</small>}
             <div>
               <input
+                className='viewer--line-input'
                 type="text"
                 maxLength={18}
                 size={18}
                 value={this.state.staticLine1}
-                onChange={(evt) => this.setState({ staticLine1: evt.target.value, customChanges: true })}
+                onChange={this.handleInputLine1}
               />
             </div>
             <div>
               <input
+                className='viewer--line-input'
                 type="text"
                 maxLength={24}
                 size={24}
                 value={this.state.staticLine2}
-                onChange={(evt) => this.setState({ staticLine2: evt.target.value, customChanges: true })}
+                onChange={this.handleInputLine2}
               />
             </div>
-            <div><input type="submit" value="Apply" onClick={this.saveStaticText} />{this.state.customChanges ? '*' : ''}</div>
+            <div>
+              <input
+                className='viewer--apply-button'
+                disabled={!this.state.customChanges}
+                type="submit"
+                value="Apply"
+                onClick={this.saveStaticText}
+              />
+              {this.state.customChanges ? '*' : ''}</div>
           </div>
         }
       </div>

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import lineToColor from './colors';
 
@@ -13,40 +13,125 @@ function fontSize(signId) {
   return {};
 }
 
-function Sign({
-  signId,
-  lineOne,
-  lineOneDuration,
-  lineTwo,
-  lineTwoDuration,
-  currentTime,
-  line,
-  isEnabled,
-  setEnabled,
-  realtimeId,
-}) {
-  return (
-    <div className="viewer--sign">
-      <div className="viewer--sign-id" style={{ borderTopColor: lineToColor(line) }}>
-        <span style={fontSize(signId)}>
-          {signId}
-        </span>
-        <div>
-          <input id={realtimeId} type="checkbox" checked={isEnabled} className="ios8-switch" onChange={() => { setEnabled({ [realtimeId]: !isEnabled }); }} />
-          {/* eslint-disable-next-line jsx-a11y/label-has-for */}
-          <label htmlFor={realtimeId} />
+function makeConfig(mode) {
+  if (mode == 'auto') {
+    return { 'mode': 'auto' };
+  }
+
+  if (mode == 'off') {
+    return { 'mode': 'off', 'expires': null };
+  }
+
+  if (mode == 'static_text') {
+    return { 'mode': 'static_text', 'expires': null, 'line1': '', 'line2': '' };
+  }
+}
+
+class Sign extends Component {
+  constructor(props) {
+    super(props);
+
+    this.saveStaticText = this.saveStaticText.bind(this);
+
+    if (props.signConfig.mode === 'static_text') {
+      this.state = {
+        staticLine1: props.signConfig.line1,
+        staticLine2: props.signConfig.line2,
+        customChanges: false
+      }
+    } else {
+      this.state = { staticLine1: '', staticLine2: '', customChanges: false }
+    }
+  }
+
+  saveStaticText() {
+    const { setConfigs, realtimeId } = this.props;
+    const { staticLine1, staticLine2 } = this.state;
+
+    this.setState({ customChanges: false })
+
+    setConfigs({
+      [realtimeId]: {
+        'mode': 'static_text',
+        'line1': staticLine1,
+        'line2': staticLine2,
+        'expires': null
+      }
+    })
+  }
+
+  render() {
+    const {
+      signId,
+      lineOne,
+      lineOneDuration,
+      lineTwo,
+      lineTwoDuration,
+      currentTime,
+      line,
+      signConfig,
+      setConfigs,
+      realtimeId,
+    } = this.props;
+
+    return (
+      <div>
+        <div className="viewer--sign">
+          <div className="viewer--sign-id" style={{ borderTopColor: lineToColor(line) }}>
+            <span style={fontSize(signId)}>
+              {signId}
+            </span>
+            <div>
+              <select id={realtimeId} value={signConfig['mode']} onChange={
+                (event) => {
+                  setConfigs({ [realtimeId]: makeConfig(event.target.value) })
+                }
+              }>
+                <option value="auto">On</option>
+                <option value="off">Off</option>
+                <option value="static_text">Text</option>
+              </select>
+              {/* eslint-disable-next-line jsx-a11y/label-has-for */}
+              <label htmlFor={realtimeId} />
+            </div>
+          </div>
+          <div className="viewer--sign-lines">
+            <div className="viewer--sign-line">
+              {displayLine(lineOneDuration, currentTime) ? lineOne : null}
+            </div>
+            <div className="viewer--sign-line">
+              {displayLine(lineTwoDuration, currentTime) ? lineTwo : null}
+            </div>
+          </div>
         </div>
+
+        {signConfig['mode'] == 'static_text' &&
+          <div className="viewer--static-text-form">
+            <div>Set custom text:</div>
+            <div>
+              <input
+                type="text"
+                maxLength={18}
+                size={18}
+                value={this.state.staticLine1}
+                onChange={(evt) => this.setState({ staticLine1: evt.target.value, customChanges: true })}
+              />
+            </div>
+            <div>
+              <input
+                type="text"
+                maxLength={24}
+                size={24}
+                value={this.state.staticLine2}
+                onChange={(evt) => this.setState({ staticLine2: evt.target.value, customChanges: true })}
+              />
+            </div>
+            <div><input type="submit" value="Apply" onClick={this.saveStaticText} />{this.state.customChanges ? '*' : ''}</div>
+          </div>
+        }
       </div>
-      <div className="viewer--sign-lines">
-        <div className="viewer--sign-line">
-          { displayLine(lineOneDuration, currentTime) ? lineOne : null }
-        </div>
-        <div className="viewer--sign-line">
-          { displayLine(lineTwoDuration, currentTime) ? lineTwo : null }
-        </div>
-      </div>
-    </div>
-  );
+    );
+  }
 }
 
 Sign.propTypes = {
@@ -57,8 +142,12 @@ Sign.propTypes = {
   lineTwoDuration: PropTypes.string,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  setEnabled: PropTypes.func.isRequired,
-  isEnabled: PropTypes.bool.isRequired,
+  setConfigs: PropTypes.func.isRequired,
+  signConfig: PropTypes.oneOfType([
+    PropTypes.exact({ mode: PropTypes.oneOf(["off"]), expires: PropTypes.string }),
+    PropTypes.exact({ mode: PropTypes.oneOf(["auto"]) }),
+    PropTypes.exact({ mode: PropTypes.oneOf(["static_text"]), line1: PropTypes.string.isRequired, line2: PropTypes.string.isRequired, expires: PropTypes.string })
+  ]).isRequired,
   realtimeId: PropTypes.string.isRequired,
 };
 

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -15,20 +15,22 @@ function fontSize(signId) {
 
 function makeConfig(mode) {
   if (mode == 'auto') {
-    return { 'mode': 'auto' };
+    return { mode: 'auto' };
   }
 
   if (mode == 'off') {
-    return { 'mode': 'off', 'expires': null };
+    return { mode: 'off', expires: null };
   }
 
   if (mode == 'static_text') {
-    return { 'mode': 'static_text', 'expires': null, 'line1': '', 'line2': '' };
+    return {
+      mode: 'static_text', expires: null, line1: '', line2: '',
+    };
   }
 }
 
 function isValidText(text) {
-  return !(/[^a-zA-Z0-9,.!@' ]/.test(text))
+  return !(/[^a-zA-Z0-9,.!@' ]/.test(text));
 }
 
 class Sign extends Component {
@@ -43,8 +45,8 @@ class Sign extends Component {
       staticLine1: props.signConfig.line1 || '',
       staticLine2: props.signConfig.line2 || '',
       customChanges: false,
-      tipText: false
-    }
+      tipText: false,
+    };
   }
 
   handleInputLine1(evt) {
@@ -53,7 +55,7 @@ class Sign extends Component {
     if (isValidText(text)) {
       this.setState({ staticLine1: text, customChanges: true });
     } else {
-      this.setState({ tipText: true })
+      this.setState({ tipText: true });
     }
   }
 
@@ -63,7 +65,7 @@ class Sign extends Component {
     if (isValidText(text)) {
       this.setState({ staticLine2: text, customChanges: true });
     } else {
-      this.setState({ tipText: true })
+      this.setState({ tipText: true });
     }
   }
 
@@ -71,16 +73,16 @@ class Sign extends Component {
     const { setConfigs, realtimeId } = this.props;
     const { staticLine1, staticLine2 } = this.state;
 
-    this.setState({ customChanges: false })
+    this.setState({ customChanges: false });
 
     setConfigs({
       [realtimeId]: {
-        'mode': 'static_text',
-        'line1': staticLine1,
-        'line2': staticLine2,
-        'expires': null
-      }
-    })
+        mode: 'static_text',
+        line1: staticLine1,
+        line2: staticLine2,
+        expires: null,
+      },
+    });
   }
 
   render() {
@@ -105,14 +107,24 @@ class Sign extends Component {
               {signId}
             </span>
             <div>
-              <select id={realtimeId} value={signConfig['mode']} onChange={
+              <select
+                id={realtimeId}
+                value={signConfig.mode}
+                onChange={
                 (event) => {
-                  setConfigs({ [realtimeId]: makeConfig(event.target.value) })
+                  setConfigs({ [realtimeId]: makeConfig(event.target.value) });
                 }
-              }>
-                <option value="auto">On</option>
-                <option value="off">Off</option>
-                <option value="static_text">Text</option>
+              }
+              >
+                <option value="auto">
+On
+                </option>
+                <option value="off">
+Off
+                </option>
+                <option value="static_text">
+Text
+                </option>
               </select>
               {/* eslint-disable-next-line jsx-a11y/label-has-for */}
               <label htmlFor={realtimeId} />
@@ -128,13 +140,22 @@ class Sign extends Component {
           </div>
         </div>
 
-        {signConfig['mode'] == 'static_text' &&
+        {signConfig.mode == 'static_text'
+          && (
           <div className="viewer--static-text-form">
-            <div><strong>Set custom message</strong></div>
-            {this.state.tipText && <small>Only allowed letters, numbers, and: ,.!@'</small>}
+            <div>
+              <strong>
+Set custom message
+              </strong>
+            </div>
+            {this.state.tipText && (
+            <small>
+Only allowed letters, numbers, and: ,.!@'
+            </small>
+            )}
             <div>
               <input
-                className='viewer--line-input'
+                className="viewer--line-input"
                 type="text"
                 maxLength={18}
                 size={18}
@@ -144,7 +165,7 @@ class Sign extends Component {
             </div>
             <div>
               <input
-                className='viewer--line-input'
+                className="viewer--line-input"
                 type="text"
                 maxLength={24}
                 size={24}
@@ -154,14 +175,16 @@ class Sign extends Component {
             </div>
             <div>
               <input
-                className='viewer--apply-button'
+                className="viewer--apply-button"
                 disabled={!this.state.customChanges}
                 type="submit"
                 value="Apply"
                 onClick={this.saveStaticText}
               />
-              {this.state.customChanges ? '*' : ''}</div>
+              {this.state.customChanges ? '*' : ''}
+            </div>
           </div>
+          )
         }
       </div>
     );
@@ -178,9 +201,11 @@ Sign.propTypes = {
   line: PropTypes.string.isRequired,
   setConfigs: PropTypes.func.isRequired,
   signConfig: PropTypes.oneOfType([
-    PropTypes.exact({ mode: PropTypes.oneOf(["off"]), expires: PropTypes.string }),
-    PropTypes.exact({ mode: PropTypes.oneOf(["auto"]) }),
-    PropTypes.exact({ mode: PropTypes.oneOf(["static_text"]), line1: PropTypes.string.isRequired, line2: PropTypes.string.isRequired, expires: PropTypes.string })
+    PropTypes.exact({ mode: PropTypes.oneOf(['off']), expires: PropTypes.string }),
+    PropTypes.exact({ mode: PropTypes.oneOf(['auto']) }),
+    PropTypes.exact({
+      mode: PropTypes.oneOf(['static_text']), line1: PropTypes.string.isRequired, line2: PropTypes.string.isRequired, expires: PropTypes.string,
+    }),
   ]).isRequired,
   realtimeId: PropTypes.string.isRequired,
 };

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -161,8 +161,8 @@ class Sign extends Component {
                 </strong>
               </div>
               {tipText && (
-                <small>
-                  Only allowed letters, numbers, and: ,.!@&quot;
+                <small className="viewer--error-text">
+                  You may use letters, numbers, and: ,.!@&quot;
                 </small>
               )}
               <div>

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -78,7 +78,7 @@ class Sign extends Component {
     const { setConfigs, realtimeId } = this.props;
     const { staticLine1, staticLine2 } = this.state;
 
-    this.setState({ customChanges: false });
+    this.setState({ customChanges: false, tipText: false });
 
     setConfigs({
       [realtimeId]: {

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -14,8 +14,8 @@ test('does not show messages that have expired', () => {
   const lineOne = 'Alewife 1 min';
   const lineTwo = 'Alewife 3 min';
   const line = 'Red';
-  const isEnabled = true;
-  const setEnabled = () => {};
+  const signConfig = { mode: 'auto' };
+  const setConfigs = () => { };
   const realtimeId = 'id';
 
   const wrapper = mount(
@@ -27,8 +27,8 @@ test('does not show messages that have expired', () => {
       lineTwoDuration,
       currentTime,
       line,
-      isEnabled,
-      setEnabled,
+      signConfig,
+      setConfigs,
       realtimeId,
     }, null),
   );

--- a/assets/js/Station.jsx
+++ b/assets/js/Station.jsx
@@ -36,7 +36,7 @@ function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfig
 
     const realtimeId = arincToRealtimeId(key, line);
 
-    const signConfig = signConfigs[realtimeId] || { 'mode': 'off' };
+    const signConfig = signConfigs[realtimeId] || { mode: 'off' };
 
     return (
       <Sign

--- a/assets/js/Station.jsx
+++ b/assets/js/Station.jsx
@@ -14,7 +14,7 @@ function zoneDescription(stationConfig, zone) {
   return zones[zone];
 }
 
-function makeSign(config, zone, signs, currentTime, line, enabledSigns, setEnabled) {
+function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfigs) {
   if (config.zones[zone]) {
     const key = `${config.id}-${zone}`;
     const lines = signs[key];
@@ -35,7 +35,8 @@ function makeSign(config, zone, signs, currentTime, line, enabledSigns, setEnabl
     }
 
     const realtimeId = arincToRealtimeId(key, line);
-    const isEnabled = enabledSigns[realtimeId] || false;
+
+    const signConfig = signConfigs[realtimeId] || { 'mode': 'off' };
 
     return (
       <Sign
@@ -47,8 +48,8 @@ function makeSign(config, zone, signs, currentTime, line, enabledSigns, setEnabl
         lineTwo={lineTwo}
         lineTwoDuration={lineTwoDuration}
         currentTime={currentTime}
-        isEnabled={isEnabled}
-        setEnabled={setEnabled}
+        signConfig={signConfig}
+        setConfigs={setConfigs}
         realtimeId={realtimeId}
       />
     );
@@ -58,7 +59,7 @@ function makeSign(config, zone, signs, currentTime, line, enabledSigns, setEnabl
 }
 
 function Station({
-  config, signs, currentTime, line, enabledSigns, setEnabled,
+  config, signs, currentTime, line, signConfigs, setConfigs,
 }) {
   return (
     <div key={config.id}>
@@ -66,23 +67,23 @@ function Station({
         {config.name}
         {' '}
         <small>
-(
+          (
           {config.id}
-)
+          )
         </small>
       </h3>
       <div className="row">
         <div className="col">
-          {makeSign(config, 's', signs, currentTime, line, enabledSigns, setEnabled)}
-          {makeSign(config, 'w', signs, currentTime, line, enabledSigns, setEnabled)}
+          {makeSign(config, 's', signs, currentTime, line, signConfigs, setConfigs)}
+          {makeSign(config, 'w', signs, currentTime, line, signConfigs, setConfigs)}
         </div>
         <div className="col">
-          {makeSign(config, 'c', signs, currentTime, line, enabledSigns, setEnabled)}
-          {makeSign(config, 'm', signs, currentTime, line, enabledSigns, setEnabled)}
+          {makeSign(config, 'c', signs, currentTime, line, signConfigs, setConfigs)}
+          {makeSign(config, 'm', signs, currentTime, line, signConfigs, setConfigs)}
         </div>
         <div className="col">
-          {makeSign(config, 'n', signs, currentTime, line, enabledSigns, setEnabled)}
-          {makeSign(config, 'e', signs, currentTime, line, enabledSigns, setEnabled)}
+          {makeSign(config, 'n', signs, currentTime, line, signConfigs, setConfigs)}
+          {makeSign(config, 'e', signs, currentTime, line, signConfigs, setConfigs)}
         </div>
       </div>
       <hr />
@@ -108,8 +109,8 @@ Station.propTypes = {
   }))).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  enabledSigns: PropTypes.objectOf(PropTypes.bool.isRequired).isRequired,
-  setEnabled: PropTypes.func.isRequired,
+  signConfigs: PropTypes.object.isRequired,
+  setConfigs: PropTypes.func.isRequired,
 };
 
 export default Station;

--- a/assets/js/Station.jsx
+++ b/assets/js/Station.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Sign from './Sign';
 import { arincToRealtimeId } from './mbta';
+import { signConfigType } from './types';
 
 function zoneDescription(stationConfig, zone) {
   if (stationConfig.zones[zone] !== true) {
@@ -109,7 +110,7 @@ Station.propTypes = {
   }))).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  signConfigs: PropTypes.object.isRequired,
+  signConfigs: PropTypes.objectOf(signConfigType).isRequired,
   setConfigs: PropTypes.func.isRequired,
 };
 

--- a/assets/js/Station.test.js
+++ b/assets/js/Station.test.js
@@ -19,12 +19,12 @@ test('shows the custom configuration information for a station', () => {
     ],
   };
   const line = 'Orange';
-  const enabledSigns = {};
-  const setEnabled = () => {};
+  const signConfigs = {};
+  const setConfigs = () => { };
 
   const wrapper = mount(
     React.createElement(Station, {
-      config, signs, currentTime, line, enabledSigns, setEnabled,
+      config, signs, currentTime, line, signConfigs, setConfigs,
     }),
   );
 

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Line from './Line';
+import { signConfigType } from './types';
 
 function Viewer({
   signs, currentTime, line, signConfigs, setConfigs,
@@ -24,7 +25,7 @@ Viewer.propTypes = {
   }))).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  signConfigs: PropTypes.object.isRequired,
+  signConfigs: PropTypes.objectOf(signConfigType).isRequired,
   setConfigs: PropTypes.func.isRequired,
 };
 

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Line from './Line';
 
 function Viewer({
-  signs, currentTime, line, enabledSigns, setEnabled,
+  signs, currentTime, line, signConfigs, setConfigs,
 }) {
   return (
     <div>
@@ -11,8 +11,8 @@ function Viewer({
         signs={signs}
         currentTime={currentTime}
         line={line}
-        enabledSigns={enabledSigns}
-        setEnabled={setEnabled}
+        signConfigs={signConfigs}
+        setConfigs={setConfigs}
       />
     </div>
   );
@@ -24,8 +24,8 @@ Viewer.propTypes = {
   }))).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
-  enabledSigns: PropTypes.objectOf(PropTypes.bool.isRequired).isRequired,
-  setEnabled: PropTypes.func.isRequired,
+  signConfigs: PropTypes.object.isRequired,
+  setConfigs: PropTypes.func.isRequired,
 };
 
 export default Viewer;

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -4,6 +4,7 @@ import { Socket } from 'phoenix';
 import Viewer from './Viewer';
 import { updateSigns } from './helpers';
 import lineToColor from './colors';
+import { signConfigType } from './types';
 
 class ViewerApp extends Component {
   constructor(props) {
@@ -125,7 +126,7 @@ ViewerApp.propTypes = {
   initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
     text: PropTypes.string, duration: PropTypes.string,
   }))).isRequired,
-  initialSignConfigs: PropTypes.object.isRequired,
+  initialSignConfigs: PropTypes.objectOf(signConfigType).isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -9,13 +9,13 @@ class ViewerApp extends Component {
   constructor(props) {
     super(props);
 
-    this.setEnabled = this.setEnabled.bind(this);
+    this.setConfigs = this.setConfigs.bind(this);
     this.changeLine = this.changeLine.bind(this);
     this.updateTime = this.updateTime.bind(this);
 
     this.state = {
       signs: props.initialSigns,
-      enabledSigns: props.initialEnabledSigns,
+      signConfigs: props.initialSignConfigs,
       currentTime: Date.now(),
       channel: null,
     };
@@ -28,7 +28,7 @@ class ViewerApp extends Component {
     const channel = socket.channel('signs:all', {});
     channel
       .join()
-      .receive('ok', () => {});
+      .receive('ok', () => { });
 
     channel.on('sign_update', ({
       sign_id: signId, duration, line_number: lineNumber, text: content,
@@ -40,8 +40,8 @@ class ViewerApp extends Component {
       }));
     });
 
-    channel.on('new_enabled_signs_state', (state) => {
-      this.setState({ enabledSigns: state });
+    channel.on('new_sign_configs_state', (state) => {
+      this.setState({ signConfigs: state });
     });
 
     this.setState({ channel });
@@ -56,15 +56,15 @@ class ViewerApp extends Component {
     clearInterval(this.timerID);
   }
 
-  setEnabled(signStatuses) {
+  setConfigs(signConfigs) {
     const { channel } = this.state;
 
     if (channel) {
-      channel.push('changeSigns', signStatuses);
+      channel.push('changeSigns', signConfigs);
 
       this.setState(oldState => ({
         ...oldState,
-        enabledSigns: { ...oldState.enabledSigns, ...signStatuses },
+        signConfigs: { ...oldState.signConfigs, ...signConfigs },
       }));
     }
   }
@@ -82,7 +82,7 @@ class ViewerApp extends Component {
 
   render() {
     const {
-      signs, currentTime, line, enabledSigns,
+      signs, currentTime, line, signConfigs,
     } = this.state;
     return (
       <div className="viewer--main container">
@@ -108,13 +108,13 @@ class ViewerApp extends Component {
         </div>
         {line
           && (
-          <Viewer
-            signs={signs}
-            enabledSigns={enabledSigns}
-            setEnabled={this.setEnabled}
-            currentTime={currentTime}
-            line={line}
-          />
+            <Viewer
+              signs={signs}
+              signConfigs={signConfigs}
+              setConfigs={this.setConfigs}
+              currentTime={currentTime}
+              line={line}
+            />
           )}
       </div>
     );
@@ -125,7 +125,7 @@ ViewerApp.propTypes = {
   initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
     text: PropTypes.string, duration: PropTypes.string,
   }))).isRequired,
-  initialEnabledSigns: PropTypes.objectOf(PropTypes.bool.isRequired).isRequired,
+  initialSignConfigs: PropTypes.object.isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.test.js
+++ b/assets/js/ViewerApp.test.js
@@ -40,7 +40,7 @@ test('Can enable/disable a sign', () => {
 
   const currentTime = now + 2000;
   const line = 'Red';
-  const initialEnabledSigns = { davis_southbound: true };
+  const initialEnabledSigns = { davis_southbound: { mode: 'auto' } };
 
   const wrapper = mount(
     React.createElement(ViewerApp, {

--- a/assets/js/ViewerApp.test.js
+++ b/assets/js/ViewerApp.test.js
@@ -13,11 +13,11 @@ test('Shows all signs for a line', () => {
 
   const currentTime = now + 2000;
   const line = 'Red';
-  const initialEnabledSigns = {};
+  const initialSignConfigs = {};
 
   const wrapper = mount(
     React.createElement(ViewerApp, {
-      initialSigns: signs, currentTime, line, initialEnabledSigns,
+      initialSigns: signs, currentTime, line, initialSignConfigs,
     }, null),
   );
 
@@ -40,16 +40,16 @@ test('Can enable/disable a sign', () => {
 
   const currentTime = now + 2000;
   const line = 'Red';
-  const initialEnabledSigns = { davis_southbound: { mode: 'auto' } };
+  const initialSignConfigs = { davis_southbound: { mode: 'auto' } };
 
   const wrapper = mount(
     React.createElement(ViewerApp, {
-      initialSigns: signs, currentTime, line, initialEnabledSigns,
+      initialSigns: signs, currentTime, line, initialSignConfigs,
     }, null),
   );
 
   wrapper.find('#red-button').simulate('click');
-  expect(wrapper.find('#davis_southbound').props().checked).toBe(true);
-  wrapper.find('#davis_southbound').simulate('change');
-  expect(wrapper.find('#davis_southbound').props().checked).toBe(false);
+  expect(wrapper.find('#davis_southbound').props().value).toBe('auto');
+  wrapper.find('#davis_southbound').simulate('change', { target: { value: 'off' } });
+  expect(wrapper.find('#davis_southbound').props().value).toBe('off');
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,7 +9,7 @@ import ViewerApp from './ViewerApp';
 
 const realtimeRoot = document.getElementById('viewer-root');
 if (realtimeRoot) {
-  const { initialSignsData: initialSigns, initialEnabledSigns } = window;
-  const viewerApp = React.createElement(ViewerApp, { initialSigns, initialEnabledSigns }, null);
+  const { initialSignsData: initialSigns, initialSignConfigs } = window;
+  const viewerApp = React.createElement(ViewerApp, { initialSigns, initialSignConfigs }, null);
   ReactDOM.render(viewerApp, realtimeRoot);
 }

--- a/assets/js/types.js
+++ b/assets/js/types.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+
+const signConfigType = PropTypes.oneOfType([
+  PropTypes.exact({ mode: PropTypes.oneOf(['off']), expires: PropTypes.string }),
+  PropTypes.exact({ mode: PropTypes.oneOf(['auto']) }),
+  PropTypes.exact({
+    mode: PropTypes.oneOf(['static_text']), line1: PropTypes.string.isRequired, line2: PropTypes.string.isRequired, expires: PropTypes.string,
+  }),
+]);
+
+// eslint-disable-next-line import/prefer-default-export
+export { signConfigType };

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -177,7 +177,7 @@ defmodule SignsUI.Signs.Sign do
     %{
       "id" => sign.id,
       "mode" => "static_text",
-      "enabled" => true,
+      "enabled" => false,
       "line1" => sign.config.line1,
       "line2" => sign.config.line2,
       "expires" => sign.config.expires

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -177,7 +177,7 @@ defmodule SignsUI.Signs.Sign do
     %{
       "id" => sign.id,
       "mode" => "static_text",
-      "enabled" => false,
+      "enabled" => true,
       "line1" => sign.config.line1,
       "line2" => sign.config.line2,
       "expires" => sign.config.expires

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -105,7 +105,7 @@ defmodule SignsUI.Signs.Sign do
     }
   end
 
-  @spec from_config(any(), map()) :: t()
+  @spec from_config(String.t(), map()) :: t()
   def from_config(sign_id, %{"mode" => "auto"}) do
     %__MODULE__{id: sign_id, config: %{mode: :auto}}
   end
@@ -147,7 +147,8 @@ defmodule SignsUI.Signs.Sign do
     }
   end
 
-  def to_json(%{config: %{mode: :auto}} = sign) do
+  @spec to_json(t()) :: map()
+  def to_json(%__MODULE__{config: %{mode: :auto}} = sign) do
     %{
       "id" => sign.id,
       "mode" => "auto",
@@ -155,7 +156,7 @@ defmodule SignsUI.Signs.Sign do
     }
   end
 
-  def to_json(%{config: %{mode: :off}} = sign) do
+  def to_json(%__MODULE__{config: %{mode: :off}} = sign) do
     %{
       "id" => sign.id,
       "mode" => "off",
@@ -164,7 +165,7 @@ defmodule SignsUI.Signs.Sign do
     }
   end
 
-  def to_json(%{config: %{mode: :headway}} = sign) do
+  def to_json(%__MODULE__{config: %{mode: :headway}} = sign) do
     %{
       "id" => sign.id,
       "mode" => "headway",
@@ -173,7 +174,7 @@ defmodule SignsUI.Signs.Sign do
     }
   end
 
-  def to_json(%{config: %{mode: :static_text}} = sign) do
+  def to_json(%__MODULE__{config: %{mode: :static_text}} = sign) do
     %{
       "id" => sign.id,
       "mode" => "static_text",

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -105,6 +105,48 @@ defmodule SignsUI.Signs.Sign do
     }
   end
 
+  @spec from_config(any(), map()) :: t()
+  def from_config(sign_id, %{"mode" => "auto"}) do
+    %__MODULE__{id: sign_id, config: %{mode: :auto}}
+  end
+
+  def from_config(sign_id, %{"mode" => "off", "expires" => expires}) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :off,
+        expires: expires
+      }
+    }
+  end
+
+  def from_config(sign_id, %{"mode" => "headway", "expires" => expires}) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :headway,
+        expires: expires
+      }
+    }
+  end
+
+  def from_config(sign_id, %{
+        "mode" => "static_text",
+        "expires" => expires,
+        "line1" => line1,
+        "line2" => line2
+      }) do
+    %__MODULE__{
+      id: sign_id,
+      config: %{
+        mode: :static_text,
+        expires: expires,
+        line1: line1,
+        line2: line2
+      }
+    }
+  end
+
   def to_json(%{config: %{mode: :auto}} = sign) do
     %{
       "id" => sign.id,

--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -51,6 +51,7 @@ defmodule SignsUI.Signs.State do
     {:reply, {:ok, new_state}, new_state}
   end
 
+  @spec save_changes(t(), t()) :: t()
   defp save_changes(changes, old_state) do
     external_post_mod = Application.get_env(:signs_ui, :signs_external_post_mod)
 

--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -24,7 +24,7 @@ defmodule SignsUI.Signs.State do
     :ok
   end
 
-  @spec update_some(GenServer.server(), %{Signs.Sign.id() => boolean()}) :: :ok
+  @spec update_some(GenServer.server(), %{Signs.Sign.id() => Signs.Sign.t()}) :: {:ok, t()}
   def update_some(pid \\ __MODULE__, changes) do
     GenServer.call(pid, {:update_some, changes})
   end
@@ -54,12 +54,7 @@ defmodule SignsUI.Signs.State do
   defp save_changes(changes, old_state) do
     external_post_mod = Application.get_env(:signs_ui, :signs_external_post_mod)
 
-    new_signs =
-      changes
-      |> Enum.map(fn {id, enabled?} -> {id, Signs.Sign.new(id, enabled?)} end)
-      |> Enum.into(%{})
-
-    signs = Map.merge(old_state, new_signs)
+    signs = Map.merge(old_state, changes)
     {:ok, _} = external_post_mod.update(signs)
     signs
   end

--- a/lib/signs_ui_web/channels/signs_channel.ex
+++ b/lib/signs_ui_web/channels/signs_channel.ex
@@ -1,23 +1,29 @@
 defmodule SignsUiWeb.SignsChannel do
   use Phoenix.Channel
   require Logger
+  alias SignsUI.Signs.Sign
 
   def join("signs:all", _message, socket) do
     {:ok, socket}
   end
 
-  @spec handle_in(String.t(), %{SignsUI.Signs.Sign.id() => boolean()}, any()) :: {:noreply, any()}
+  @spec handle_in(String.t(), %{Sign.id() => map()}, any()) :: {:noreply, Phoenix.Socket.t()}
   def handle_in("changeSigns", changes, socket) do
-    {:ok, new_state} = SignsUI.Signs.State.update_some(changes)
+    new_signs =
+      changes
+      |> Enum.map(fn {id, config} -> {id, Sign.from_config(id, config)} end)
+      |> Enum.into(%{})
+
+    {:ok, new_state} = SignsUI.Signs.State.update_some(new_signs)
 
     Logger.info("Sign toggled: #{inspect(changes)}")
 
     broadcast_data =
       new_state
-      |> Enum.map(fn {_id, sign} -> {sign.id, sign.enabled?} end)
+      |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
       |> Enum.into(%{})
 
-    broadcast!(socket, "new_enabled_signs_state", broadcast_data)
+    broadcast!(socket, "new_sign_configs_state", broadcast_data)
 
     {:noreply, socket}
   end

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -3,6 +3,7 @@ defmodule SignsUiWeb.MessagesController do
 
   alias SignsUi.Signs.Messages
 
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     messages = Messages.list_messages()
 
@@ -16,6 +17,7 @@ defmodule SignsUiWeb.MessagesController do
     render(conn, "index.html", messages: messages, sign_configs: sign_configs)
   end
 
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(conn, params) do
     case Messages.add_message(params) do
       {:ok, _messages} ->

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -6,14 +6,14 @@ defmodule SignsUiWeb.MessagesController do
   def index(conn, _params) do
     messages = Messages.list_messages()
 
-    enabled_signs =
+    sign_configs =
       SignsUI.Signs.State.get_all()
       |> Enum.map(fn {_id, sign} ->
-        {sign.id, SignsUI.Signs.Sign.enabled?(sign)}
+        {sign.id, sign.config}
       end)
       |> Enum.into(%{})
 
-    render(conn, "index.html", messages: messages, enabled_signs: enabled_signs)
+    render(conn, "index.html", messages: messages, sign_configs: sign_configs)
   end
 
   def create(conn, params) do

--- a/lib/signs_ui_web/templates/messages/index.html.eex
+++ b/lib/signs_ui_web/templates/messages/index.html.eex
@@ -1,4 +1,4 @@
 <div id="viewer-root"></div>
 
 <script>window.initialSignsData = <%= raw(Poison.encode!(@messages)) %></script>
-<script>window.initialEnabledSigns = <%= raw(Poison.encode!(@enabled_signs)) %></script>
+<script>window.initialSignConfigs = <%= raw(Poison.encode!(@sign_configs)) %></script>

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -24,7 +24,10 @@ defmodule SignsUI.Signs.StateTest do
              } = get_all(pid)
 
       {:ok, new_state} =
-        update_some(pid, %{"maverick_eastbound" => false, "maverick_westbound" => false})
+        update_some(pid, %{
+          "maverick_eastbound" => Sign.new("maverick_eastbound", false),
+          "maverick_westbound" => Sign.new("maverick_westbound", false)
+        })
 
       assert %{
                "maverick_westbound" => %Signs.Sign{config: %{mode: :off}},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** `signs_ui` subtask of [[8] PIOs can put static text on a sign](https://app.asana.com/0/584764604969369/831665421652437)

This changes the on/off toggle on the viewer to a select box with "On", "Off", and "Text" options. If "Text" is selected, a form appears below the sign allowing the PIO to manually enter custom text:

![screen shot 2019-01-17 at 1 58 42 pm](https://user-images.githubusercontent.com/384428/51341830-42b74380-1a60-11e9-9988-8d45a4e6b356.png)

The changes get persisted to the JSON config file when the "Apply" button is pressed, and realtime_signs will then pick it up.

The branch is deployed to [Signs Dev](https://signs-dev.mbtace.com) if you want to play around with it.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
