### PR TITLE
Alert client when setting is expired

### DIFF
--- a/lib/signs_ui/signs/expiration.ex
+++ b/lib/signs_ui/signs/expiration.ex
@@ -37,14 +37,7 @@ defmodule SignsUI.Signs.Expiration do
 
     if updates != %{} do
       Logger.info("Cleaning expired settings for sign IDs: #{inspect(Map.keys(updates))}")
-      {:ok, new_state} = SignsUI.Signs.State.update_some(state.sign_state_server, updates)
-
-      broadcast_data =
-        new_state
-        |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
-        |> Enum.into(%{})
-
-      SignsUiWeb.Endpoint.broadcast!("signs:all", "new_sign_config_state", broadcast_data)
+      {:ok, _new_state} = SignsUI.Signs.State.update_some(state.sign_state_server, updates)
     end
 
     schedule_loop(self(), state.loop_ms)

--- a/lib/signs_ui/signs/expiration.ex
+++ b/lib/signs_ui/signs/expiration.ex
@@ -37,7 +37,14 @@ defmodule SignsUI.Signs.Expiration do
 
     if updates != %{} do
       Logger.info("Cleaning expired settings for sign IDs: #{inspect(Map.keys(updates))}")
-      SignsUI.Signs.State.update_some(state.sign_state_server, updates)
+      {:ok, new_state} = SignsUI.Signs.State.update_some(state.sign_state_server, updates)
+
+      broadcast_data =
+        new_state
+        |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
+        |> Enum.into(%{})
+
+      SignsUiWeb.Endpoint.broadcast!("signs:all", "new_sign_config_state", broadcast_data)
     end
 
     schedule_loop(self(), state.loop_ms)

--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -57,6 +57,14 @@ defmodule SignsUI.Signs.State do
 
     signs = Map.merge(old_state, changes)
     {:ok, _} = external_post_mod.update(signs)
+
+    broadcast_data =
+      signs
+      |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
+      |> Enum.into(%{})
+
+    SignsUiWeb.Endpoint.broadcast!("signs:all", "new_sign_config_state", broadcast_data)
+
     signs
   end
 end

--- a/lib/signs_ui_web/channels/signs_channel.ex
+++ b/lib/signs_ui_web/channels/signs_channel.ex
@@ -14,16 +14,9 @@ defmodule SignsUiWeb.SignsChannel do
       |> Enum.map(fn {id, config} -> {id, Sign.from_config(id, config)} end)
       |> Enum.into(%{})
 
-    {:ok, new_state} = SignsUI.Signs.State.update_some(new_signs)
+    {:ok, _new_state} = SignsUI.Signs.State.update_some(new_signs)
 
     Logger.info("Sign toggled: #{inspect(changes)}")
-
-    broadcast_data =
-      new_state
-      |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
-      |> Enum.into(%{})
-
-    broadcast!(socket, "new_sign_configs_state", broadcast_data)
 
     {:noreply, socket}
   end

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -6,7 +6,6 @@ defmodule SignsUI.Signs.StateTest do
   alias SignsUI.Signs.Sign
 
   @endpoint SignsUiWeb.Endpoint
-  @endpoint.subscribe("signs:all")
 
   describe "get_all/1" do
     test "Returns all signs" do
@@ -21,6 +20,7 @@ defmodule SignsUI.Signs.StateTest do
     test "updates some values and leaves others alone" do
       {:ok, pid} = GenServer.start_link(SignsUI.Signs.State, [], [])
 
+      @endpoint.subscribe("signs:all")
       token = Phoenix.Token.sign(SignsUiWeb.Endpoint, "user socket", "admin")
       {:ok, socket} = connect(SignsUiWeb.UserSocket, %{"token" => token})
       {:ok, _, _socket} = subscribe_and_join(socket, "signs:all", %{})

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -43,10 +43,16 @@ defmodule SignsUI.Signs.StateTest do
                "forest_hills_southbound" => %Signs.Sign{config: %{mode: :auto}}
              } = new_state
 
-      assert_broadcast("new_sign_config_state", %{
-        "maverick_eastbound" => %{expires: nil, mode: :off},
-        "maverick_westbound" => %{expires: nil, mode: :off}
-      })
+      expected_broadcast =
+        pid
+        |> get_all()
+        |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
+        |> Enum.into(%{})
+
+      assert_broadcast(
+        "new_sign_config_state",
+        expected_broadcast
+      )
 
       assert %{
                "maverick_westbound" => %Signs.Sign{config: %{mode: :off}},

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -49,10 +49,7 @@ defmodule SignsUI.Signs.StateTest do
         |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
         |> Enum.into(%{})
 
-      assert_broadcast(
-        "new_sign_config_state",
-        expected_broadcast
-      )
+      assert_broadcast("new_sign_config_state", ^expected_broadcast)
 
       assert %{
                "maverick_westbound" => %Signs.Sign{config: %{mode: :off}},


### PR DESCRIPTION
#### Summary of changes
**No ticket, hotfix for:** [signs_ui automatically removes expired settings from JSON config](https://app.asana.com/0/0/989470430866018/f)

So that the UI updates when a sign expires

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
