### PR TITLE
new_sign_config_state should be new_sign_configs_state

### DIFF
--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -63,7 +63,7 @@ defmodule SignsUI.Signs.State do
       |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
       |> Enum.into(%{})
 
-    SignsUiWeb.Endpoint.broadcast!("signs:all", "new_sign_config_state", broadcast_data)
+    SignsUiWeb.Endpoint.broadcast!("signs:all", "new_sign_configs_state", broadcast_data)
 
     signs
   end

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -49,7 +49,7 @@ defmodule SignsUI.Signs.StateTest do
         |> Enum.map(fn {_id, sign} -> {sign.id, sign.config} end)
         |> Enum.into(%{})
 
-      assert_broadcast("new_sign_config_state", ^expected_broadcast)
+      assert_broadcast("new_sign_configs_state", ^expected_broadcast)
 
       assert %{
                "maverick_westbound" => %Signs.Sign{config: %{mode: :off}},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [signs_ui automatically removes expired settings from JSON config](https://app.asana.com/0/0/989470430866018/f)

Typo in the name of the thing we were broadcasting is causing the client to not pick up on configuration changes.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
