### PR TITLE
Select item should be 'Auto' not 'On'

### DIFF
--- a/assets/js/SetExpiration.jsx
+++ b/assets/js/SetExpiration.jsx
@@ -42,7 +42,7 @@ function SetExpiration({
   return (
     <div>
       <strong>
-        Schedule return to &quot;On&quot;
+        Schedule return to &quot;Auto&quot;
       </strong>
 
       <DatePicker

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -132,7 +132,7 @@ class Sign extends Component {
                 }
               >
                 <option value="auto">
-                  On
+                  Auto
                 </option>
                 <option value="off">
                   Off


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** none

Oops, ticket said that this option should have been called "Auto" rather than "On". The select value (and underlying JSON) already was "auto", so this is just a presentational change.

<img width="142" alt="screen shot 2019-01-30 at 8 22 40 am" src="https://user-images.githubusercontent.com/384428/51987707-b564ed80-2468-11e9-8911-2cc2702b86a4.png">
<img width="338" alt="screen shot 2019-01-30 at 8 26 00 am" src="https://user-images.githubusercontent.com/384428/51987721-b9910b00-2468-11e9-86ef-8d03d8529556.png">


#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
