### PR TITLE
Change static text select item to 'Custom'

### DIFF
--- a/assets/css/viewer.css
+++ b/assets/css/viewer.css
@@ -68,3 +68,7 @@
   padding: 0.25em 0.5em 0.5em 0.5em;
   width: 20em;
 }
+
+.viewer--mode-select {
+  width: 70px;
+}

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -124,6 +124,7 @@ class Sign extends Component {
             <div>
               <select
                 id={realtimeId}
+                className="viewer--mode-select"
                 value={signConfig.mode}
                 onChange={
                   (event) => {
@@ -138,7 +139,7 @@ class Sign extends Component {
                   Off
                 </option>
                 <option value="static_text">
-                  Text
+                  Custom
                 </option>
               </select>
             </div>

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -135,11 +135,11 @@ class Sign extends Component {
                 <option value="auto">
                   Auto
                 </option>
-                <option value="off">
-                  Off
-                </option>
                 <option value="static_text">
                   Custom
+                </option>
+                <option value="off">
+                  Off
                 </option>
               </select>
             </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** none

Tweak to the sign: the custom static text select item should be named "Custom" and not "Text".

<img width="333" alt="screen shot 2019-01-31 at 12 35 57 pm" src="https://user-images.githubusercontent.com/384428/52076747-f9cdb780-2554-11e9-88e5-0bc7ac0f7eb6.png">

When the select box reveals its options, you can see the full text, though:

<img width="266" alt="screen shot 2019-01-31 at 12 36 04 pm" src="https://user-images.githubusercontent.com/384428/52076783-0ce08780-2555-11e9-9318-d0be29fb7b56.png">


#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
