### PR TITLE
Fix the "World Train Center" typo

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -521,7 +521,7 @@ const stationConfig = {
     },
     {
       id: 'SWTC',
-      name: 'World Train Center',
+      name: 'World Trade Center',
       zones: {
         n: false, s: false, e: true, w: false, c: false, m: true,
       },


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [fix typo on Signs UI](https://app.asana.com/0/584764604969369/1116597727824336/f)

An especially ironic typo given that it's actually a bus.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
