### PR TITLE
Remove Capen SB sign

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -465,7 +465,7 @@ const stationConfig = {
       id: 'MCAP',
       name: 'Capen St',
       zones: {
-        n: true, s: true, e: false, w: false, c: false, m: false,
+        n: true, s: false, e: false, w: false, c: false, m: false,
       },
     },
   ],


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Bug fix: Capen Street only has a sign on the NB side](https://app.asana.com/0/584764604969369/1113190554115752/f)

Accompanying change to the [realtime_signs PR](https://github.com/mbta/realtime_signs/pull/269). Whoever deploys should make sure that the sign is turned to "auto" in prod before it gets removed.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
