### PR TITLE
Add basic routes for Cognito work

### DIFF
--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -30,5 +30,6 @@ defmodule SignsUi.Application do
     Config.update_env(:username, System.get_env("USERNAME"))
     Config.update_env(:password, System.get_env("PASSWORD"))
     Config.update_env(:realtime_signs_api_key, System.get_env("REALTIME_SIGNS_API_KEY"))
+    Config.update_env(:cognito_client_id, System.get_env("COGNITO_CLIENT_ID"))
   end
 end

--- a/lib/signs_ui_web/controllers/cognito_controller.ex
+++ b/lib/signs_ui_web/controllers/cognito_controller.ex
@@ -1,0 +1,25 @@
+defmodule SignsUiWeb.CognitoController do
+  use SignsUiWeb, :controller
+  require Logger
+
+  def index(conn, %{"code" => code}) do
+    Logger.info("cognito code=#{code}")
+
+    redirect(conn, to: "/")
+  end
+
+  def index(conn, _) do
+    Logger.info("cognito no_code")
+    send_resp(conn, 400, "no cognito code")
+  end
+
+  def new(conn, _) do
+    redirect(
+      conn,
+      external:
+        "https://mbta-signs-dev.auth.us-east-1.amazoncognito.com/login?response_type=code&client_id=#{
+          Application.get_env(:signs_ui, :cognito_client_id)
+        }&redirect_uri=http://localhost:4000/cognito"
+    )
+  end
+end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -33,6 +33,10 @@ defmodule SignsUiWeb.Router do
   end
 
   scope "/", SignsUiWeb do
+    resources("/cognito", CognitoController, only: [:index, :new])
+  end
+
+  scope "/", SignsUiWeb do
     get("/_health", HealthController, :index)
   end
 


### PR DESCRIPTION
Adds a /cognito/new route to redirect to the AWS Cognito sign in page, and a /cognito route for it to redirect back to.

Not final work, just a baseline that we can each build off, to hopefully minimize conflicts.