### PR TITLE
Fake Ueberauth strategy to use locally and in test env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,15 +31,8 @@ config :logger, :console,
 
 config :ueberauth, Ueberauth,
   providers: [
-    cognito: {Ueberauth.Strategy.Cognito, []}
+    cognito: {SignsUi.Ueberauth.Strategy.Fake, []}
   ]
-
-config :ueberauth, Ueberauth.Strategy.Cognito,
-  auth_domain: {System, :get_env, ["COGNITO_DOMAIN"]},
-  client_id: {System, :get_env, ["COGNITO_CLIENT_ID"]},
-  client_secret: {System, :get_env, ["COGNITO_CLIENT_SECRET"]},
-  user_pool_id: {System, :get_env, ["COGNITO_USER_POOL_ID"]},
-  aws_region: {System, :get_env, ["COGNITO_AWS_REGION"]}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -26,6 +26,18 @@ config :signs_ui, :redirect_http?, true
 # Do not print debug messages in production
 config :logger, level: :info
 
+config :ueberauth, Ueberauth,
+  providers: [
+    cognito: {Ueberauth.Strategy.Cognito, []}
+  ]
+
+config :ueberauth, Ueberauth.Strategy.Cognito,
+  auth_domain: {System, :get_env, ["COGNITO_DOMAIN"]},
+  client_id: {System, :get_env, ["COGNITO_CLIENT_ID"]},
+  client_secret: {System, :get_env, ["COGNITO_CLIENT_SECRET"]},
+  user_pool_id: {System, :get_env, ["COGNITO_USER_POOL_ID"]},
+  aws_region: {System, :get_env, ["COGNITO_AWS_REGION"]}
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/lib/signs_ui/ueberauth/strategy/fake.ex
+++ b/lib/signs_ui/ueberauth/strategy/fake.ex
@@ -3,12 +3,16 @@ defmodule SignsUi.Ueberauth.Strategy.Fake do
 
   def handle_request!(conn) do
     conn
-    |> redirect!(callback_path(conn))
+    |> redirect!("/auth/cognito/callback")
     |> halt()
   end
 
   def handle_callback!(conn) do
     conn
+  end
+
+  def uid(_conn) do
+    "fake_uid"
   end
 
   def credentials(_conn) do
@@ -18,10 +22,6 @@ defmodule SignsUi.Ueberauth.Strategy.Fake do
       expires: true,
       expires_at: System.system_time(:seconds) + 60 * 60
     }
-  end
-
-  def uid(_conn) do
-    "fake_uid"
   end
 
   def info(_conn) do

--- a/lib/signs_ui/ueberauth/strategy/fake.ex
+++ b/lib/signs_ui/ueberauth/strategy/fake.ex
@@ -1,0 +1,38 @@
+defmodule SignsUi.Ueberauth.Strategy.Fake do
+  use Ueberauth.Strategy
+
+  def handle_request!(conn) do
+    conn
+    |> redirect!(callback_path(conn))
+    |> halt()
+  end
+
+  def handle_callback!(conn) do
+    conn
+  end
+
+  def credentials(_conn) do
+    %Ueberauth.Auth.Credentials{
+      token: "fake_access_token",
+      refresh_token: "fake_refresh_token",
+      expires: true,
+      expires_at: System.system_time(:seconds) + 60 * 60
+    }
+  end
+
+  def uid(_conn) do
+    "fake_uid"
+  end
+
+  def info(_conn) do
+    %Ueberauth.Auth.Info{}
+  end
+
+  def extra(_conn) do
+    %Ueberauth.Auth.Extra{raw_info: %{}}
+  end
+
+  def handle_cleanup!(conn) do
+    conn
+  end
+end

--- a/test/signs_ui/ueberauth/strategy/fake_test.exs
+++ b/test/signs_ui/ueberauth/strategy/fake_test.exs
@@ -1,0 +1,46 @@
+defmodule SignsUi.Ueberauth.Strategy.FakeTest do
+  use ExUnit.Case
+  use Plug.Test
+  import SignsUi.Ueberauth.Strategy.Fake
+
+  describe "implements all the callbacks" do
+    test "handle_request!/1" do
+      conn =
+        conn(:get, "/auth/cognito")
+        |> init_test_session(%{})
+        |> handle_request!()
+
+      assert conn.status == 302
+    end
+
+    test "handle_callback!/1" do
+      conn = conn(:get, "/auth/cognito/callback")
+
+      assert ^conn = handle_callback!(conn)
+    end
+
+    test "uid/1" do
+      conn = conn(:get, "/auth/cognito/callback")
+
+      assert uid(conn) == "fake_uid"
+    end
+
+    test "credentials/1" do
+      conn = conn(:get, "/auth/cognito/callback")
+
+      assert %Ueberauth.Auth.Credentials{} = credentials(conn)
+    end
+
+    test "info/1" do
+      conn = conn(:get, "/auth/cognito/callback")
+
+      assert %Ueberauth.Auth.Info{} = info(conn)
+    end
+
+    test "extra/1" do
+      conn = conn(:get, "/auth/cognito/callback")
+
+      assert %Ueberauth.Auth.Extra{} = extra(conn)
+    end
+  end
+end

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -35,12 +35,12 @@ defmodule SignsUiWeb.AuthControllerTest do
   end
 
   describe "request" do
-    test "redirects to Cognito", %{conn: conn} do
+    test "redirects to auth callback", %{conn: conn} do
       conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :request, "cognito"))
 
       response = response(conn, 302)
 
-      assert response =~ "/oauth2/authorize"
+      assert response =~ SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito")
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

A fake strategy that implements the Ueberauth callbacks, to use locally. It means we don't need to start up with a million environment variables, or redirect out to AWS.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
