### PR TITLE
Factor out message state and processing into domain modules

### DIFF
--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -37,7 +37,7 @@ function makeConfig(mode) {
 }
 
 function isValidText(text) {
-  return !(/[^a-zA-Z0-9,.!@' ]/.test(text));
+  return !(/[^a-zA-Z0-9,.!@' +]/.test(text));
 }
 
 function timeString(currentTime) {

--- a/lib/signs_ui/messages/sign_content.ex
+++ b/lib/signs_ui/messages/sign_content.ex
@@ -39,6 +39,16 @@ defmodule SignsUi.Messages.SignContent do
     |> integer(1)
     |> times(page_text, min: 1)
 
+  # Generate a parser, for ARINC-formatted commands. See the docs in
+  # realtime_signs for what the components mean. Examples are:
+  #
+  # e145~w1-"Riverside      BRD"
+  # with expiration of 145 seconds from now, west zone, line 1
+  #
+  # or
+  #
+  # e145~s2-"Frst Hills    away".2-"Frst Hills Stopped".5-"Frst Hills 8 stops".2
+  # which is a paginated message, with page durations of 2, 5, and 2 seconds.
   defparsec(:parse_command, command)
 
   @spec new(String.t(), String.t(), DateTime.t()) :: {:ok, t()} | {:error, any()}

--- a/lib/signs_ui/messages/sign_content.ex
+++ b/lib/signs_ui/messages/sign_content.ex
@@ -1,0 +1,74 @@
+defmodule SignsUi.Messages.SignContent do
+  @moduledoc """
+  Represents an incoming MsgType=SignContent from realtime_signs. Parses
+  the request into a struct, so that it can be consumed downstream to
+  update a %Signs.Sign{}.
+  """
+
+  import NimbleParsec
+
+  @enforce_keys [:station, :zone, :line_number, :expiration, :pages]
+  defstruct @enforce_keys
+
+  @type page :: String.t() | {String.t() | non_neg_integer()}
+
+  @type t :: %__MODULE__{
+          station: String.t(),
+          zone: String.t(),
+          line_number: 1 | 2,
+          expiration: DateTime.t(),
+          pages: [page()]
+        }
+
+  page_text =
+    ignore(string("-"))
+    |> ignore(string("\""))
+    |> optional(ascii_string([?a..?z, ?A..?Z, ?0..?9, ?', ?\s, ?,, ?., ?!, ?@, ?+], min: 1))
+    |> ignore(string("\""))
+    |> optional(
+      ignore(string("."))
+      |> integer(min: 1)
+    )
+    |> tag(:page_text)
+
+  command =
+    ignore(string("e"))
+    |> integer(min: 1)
+    |> ignore(string("~"))
+    |> ascii_string([?n, ?s, ?e, ?w, ?m, ?c], 1)
+    |> integer(1)
+    |> times(page_text, min: 1)
+
+  defparsec(:parse_command, command)
+
+  @spec new(String.t(), String.t(), DateTime.t()) :: {:ok, t()} | {:error, any()}
+  def new(station, command, now \\ Timex.now()) when is_binary(station) do
+    case parse_command(command) do
+      {:ok, [exp_sec, zone, line_number | pages], _rest, _ctx, _line, _col} ->
+        {:ok,
+         %__MODULE__{
+           station: station,
+           zone: zone,
+           line_number: line_number,
+           expiration: Timex.shift(now, seconds: exp_sec),
+           pages: get_pages(pages)
+         }}
+
+      _ ->
+        {:error, :could_not_parse}
+    end
+  end
+
+  @spec get_pages([{:page_text, [any()]}]) :: [page()]
+  defp get_pages(pages) do
+    Enum.map(pages, fn
+      {:page_text, [text, duration]} -> {text, duration}
+      {:page_text, [text]} -> text
+      {:page_text, []} -> ""
+    end)
+  end
+
+  @spec page_to_text(page()) :: String.t()
+  def page_to_text({text, _duration}), do: text
+  def page_to_text(text), do: text
+end

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -1,0 +1,50 @@
+defmodule SignsUi.Signs.Sign do
+  @moduledoc """
+  Represents a sign (ARINC zone) on the countdown viewer.
+  """
+
+  @enforce_keys [:station, :zone]
+  defstruct [:station, :zone, lines: %{}]
+
+  alias SignsUi.Signs.SignLine
+  alias SignsUi.Messages.SignContent
+
+  @type t :: %__MODULE__{
+          station: String.t(),
+          zone: String.t(),
+          lines: %{integer() => SignLine.t()}
+        }
+
+  @spec new_from_message(SignContent.t()) :: t()
+  def new_from_message(%SignContent{} = msg) do
+    %__MODULE__{
+      station: msg.station,
+      zone: msg.zone,
+      lines: %{
+        msg.line_number => SignLine.new_from_message(msg)
+      }
+    }
+  end
+
+  @spec update_from_message(t(), SignContent.t()) :: t()
+  def update_from_message(sign, %SignContent{} = msg) do
+    put_in(
+      sign,
+      [Access.key(:lines), msg.line_number],
+      SignLine.new_from_message(msg)
+    )
+  end
+
+  @spec to_json(t()) :: [map()]
+  def to_json(sign) do
+    Enum.map([1, 2], fn line_number ->
+      case sign.lines[line_number] do
+        nil ->
+          %{text: "", duration: Timex.now()}
+
+        %SignLine{} = line ->
+          SignLine.to_json(line)
+      end
+    end)
+  end
+end

--- a/lib/signs_ui/signs/sign_line.ex
+++ b/lib/signs_ui/signs/sign_line.ex
@@ -1,0 +1,44 @@
+defmodule SignsUi.Signs.SignLine do
+  @moduledoc """
+  Represents a line on a %Sign{}. Internal to Sign, and should only
+  be interacted with through that module.
+  """
+
+  @enforce_keys [:expiration, :text]
+  defstruct @enforce_keys
+
+  @type page :: {String.t(), non_neg_integer()}
+
+  @type t :: %__MODULE__{
+          expiration: DateTime.t(),
+          text: String.t() | [page]
+        }
+
+  def new_from_message(%SignsUi.Messages.SignContent{} = msg) do
+    %__MODULE__{
+      expiration: msg.expiration,
+      text: message_text(msg.pages)
+    }
+  end
+
+  def to_json(%__MODULE__{text: text} = line) when is_binary(text) do
+    %{text: text, duration: line.expiration}
+  end
+
+  def to_json(%__MODULE__{text: pages} = line) do
+    %{
+      text: pages |> choose_page() |> page_text(),
+      duration: line.expiration
+    }
+  end
+
+  defp message_text([{text, _}]), do: text
+  defp message_text([text]), do: text
+  defp message_text(pages), do: pages
+
+  defp choose_page([_away, _stopped, n]), do: n
+  defp choose_page(pages), do: List.first(pages)
+
+  def page_text({text, _exp}), do: text
+  def page_text(text) when is_binary(text), do: text
+end

--- a/lib/signs_ui_web/templates/messages/index.html.eex
+++ b/lib/signs_ui_web/templates/messages/index.html.eex
@@ -1,4 +1,4 @@
 <div id="viewer-root"></div>
 
-<script>window.initialSignsData = <%= raw(Poison.encode!(@messages)) %></script>
+<script>window.initialSignsData = <%= raw(Poison.encode!(@signs)) %></script>
 <script>window.initialSignConfigs = <%= raw(Poison.encode!(@sign_configs)) %></script>

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,8 @@ defmodule SignsUi.Mixfile do
       {:timex, "~> 3.1"},
       {:guardian, "~> 1.0"},
       {:ueberauth, "~> 0.1"},
-      {:ueberauth_cognito, git: "https://github.com/mbta/ueberauth_cognito.git"}
+      {:ueberauth_cognito, git: "https://github.com/mbta/ueberauth_cognito.git"},
+      {:nimble_parsec, "~> 0.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -21,6 +21,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.2", "2a00d751f51670ea6bc3f2ba4e6eb27ecb8a2c71e7978d9cd3e5de5ccf7378bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_html": {:hex, :phoenix_html, "2.11.2", "86ebd768258ba60a27f5578bec83095bdb93485d646fc4111db8844c316602d6", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/signs_ui/messages/sign_content_test.exs
+++ b/test/signs_ui/messages/sign_content_test.exs
@@ -1,0 +1,88 @@
+defmodule SignsUi.Messages.SignContentTest do
+  use ExUnit.Case, async: true
+  alias SignsUi.Messages.SignContent
+
+  describe "new/3" do
+    test "parses a full message with all its parts" do
+      now = Timex.now()
+      command = ~s(e145~w1-"Riverside    4 min")
+
+      assert SignContent.new("OSTA", command, now) ==
+               {:ok,
+                %SignContent{
+                  expiration: Timex.shift(now, seconds: 145),
+                  line_number: 1,
+                  pages: ["Riverside    4 min"],
+                  station: "OSTA",
+                  zone: "w"
+                }}
+    end
+
+    test "parses the zone" do
+      assert {:ok, %SignContent{zone: "w"}} = SignContent.new("XYZ", ~s(e1~w1-"xyz"))
+      assert {:ok, %SignContent{zone: "e"}} = SignContent.new("XYZ", ~s(e1~e1-"xyz"))
+      assert {:ok, %SignContent{zone: "n"}} = SignContent.new("XYZ", ~s(e1~n1-"xyz"))
+      assert {:ok, %SignContent{zone: "s"}} = SignContent.new("XYZ", ~s(e1~s1-"xyz"))
+      assert {:ok, %SignContent{zone: "c"}} = SignContent.new("XYZ", ~s(e1~c1-"xyz"))
+      assert {:ok, %SignContent{zone: "m"}} = SignContent.new("XYZ", ~s(e1~m1-"xyz"))
+      assert {:error, :could_not_parse} = SignContent.new("XYZ", ~s(e1~z1-"xyz"))
+    end
+
+    test "parses the line number" do
+      assert {:ok, %SignContent{line_number: 1}} = SignContent.new("XYZ", ~s(e1~e1-"xyz"))
+      assert {:ok, %SignContent{line_number: 2}} = SignContent.new("XYZ", ~s(e1~e2-"xyz"))
+      assert {:error, :could_not_parse} = SignContent.new("XYZ", ~s(e1~ex-"xyz"))
+    end
+
+    test "parses the expiration" do
+      now = Timex.now()
+      in_1_sec = Timex.shift(now, seconds: 1)
+      in_15_sec = Timex.shift(now, seconds: 15)
+      in_157_sec = Timex.shift(now, seconds: 157)
+
+      assert {:ok, %SignContent{expiration: ^in_1_sec}} =
+               SignContent.new("XYZ", ~s(e1~e1-"xyz"), now)
+
+      assert {:ok, %SignContent{expiration: ^in_15_sec}} =
+               SignContent.new("XYZ", ~s(e15~e1-"xyz"), now)
+
+      assert {:ok, %SignContent{expiration: ^in_157_sec}} =
+               SignContent.new("XYZ", ~s(e157~e1-"xyz"), now)
+
+      assert {:error, :could_not_parse} = SignContent.new("XYZ", ~s(ea~e1-"xyz"), now)
+    end
+
+    test "parses out pages" do
+      assert {:ok, %SignContent{pages: ["pg1", "pg2"]}} =
+               SignContent.new("XYZ", ~s(e1~w1-"pg1"-"pg2"))
+    end
+
+    test "parses pages with optional duration" do
+      assert {:ok, %SignContent{pages: [{"pg1", 3}, {"pg2", 5}]}} =
+               SignContent.new("XYZ", ~s(e1~w1-"pg1".3-"pg2".5))
+    end
+
+    test "parses text with a + in it" do
+      assert {:ok, %SignContent{pages: ["30+ min"]}} = SignContent.new("XYZ", ~s(e1~w1-"30+ min"))
+    end
+
+    test "parses empty text requests" do
+      assert {:ok, %SignContent{pages: [""]}} = SignContent.new("XYZ", ~s(e1~w1-""))
+    end
+
+    test "parses text with a ' in it" do
+      assert {:ok, %SignContent{pages: ["what's up"]}} =
+               SignContent.new("XYZ", ~s(e1~w1-"what's up"))
+    end
+  end
+
+  describe "page_to_text/1" do
+    test "works with a string page" do
+      assert SignContent.page_to_text("text") == "text"
+    end
+
+    test "works when the page has a duration" do
+      assert SignContent.page_to_text({"text", 5}) == "text"
+    end
+  end
+end

--- a/test/signs_ui/signs/sign_line_test.exs
+++ b/test/signs_ui/signs/sign_line_test.exs
@@ -1,0 +1,69 @@
+defmodule SignsUi.Signs.SignLineTest do
+  use ExUnit.Case, async: true
+
+  alias SignsUi.Signs.SignLine
+  alias SignsUi.Messages.SignContent
+
+  @now Timex.now()
+
+  @message %SignContent{
+    station: "STA",
+    zone: "w",
+    line_number: 1,
+    expiration: @now,
+    pages: ["pg1", "pg2"]
+  }
+
+  @sign_line %SignLine{
+    expiration: @now,
+    text: "text"
+  }
+
+  describe "new_from_message" do
+    test "turns a single page into just a string" do
+      message = %{@message | pages: ["page 1"]}
+      assert %SignLine{expiration: @now, text: "page 1"} = SignLine.new_from_message(message)
+    end
+
+    test "turns a single page, with duration, into just a string" do
+      message = %{@message | pages: [{"page 1", 5}]}
+      assert %SignLine{expiration: @now, text: "page 1"} = SignLine.new_from_message(message)
+    end
+
+    test "when multiple pages, keeps them all" do
+      message = %{@message | pages: [{"page 1", 5}, {"page 2", 5}]}
+
+      assert %SignLine{expiration: @now, text: [{"page 1", 5}, {"page 2", 5}]} =
+               SignLine.new_from_message(message)
+    end
+  end
+
+  describe "to_json/1" do
+    test "When pages are 'away ... stopped ... n stops' (re-ordered because ARINC), returns n stops" do
+      sign_line = %{@sign_line | text: [{"away", 2}, {"stopped", 5}, {"2 stops", 2}]}
+
+      assert %{
+               duration: @now,
+               text: "2 stops"
+             } = SignLine.to_json(sign_line)
+    end
+
+    test "When not 3 pages, takes the first page" do
+      sign_line = %{@sign_line | text: [{"Trk 2", 5}, {"Ashmont BRD", 2}]}
+
+      assert %{
+               duration: @now,
+               text: "Trk 2"
+             } = SignLine.to_json(sign_line)
+    end
+  end
+
+  test "Serializes page when the duration is not included" do
+    sign_line = %{@sign_line | text: ["Ashmont 1 min"]}
+
+    assert %{
+             duration: @now,
+             text: "Ashmont 1 min"
+           } = SignLine.to_json(sign_line)
+  end
+end

--- a/test/signs_ui/signs/sign_test.exs
+++ b/test/signs_ui/signs/sign_test.exs
@@ -1,0 +1,73 @@
+defmodule SignsUi.Signs.SignTest do
+  use ExUnit.Case, async: true
+
+  alias SignsUi.Signs.Sign
+  alias SignsUi.Signs.SignLine
+  alias SignsUi.Messages.SignContent
+
+  @now Timex.now()
+
+  @sign %Sign{
+    station: "XYZ",
+    zone: "w",
+    lines: %{
+      1 => %SignLine{
+        expiration: @now,
+        text: "a page"
+      }
+    }
+  }
+
+  @message %SignContent{
+    station: "XYZ",
+    zone: "w",
+    line_number: 1,
+    expiration: @now,
+    pages: ["a page"]
+  }
+
+  describe "new_from_message/1" do
+    test "creates a new sign from a SignContent message" do
+      assert %Sign{
+               station: "XYZ",
+               zone: "w",
+               lines: %{
+                 1 => %SignLine{
+                   expiration: @now,
+                   text: "a page"
+                 }
+               }
+             } = Sign.new_from_message(@message)
+    end
+  end
+
+  describe "update_from_message" do
+    test "adds a new line to a sign without one" do
+      message2 = %{@message | line_number: 2, pages: ["2nd page"]}
+
+      assert %Sign{
+               station: "XYZ",
+               zone: "w",
+               lines: %{
+                 1 => %SignLine{
+                   expiration: @now,
+                   text: "a page"
+                 },
+                 2 => %SignLine{
+                   expiration: @now,
+                   text: "2nd page"
+                 }
+               }
+             } = Sign.update_from_message(@sign, message2)
+    end
+  end
+
+  describe "to_json" do
+    test "serializes to the map that the frontend expects" do
+      assert [
+               %{duration: %DateTime{}, text: "a page"},
+               %{duration: %DateTime{}, text: ""}
+             ] = Sign.to_json(@sign)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Precursor to [[3] PIO can see paging on Signs UI]](https://app.asana.com/0/584764604969369/747281786398695)

When working on that ticket, I got tripped up by the "stringly typed" nature of how we were storing this stuff, and how it was being parsed through a combination of manual string manipulation and regexes.

So this cleans that up a bit:

* Parses the ARINC messages with a real parser (using a parser combinator library by Jose Valim called [NimbleParsec](https://hexdocs.pm/nimble_parsec/NimbleParsec.html)).
* Stores the messages in a struct, and stores the sign contents in structs of their own.

This should lay the groundwork to allow

* Richer representations of signs in our app (in particular, pagination right now, audio in the future)
* Processing other kinds of ARINC messages (AdHoc and Canned)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
