### PR TITLE
Use groups in authentication

### DIFF
--- a/lib/signs_ui/ueberauth/strategy/fake.ex
+++ b/lib/signs_ui/ueberauth/strategy/fake.ex
@@ -24,7 +24,8 @@ defmodule SignsUi.Ueberauth.Strategy.Fake do
       token: "fake_access_token",
       refresh_token: "fake_refresh_token",
       expires: true,
-      expires_at: System.system_time(:seconds) + 60 * 60
+      expires_at: System.system_time(:seconds) + 60 * 60,
+      other: %{groups: ["signs-ui-admin"]}
     }
   end
 

--- a/lib/signs_ui_web/auth_manager.ex
+++ b/lib/signs_ui_web/auth_manager.ex
@@ -3,6 +3,8 @@ defmodule SignsUiWeb.AuthManager do
 
   @type t :: String.t()
 
+  @signs_ui_group "signs-ui-admin"
+
   def subject_for_token(resource, _claims) do
     {:ok, resource}
   end
@@ -12,4 +14,13 @@ defmodule SignsUiWeb.AuthManager do
   end
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
+
+  @spec claims_grant_signs_access?(Guardian.Token.claims()) :: boolean()
+  def claims_grant_signs_access?(%{"groups" => groups}) do
+    not is_nil(groups) and @signs_ui_group in groups
+  end
+
+  def claims_grant_signs_access?(_claims) do
+    false
+  end
 end

--- a/lib/signs_ui_web/channels/signs_channel.ex
+++ b/lib/signs_ui_web/channels/signs_channel.ex
@@ -40,9 +40,11 @@ defmodule SignsUiWeb.SignsChannel do
     claims = Guardian.Phoenix.Socket.current_claims(socket)
     token = Guardian.Phoenix.Socket.current_token(socket)
 
-    case SignsUiWeb.AuthManager.decode_and_verify(token, claims) do
-      {:ok, _claims} -> true
-      {:error, _error} -> false
+    with {:ok, claims} <- SignsUiWeb.AuthManager.decode_and_verify(token, claims),
+         true <- SignsUiWeb.AuthManager.claims_grant_signs_access?(claims) do
+      true
+    else
+      _ -> false
     end
   end
 

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -6,6 +6,7 @@ defmodule SignsUiWeb.AuthController do
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     username = auth.uid
     expiration = auth.credentials.expires_at
+    credentials = conn.assigns.ueberauth_auth.credentials
 
     current_time = System.system_time(:second)
 
@@ -13,7 +14,7 @@ defmodule SignsUiWeb.AuthController do
     |> Guardian.Plug.sign_in(
       SignsUiWeb.AuthManager,
       username,
-      %{},
+      %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )
     |> redirect(to: SignsUiWeb.Router.Helpers.messages_path(conn, :index))

--- a/lib/signs_ui_web/controllers/unauthorized_controller.ex
+++ b/lib/signs_ui_web/controllers/unauthorized_controller.ex
@@ -1,0 +1,10 @@
+defmodule SignsUiWeb.UnauthorizedController do
+  use SignsUiWeb, :controller
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    conn
+    |> put_status(403)
+    |> render("index.html")
+  end
+end

--- a/lib/signs_ui_web/ensure_signs_ui_group.ex
+++ b/lib/signs_ui_web/ensure_signs_ui_group.ex
@@ -6,7 +6,7 @@ defmodule SignsUiWeb.EnsureSignsUiGroup do
   def call(conn, _opts) do
     claims = Guardian.Plug.current_claims(conn)
 
-    if not is_nil(claims["groups"]) and @signs_ui_group in claims["groups"] do
+    if SignsUiWeb.AuthManager.claims_grant_signs_access?(claims) do
       conn
     else
       conn

--- a/lib/signs_ui_web/ensure_signs_ui_group.ex
+++ b/lib/signs_ui_web/ensure_signs_ui_group.ex
@@ -1,0 +1,19 @@
+defmodule SignsUiWeb.EnsureSignsUiGroup do
+  import Plug.Conn
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    claims = Guardian.Plug.current_claims(conn)
+
+    if not is_nil(claims["groups"]) and @signs_ui_group in claims["groups"] do
+      conn
+    else
+      conn
+      |> Phoenix.Controller.redirect(
+        to: SignsUiWeb.Router.Helpers.unauthorized_path(conn, :index)
+      )
+      |> halt()
+    end
+  end
+end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -28,6 +28,10 @@ defmodule SignsUiWeb.Router do
     plug(Guardian.Plug.EnsureAuthenticated)
   end
 
+  pipeline :ensure_signs_ui_group do
+    plug(SignsUiWeb.EnsureSignsUiGroup)
+  end
+
   scope "/auth", SignsUiWeb do
     pipe_through([:redirect_prod_http, :browser])
 
@@ -39,10 +43,18 @@ defmodule SignsUiWeb.Router do
     pipe_through([:redirect_prod_http, :browser, :auth])
 
     get("/", PageController, :index)
+    get("/unauthorized", UnauthorizedController, :index)
   end
 
   scope "/", SignsUiWeb do
-    pipe_through([:redirect_prod_http, :browser, :auth, :ensure_auth, :put_user_token])
+    pipe_through([
+      :redirect_prod_http,
+      :browser,
+      :auth,
+      :ensure_auth,
+      :ensure_signs_ui_group,
+      :put_user_token
+    ])
 
     get("/viewer", MessagesController, :index)
   end

--- a/lib/signs_ui_web/templates/unauthorized/index.html.eex
+++ b/lib/signs_ui_web/templates/unauthorized/index.html.eex
@@ -1,0 +1,3 @@
+You are not authorized to access the signs viewer. If you believe you
+should have access, please have your supervisor contact
+realtimeappsdl@mbta.com.

--- a/lib/signs_ui_web/views/unauthorized_view.ex
+++ b/lib/signs_ui_web/views/unauthorized_view.ex
@@ -1,0 +1,3 @@
+defmodule SignsUiWeb.UnauthorizedView do
+  use SignsUiWeb, :view
+end

--- a/mix.lock
+++ b/mix.lock
@@ -36,6 +36,6 @@
   "timex": {:hex, :timex, "3.3.0", "e0695aa0ddb37d460d93a2db34d332c2c95a40c27edf22fbfea22eb8910a9c8d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.17", "50793e3d85af49736701da1a040c415c97dc1caf6464112fd9bd18f425d3053b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "ueberauth": {:hex, :ueberauth, "0.6.1", "9e90d3337dddf38b1ca2753aca9b1e53d8a52b890191cdc55240247c89230412", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
-  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "d85831384bd20504fb0c949f83986f47d9ea2097", []},
+  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "99817377cd3f4d33613ad5ffb73e371e767f7712", []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/test/signs_ui/ueberauth/strategy/fake_test.exs
+++ b/test/signs_ui/ueberauth/strategy/fake_test.exs
@@ -28,7 +28,7 @@ defmodule SignsUi.Ueberauth.Strategy.FakeTest do
     test "credentials/1" do
       conn = conn(:get, "/auth/cognito/callback")
 
-      assert %Ueberauth.Auth.Credentials{} = credentials(conn)
+      assert %Ueberauth.Auth.Credentials{other: %{groups: ["signs-ui-admin"]}} = credentials(conn)
     end
 
     test "info/1" do

--- a/test/signs_ui_web/channels/signs_channel_test.exs
+++ b/test/signs_ui_web/channels/signs_channel_test.exs
@@ -13,7 +13,10 @@ defmodule SignsUiWeb.SignsChannelTest do
       expiration_time = current_time + 500
 
       {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{"exp" => expiration_time})
+        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
+          "exp" => expiration_time,
+          "groups" => ["signs-ui-admin"]
+        })
 
       socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
 
@@ -47,7 +50,10 @@ defmodule SignsUiWeb.SignsChannelTest do
       expiration_time = current_time + 500
 
       {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{"exp" => expiration_time})
+        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
+          "exp" => expiration_time,
+          "groups" => ["signs-ui-admin"]
+        })
 
       socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
 

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -8,7 +8,8 @@ defmodule SignsUiWeb.AuthControllerTest do
       auth = %Ueberauth.Auth{
         uid: "foo@mbta.com",
         credentials: %Ueberauth.Auth.Credentials{
-          expires_at: current_time + 1_000
+          expires_at: current_time + 1_000,
+          other: %{groups: ["test1"]}
         }
       }
 
@@ -20,6 +21,7 @@ defmodule SignsUiWeb.AuthControllerTest do
       response = html_response(conn, 302)
 
       assert response =~ SignsUiWeb.Router.Helpers.messages_path(conn, :index)
+      assert Guardian.Plug.current_claims(conn)["groups"] == ["test1"]
     end
 
     test "handles failure", %{conn: conn} do

--- a/test/signs_ui_web/controllers/unauthorized_controller_test.exs
+++ b/test/signs_ui_web/controllers/unauthorized_controller_test.exs
@@ -1,0 +1,11 @@
+defmodule SignsUiWeb.UnauthorizedControllerTest do
+  use SignsUiWeb.ConnCase
+
+  describe "index/2" do
+    test "renders response" do
+      conn = get(conn, unauthorized_path(conn, :index))
+
+      assert html_response(conn, 403) =~ "not authorized"
+    end
+  end
+end

--- a/test/signs_ui_web/ensure_signs_ui_group_test.exs
+++ b/test/signs_ui_web/ensure_signs_ui_group_test.exs
@@ -1,0 +1,23 @@
+defmodule SignsUiWeb.EnsureSignsUiGroupTest do
+  use SignsUiWeb.ConnCase
+
+  describe "init/1" do
+    test "passes options through unchanged" do
+      assert SignsUiWeb.EnsureSignsUiGroup.init([]) == []
+    end
+  end
+
+  describe "call/2" do
+    @tag :authenticated
+    test "does nothing when user is in the signs-ui-admin group", %{conn: conn} do
+      assert conn == SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
+    end
+
+    test "redirects when user is not in the signs-ui-admin group" do
+      conn = SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
+
+      response = html_response(conn, 302)
+      assert response =~ "/unauthorized"
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -35,7 +35,7 @@ defmodule SignsUiWeb.ConnCase do
         conn =
           Phoenix.ConnTest.build_conn()
           |> init_test_session(%{})
-          |> Guardian.Plug.sign_in(SignsUiWeb.AuthManager, user)
+          |> Guardian.Plug.sign_in(SignsUiWeb.AuthManager, user, %{groups: ["signs-ui-admin"]})
 
         {conn, user}
       else


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🕵️ Levels of permission](https://app.asana.com/0/584764604969369/1124399243620929/f)

Takes the group information from Ueberauth and includes it in the Guardian token as well. When trying to access the viewer, go through a new plug that verifies that the user has the appropriate group. If not, return a 403 with an accompanying message. In the future we can add a `signs-ui-readonly` group or something like that by generalizing this somewhat (will also require tweaks to how the token for the websocket works, I think).

Instead of writing a new plug, I could have used `plug(Guradian.Plug.EnsureAuthenticated, %{groups: ["signs-ui-admin"]})` in tandem with updated to the error handler to somehow be aware of what kind of check we're doing against the token and then either redirecting to Cognito if it's completely missing, or giving the 403 is the group isn't present. That seemed a bit too underhanded to me, though, so I decided to be explicit and create a separate plug.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
