### PR TITLE
Paginate signs on the page.

### DIFF
--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Station from './Station';
 import { stationConfig, arincToRealtimeId } from './mbta';
-import { signConfigType } from './types';
+import { signConfigType, signContentType } from './types';
 
 function name(line) {
   if (line === 'Red') { return 'Red Line'; }
@@ -82,9 +82,7 @@ function Line({
 }
 
 Line.propTypes = {
-  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string, duration: PropTypes.string,
-  }))).isRequired,
+  signs: PropTypes.objectOf(signContentType).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
   signConfigs: PropTypes.objectOf(signConfigType).isRequired,

--- a/assets/js/Line.test.js
+++ b/assets/js/Line.test.js
@@ -5,8 +5,7 @@ import Line from './Line';
 
 test('Shows all signs for a line', () => {
   const now = Date.now();
-  const fresh = new Date(now + 5000).toLocaleString();
-  const signs = { signID: [{ text: 'Alewife 1 min', duration: fresh }, { text: 'Alewife 3 min', duration: fresh }] };
+  const signs = {};
 
   const currentTime = now + 2000;
   const line = 'Red';

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -6,25 +6,37 @@ import Sign from './Sign';
 test('does not show messages that have expired', () => {
   const now = new Date('2019-01-15T20:15:00Z').valueOf();
   const fresh = new Date(now + 5000).toLocaleString();
-  const lineOneDuration = fresh;
   const expired = new Date(now).toLocaleString();
-  const lineTwoDuration = expired;
   const currentTime = now + 2000;
-  const signId = 'RDAV-s';
-  const lineOne = 'Alewife 1 min';
-  const lineTwo = 'Alewife 3 min';
+  const signId = 'RDAV-n';
   const line = 'Red';
   const signConfig = { mode: 'auto' };
+  const signContent = {
+    sign_id: 'RDAV-n',
+    lines: {
+      1: {
+        text: [{
+          content: 'Alewife 1 min',
+          duration: 5,
+        }],
+        expiration: fresh,
+      },
+      2: {
+        text: [{
+          content: 'Alewife 3 min',
+          duration: 5,
+        }],
+        expiration: expired,
+      },
+    },
+  };
   const setConfigs = () => { };
   const realtimeId = 'id';
 
   const wrapper = mount(
     React.createElement(Sign, {
       signId,
-      lineOne,
-      lineOneDuration,
-      lineTwo,
-      lineTwoDuration,
+      signContent,
       currentTime,
       line,
       signConfig,

--- a/assets/js/Station.jsx
+++ b/assets/js/Station.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Sign from './Sign';
 import { arincToRealtimeId } from './mbta';
-import { signConfigType } from './types';
+import { signConfigType, signContentType } from './types';
 
 function zoneDescription(stationConfig, zone) {
   if (stationConfig.zones[zone] !== true) {
@@ -18,25 +18,8 @@ function zoneDescription(stationConfig, zone) {
 function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfigs) {
   if (config.zones[zone]) {
     const key = `${config.id}-${zone}`;
-    const lines = signs[key];
-    let lineOne;
-    let lineTwo;
-    let lineOneDuration;
-    let lineTwoDuration;
-    if (lines !== undefined) {
-      lineOne = lines[0].text;
-      lineTwo = lines[1].text;
-      lineOneDuration = lines[0].duration;
-      lineTwoDuration = lines[1].duration;
-    } else {
-      lineOne = '';
-      lineTwo = '';
-      lineOneDuration = '0';
-      lineTwoDuration = '0';
-    }
-
+    const signContent = signs[key] || { sign_id: key, lines: {} };
     const realtimeId = arincToRealtimeId(key, line);
-
     const signConfig = signConfigs[realtimeId] || { mode: 'off' };
 
     return (
@@ -44,10 +27,7 @@ function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfig
         key={key}
         signId={zoneDescription(config, zone)}
         line={line}
-        lineOne={lineOne}
-        lineOneDuration={lineOneDuration}
-        lineTwo={lineTwo}
-        lineTwoDuration={lineTwoDuration}
+        signContent={signContent}
         currentTime={currentTime}
         signConfig={signConfig}
         setConfigs={setConfigs}
@@ -105,9 +85,7 @@ Station.propTypes = {
       m: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     }).isRequired,
   }).isRequired,
-  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string, duration: PropTypes.string,
-  }))).isRequired,
+  signs: PropTypes.objectOf(signContentType).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
   signConfigs: PropTypes.objectOf(signConfigType).isRequired,

--- a/assets/js/Station.test.js
+++ b/assets/js/Station.test.js
@@ -12,12 +12,7 @@ test('shows the custom configuration information for a station', () => {
     },
   };
   const currentTime = Date.now() + 2000;
-  const signs = {
-    'OMAL-m': [
-      { text: 'Alewife 1 min', duration: (currentTime + 1000).toLocaleString() },
-      { text: 'Alewife 3 min', duration: (currentTime + 1000).toLocaleString() },
-    ],
-  };
+  const signs = {};
   const line = 'Orange';
   const signConfigs = {};
   const setConfigs = () => { };

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Line from './Line';
-import { signConfigType } from './types';
+import { signConfigType, signContentType } from './types';
 
 function Viewer({
   signs, currentTime, line, signConfigs, setConfigs,
@@ -20,9 +20,7 @@ function Viewer({
 }
 
 Viewer.propTypes = {
-  signs: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string, duration: PropTypes.string,
-  }))).isRequired,
+  signs: PropTypes.objectOf(signContentType).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,
   signConfigs: PropTypes.objectOf(signConfigType).isRequired,

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Socket } from 'phoenix';
 import Viewer from './Viewer';
-import { updateSigns } from './helpers';
 import lineToColor from './colors';
-import { signConfigType } from './types';
+import { signConfigType, signContentType } from './types';
 
 class ViewerApp extends Component {
   constructor(props) {
@@ -31,13 +30,12 @@ class ViewerApp extends Component {
       .join()
       .receive('ok', () => { });
 
-    channel.on('sign_update', ({
-      sign_id: signId, duration, line_number: lineNumber, text: content,
-    }) => {
+    channel.on('sign_update', (sign) => {
       this.setState(prevState => ({
-        signs: updateSigns(prevState.signs, {
-          signId, duration, lineNumber, content,
-        }),
+        signs: {
+          ...prevState.signs,
+          [sign.sign_id]: sign,
+        },
       }));
     });
 
@@ -46,7 +44,6 @@ class ViewerApp extends Component {
     });
 
     channel.on('auth_expired', () => {
-      console.log('auth_expired');
       window.location.reload(true);
     });
 
@@ -128,9 +125,7 @@ class ViewerApp extends Component {
 }
 
 ViewerApp.propTypes = {
-  initialSigns: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string, duration: PropTypes.string,
-  }))).isRequired,
+  initialSigns: PropTypes.objectOf(signContentType).isRequired,
   initialSignConfigs: PropTypes.objectOf(signConfigType).isRequired,
 };
 

--- a/assets/js/ViewerApp.test.js
+++ b/assets/js/ViewerApp.test.js
@@ -1,16 +1,42 @@
 import React from 'react';
 import { mount } from 'enzyme';
-
 import ViewerApp from './ViewerApp';
+
+function someSignContent(now) {
+  const fresh = new Date(now + 5000).toLocaleString();
+  return {
+    'RDAV-s': {
+      sign_id: 'RDAV-s',
+      lines: {
+        1: {
+          expiration: fresh,
+          text: [{ content: 'Alewife 1 min', duration: 5 }],
+        },
+        2: {
+          expiration: fresh,
+          text: [{ content: 'Alewife 3 min', duration: 5 }],
+        },
+      },
+    },
+    'OGRE-m': {
+      sign_id: 'OGRE-m',
+      lines: {
+        1: {
+          expiration: fresh,
+          text: [{ content: 'Oak Grove 1 min', duration: 5 }],
+        },
+        2: {
+          expiration: fresh,
+          text: [{ content: 'Forest Hills 3 min', duration: 5 }],
+        },
+      },
+    },
+  };
+}
 
 test('Shows all signs for a line', () => {
   const now = Date.now();
-  const fresh = new Date(now + 5000).toLocaleString();
-  const signs = {
-    'RDAV-s': [{ text: 'Alewife 1 min', duration: fresh }, { text: 'Alewife 3 min', duration: fresh }],
-    'OGRE-m': [{ text: 'Oak Grove 1 min', duration: fresh }, { text: 'Forest Hills 3 min', duration: fresh }],
-  };
-
+  const signs = someSignContent(now);
   const currentTime = now + 2000;
   const line = 'Red';
   const initialSignConfigs = {};
@@ -32,12 +58,7 @@ test('Shows all signs for a line', () => {
 
 test('Can enable/disable a sign', () => {
   const now = Date.now();
-  const fresh = new Date(now + 5000).toLocaleString();
-  const signs = {
-    'RDAV-s': [{ text: 'Alewife 1 min', duration: fresh }, { text: 'Alewife 3 min', duration: fresh }],
-    'OGRE-m': [{ text: 'Oak Grove 1 min', duration: fresh }, { text: 'Forest Hills 3 min', duration: fresh }],
-  };
-
+  const signs = someSignContent();
   const currentTime = now + 2000;
   const line = 'Red';
   const initialSignConfigs = { davis_southbound: { mode: 'auto' } };

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,14 +1,18 @@
-function updateSigns(oldSigns, {
-  signId, lineNumber, content, duration,
-}) {
-  const newValues = oldSigns[signId] ? oldSigns[signId].slice(0) : [{ text: '', duration: '0' }, { text: '', duration: '0' }];
-  newValues[lineNumber - 1] = { text: content, duration };
+function choosePage(pages, elapsedSeconds) {
+  if (pages.length === 1) { return pages[0].content; }
 
-  return {
-    ...oldSigns,
-    [signId]: newValues,
-  };
+  const repeatTime = pages.reduce((acc, pg) => acc + pg.duration, 0);
+  let excessTime = elapsedSeconds % repeatTime;
+
+  for (let i = 0; i < pages.length; i += 1) {
+    if (excessTime <= pages[i].duration) {
+      return pages[i].content;
+    }
+    excessTime -= pages[i].duration;
+  }
+
+  return '';
 }
 
 /* eslint-disable import/prefer-default-export */
-export { updateSigns };
+export { choosePage };

--- a/assets/js/helpers.test.js
+++ b/assets/js/helpers.test.js
@@ -1,17 +1,28 @@
-import { updateSigns } from './helpers';
+import { choosePage } from './helpers';
 
-test('updateSigns returns a new map with changed values for the ID', () => {
-  const oldSigns = { id1: ['one', 'two'] };
-  const newSigns = updateSigns(oldSigns, {
-    signId: 'id1', lineNumber: 2, duration: 2, content: 'TWO',
-  });
-  expect(oldSigns).toEqual({ id1: ['one', 'two'] });
-  expect(newSigns).toEqual({ id1: ['one', { duration: 2, text: 'TWO' }] });
+test('choosePage returns the first page when there is only one', () => {
+  const pages = [{ content: 'the page', duration: 5 }];
+
+  expect(choosePage(pages, 2)).toEqual('the page');
+  expect(choosePage(pages, 7)).toEqual('the page');
 });
 
-test('updateSigns returns a new map adding a new sign if not present before', () => {
-  const signs = updateSigns({}, {
-    signId: 'newSign', lineNumber: 1, duration: 2, content: 'ONE',
-  });
-  expect(signs).toEqual({ newSign: [{ duration: 2, text: 'ONE' }, { duration: '0', text: '' }] });
+test('choosePage cycles through pages as time elapses', () => {
+  const pages = [
+    { content: 'page one', duration: 2 },
+    { content: 'page two', duration: 5 },
+    { content: 'page three', duration: 2 },
+  ];
+
+  expect(choosePage(pages, 1.5)).toEqual('page one');
+  expect(choosePage(pages, 2.5)).toEqual('page two');
+  expect(choosePage(pages, 3.5)).toEqual('page two');
+  expect(choosePage(pages, 4.5)).toEqual('page two');
+  expect(choosePage(pages, 5.5)).toEqual('page two');
+  expect(choosePage(pages, 6.5)).toEqual('page two');
+  expect(choosePage(pages, 7.5)).toEqual('page three');
+  expect(choosePage(pages, 8.5)).toEqual('page three');
+  expect(choosePage(pages, 9.5)).toEqual('page one');
+  expect(choosePage(pages, 10.5)).toEqual('page one');
+  expect(choosePage(pages, 100.5)).toEqual('page one');
 });

--- a/assets/js/types.js
+++ b/assets/js/types.js
@@ -11,5 +11,15 @@ const signConfigType = PropTypes.oneOfType([
   }),
 ]);
 
-// eslint-disable-next-line import/prefer-default-export
-export { signConfigType };
+const signContentType = PropTypes.shape({
+  sign_id: PropTypes.string.isRequired,
+  lines: PropTypes.objectOf(PropTypes.shape({
+    text: PropTypes.arrayOf(PropTypes.shape({
+      content: PropTypes.string.isRequired,
+      duration: PropTypes.number.isRequired,
+    })).isRequired,
+    expiration: PropTypes.string,
+  })),
+});
+
+export { signConfigType, signContentType };

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -35,16 +35,14 @@ defmodule SignsUi.Signs.Sign do
     )
   end
 
-  @spec to_json(t()) :: [map()]
+  @spec to_json(t()) :: %{sign_id: String.t(), lines: map()}
   def to_json(sign) do
-    Enum.map([1, 2], fn line_number ->
-      case sign.lines[line_number] do
-        nil ->
-          %{text: "", duration: Timex.now()}
-
-        %SignLine{} = line ->
-          SignLine.to_json(line)
-      end
-    end)
+    %{
+      sign_id: "#{sign.station}-#{sign.zone}",
+      lines:
+        Map.new(sign.lines, fn {line_number, line} ->
+          {line_number, SignLine.to_json(line)}
+        end)
+    }
   end
 end

--- a/lib/signs_ui/signs/sign_line.ex
+++ b/lib/signs_ui/signs/sign_line.ex
@@ -7,6 +7,8 @@ defmodule SignsUi.Signs.SignLine do
   @enforce_keys [:expiration, :text]
   defstruct @enforce_keys
 
+  alias SignsUi.Messages.SignContent
+
   @type page :: {String.t(), non_neg_integer()}
 
   @type t :: %__MODULE__{
@@ -14,13 +16,15 @@ defmodule SignsUi.Signs.SignLine do
           text: [page]
         }
 
-  def new_from_message(%SignsUi.Messages.SignContent{} = msg) do
+  @spec new_from_message(SignContent.t()) :: t()
+  def new_from_message(%SignContent{} = msg) do
     %__MODULE__{
       expiration: msg.expiration,
       text: Enum.map(msg.pages, &normalize_page/1)
     }
   end
 
+  @spec to_json(t()) :: map()
   def to_json(%__MODULE__{text: pages} = line) do
     %{
       text: Enum.map(pages, &page_to_json/1),
@@ -28,8 +32,10 @@ defmodule SignsUi.Signs.SignLine do
     }
   end
 
+  @spec normalize_page(String.t() | {String.t(), integer()}) :: {String.t(), integer()}
   defp normalize_page({text, duration}), do: {text, duration}
   defp normalize_page(text) when is_binary(text), do: {text, 5}
 
+  @spec page_to_json({String.t(), integer()}) :: map()
   defp page_to_json({text, duration}), do: %{content: text, duration: duration}
 end

--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -50,26 +50,12 @@ defmodule SignsUi.Signs.State do
       |> Map.get(sign_id, Sign.new_from_message(message))
       |> Sign.update_from_message(message)
 
-    broadcast_update(message)
+    broadcast_update(sign)
     {:reply, :ok, Map.put(state, sign_id, sign)}
   end
 
-  @spec broadcast_update(SignContent.t()) :: :ok
-  defp broadcast_update(message) do
-    SignsUiWeb.Endpoint.broadcast!("signs:all", "sign_update", %{
-      sign_id: "#{message.station}-#{message.zone}",
-      line_number: message.line_number,
-      text: message.pages |> get_page() |> SignContent.page_to_text(),
-      duration: message.expiration
-    })
-  end
-
-  @spec get_page([SignContent.page()]) :: SignContent.page()
-  defp get_page([_away, _stopped, n_stops]) do
-    n_stops
-  end
-
-  defp get_page(pages) do
-    List.first(pages)
+  @spec broadcast_update(Sign.t()) :: :ok
+  defp broadcast_update(sign) do
+    SignsUiWeb.Endpoint.broadcast!("signs:all", "sign_update", Sign.to_json(sign))
   end
 end

--- a/test/signs_ui/signs/sign_line_test.exs
+++ b/test/signs_ui/signs/sign_line_test.exs
@@ -20,18 +20,15 @@ defmodule SignsUi.Signs.SignLineTest do
   }
 
   describe "new_from_message" do
-    test "turns a single page into just a string" do
+    test "turns a single page into just a string with default duration" do
       message = %{@message | pages: ["page 1"]}
-      assert %SignLine{expiration: @now, text: "page 1"} = SignLine.new_from_message(message)
-    end
 
-    test "turns a single page, with duration, into just a string" do
-      message = %{@message | pages: [{"page 1", 5}]}
-      assert %SignLine{expiration: @now, text: "page 1"} = SignLine.new_from_message(message)
+      assert %SignLine{expiration: @now, text: [{"page 1", 5}]} =
+               SignLine.new_from_message(message)
     end
 
     test "when multiple pages, keeps them all" do
-      message = %{@message | pages: [{"page 1", 5}, {"page 2", 5}]}
+      message = %{@message | pages: [{"page 1", 5}, "page 2"]}
 
       assert %SignLine{expiration: @now, text: [{"page 1", 5}, {"page 2", 5}]} =
                SignLine.new_from_message(message)
@@ -43,27 +40,13 @@ defmodule SignsUi.Signs.SignLineTest do
       sign_line = %{@sign_line | text: [{"away", 2}, {"stopped", 5}, {"2 stops", 2}]}
 
       assert %{
-               duration: @now,
-               text: "2 stops"
+               expiration: @now,
+               text: [
+                 %{content: "away", duration: 2},
+                 %{content: "stopped", duration: 5},
+                 %{content: "2 stops", duration: 2}
+               ]
              } = SignLine.to_json(sign_line)
     end
-
-    test "When not 3 pages, takes the first page" do
-      sign_line = %{@sign_line | text: [{"Trk 2", 5}, {"Ashmont BRD", 2}]}
-
-      assert %{
-               duration: @now,
-               text: "Trk 2"
-             } = SignLine.to_json(sign_line)
-    end
-  end
-
-  test "Serializes page when the duration is not included" do
-    sign_line = %{@sign_line | text: ["Ashmont 1 min"]}
-
-    assert %{
-             duration: @now,
-             text: "Ashmont 1 min"
-           } = SignLine.to_json(sign_line)
   end
 end

--- a/test/signs_ui/signs/sign_test.exs
+++ b/test/signs_ui/signs/sign_test.exs
@@ -13,7 +13,7 @@ defmodule SignsUi.Signs.SignTest do
     lines: %{
       1 => %SignLine{
         expiration: @now,
-        text: "a page"
+        text: [{"a page", 5}]
       }
     }
   }
@@ -34,7 +34,7 @@ defmodule SignsUi.Signs.SignTest do
                lines: %{
                  1 => %SignLine{
                    expiration: @now,
-                   text: "a page"
+                   text: [{"a page", 5}]
                  }
                }
              } = Sign.new_from_message(@message)
@@ -51,11 +51,11 @@ defmodule SignsUi.Signs.SignTest do
                lines: %{
                  1 => %SignLine{
                    expiration: @now,
-                   text: "a page"
+                   text: [{"a page", 5}]
                  },
                  2 => %SignLine{
                    expiration: @now,
-                   text: "2nd page"
+                   text: [{"2nd page", 5}]
                  }
                }
              } = Sign.update_from_message(@sign, message2)
@@ -64,10 +64,15 @@ defmodule SignsUi.Signs.SignTest do
 
   describe "to_json" do
     test "serializes to the map that the frontend expects" do
-      assert [
-               %{duration: %DateTime{}, text: "a page"},
-               %{duration: %DateTime{}, text: ""}
-             ] = Sign.to_json(@sign)
+      assert %{
+               sign_id: "XYZ-w",
+               lines: %{
+                 1 => %{
+                   expiration: @now,
+                   text: [%{content: "a page", duration: 5}]
+                 }
+               }
+             } = Sign.to_json(@sign)
     end
   end
 end

--- a/test/signs_ui/signs/state_test.exs
+++ b/test/signs_ui/signs/state_test.exs
@@ -22,10 +22,15 @@ defmodule SignsUi.Signs.StateTest do
     State.process_message(pid, msg)
 
     assert %{
-             "XYZ-w" => [
-               %{text: "Alewife 12 min", duration: ^later},
-               %{text: ""}
-             ]
+             "XYZ-w" => %{
+               sign_id: "XYZ-w",
+               lines: %{
+                 1 => %{
+                   text: [%{content: "Alewife 12 min", duration: 5}],
+                   expiration: ^later
+                 }
+               }
+             }
            } = State.list_signs(pid)
   end
 
@@ -36,7 +41,7 @@ defmodule SignsUi.Signs.StateTest do
         zone: "w",
         lines: %{
           1 => %SignLine{
-            text: "Alewife 1 min",
+            text: [{"Alewife 1 min", 5}],
             expiration: Timex.now()
           }
         }
@@ -57,8 +62,8 @@ defmodule SignsUi.Signs.StateTest do
                 station: "ABCD",
                 zone: "w",
                 lines: %{
-                  1 => %SignLine{text: "Alewife 1 min"},
-                  2 => %SignLine{text: "Alewife 8 min"}
+                  1 => %SignLine{text: [{"Alewife 1 min", 5}]},
+                  2 => %SignLine{text: [{"Alewife 8 min", 5}]}
                 }
               }
             }} = State.handle_call({:process_message, msg}, self(), state)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁️ PIO can see paging on Signs UI](https://app.asana.com/0/584764604969369/747281786398695)

This reworks the representation of the sign data in JS to accommodate multiple pages, each with their own durations. Each Sign element now keeps track of the elapsed seconds since it was constructed, so it can page through appropriately.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
