### PR TITLE
Add padding to first line to space out clock

### DIFF
--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -49,7 +49,8 @@ function timeString(currentTime) {
 function line1DisplayText(lineContent, currentTime, initialTime) {
   if (lineContent !== undefined && isNotExpired(lineContent.expiration, currentTime)) {
     const text = choosePage(lineContent.text, (currentTime - initialTime) / 1000);
-    return `${text}${timeString(currentTime)}`;
+
+    return `${text.padEnd(19)}${timeString(currentTime)}`;
   }
   return '';
 }

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -45,7 +45,7 @@ test('does not show messages that have expired', () => {
     }, null),
   );
 
-  expect(wrapper.text()).toMatch('Alewife 1 min');
+  expect(wrapper.text()).toMatch('Alewife 1 min      ');
   expect(wrapper.text()).toMatch('3:15');
 
   expect(wrapper.text()).not.toMatch('Alewife 3 min');


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Oops, [deleted a line in my last PR](https://github.com/mbta/signs_ui/pull/91/files#diff-b99b41d74e9383347a4083f0bea2f70bL50) that padded the first line out to 19 characters. This PR adds it back.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
