### PR TITLE
Read-only view

### DIFF
--- a/assets/css/viewer.css
+++ b/assets/css/viewer.css
@@ -69,6 +69,12 @@
   width: 20em;
 }
 
+.viewer--schedule-expires:empty {
+  padding: 0em 0em 0em 0em;
+  margin-bottom: 0em;
+  margin-top: 0em;
+}
+
 .viewer--mode-select {
   width: 70px;
 }

--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -35,7 +35,7 @@ function setEnabledStations(setConfigFn, stations, line, enabled) {
 }
 
 function Line({
-  signs, currentTime, line, signConfigs, setConfigs,
+  signs, currentTime, line, signConfigs, setConfigs, readOnly,
 }) {
   const stations = stationConfig[line] || [];
 
@@ -45,25 +45,29 @@ function Line({
         {name(line)}
       </h1>
 
-      <div className="viewer--toggle-all">
-        <button
-          type="button"
-          className="btn btn-outline-secondary"
-          onClick={() => { setEnabledStations(setConfigs, stations, line, true); }}
-        >
-          Enable all
-        </button>
+      {!readOnly
+        && (
+          <div className="viewer--toggle-all">
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={() => { setEnabledStations(setConfigs, stations, line, true); }}
+            >
+              Enable all
+            </button>
 
-        &nbsp;
+            &nbsp;
 
-        <button
-          type="button"
-          className="btn btn-outline-secondary"
-          onClick={() => { setEnabledStations(setConfigs, stations, line, false); }}
-        >
-          Disable all
-        </button>
-      </div>
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={() => { setEnabledStations(setConfigs, stations, line, false); }}
+            >
+              Disable all
+            </button>
+          </div>
+        )
+      }
       {
         stations.map(station => (
           <Station
@@ -74,6 +78,7 @@ function Line({
             line={line}
             signConfigs={signConfigs}
             setConfigs={setConfigs}
+            readOnly={readOnly}
           />
         ))
       }
@@ -87,6 +92,7 @@ Line.propTypes = {
   line: PropTypes.string.isRequired,
   signConfigs: PropTypes.objectOf(signConfigType).isRequired,
   setConfigs: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool.isRequired,
 };
 
 export default Line;

--- a/assets/js/Line.test.js
+++ b/assets/js/Line.test.js
@@ -11,11 +11,48 @@ test('Shows all signs for a line', () => {
   const line = 'Red';
   const signConfigs = {};
   const setConfigs = () => { };
+  const readOnly = false;
 
   const wrapper = mount(React.createElement(Line, {
-    signs, currentTime, line, signConfigs, setConfigs,
+    signs, currentTime, line, signConfigs, setConfigs, readOnly,
   }, null));
 
   expect(wrapper.text()).toMatch('Alewife (RALE)');
   expect(wrapper.text()).not.toMatch('Oak Grove (OOAK)');
+});
+
+test('Shows enable / disable all buttons when not read-only', () => {
+  const now = Date.now();
+  const signs = {};
+
+  const currentTime = now + 2000;
+  const line = 'Red';
+  const signConfigs = {};
+  const setConfigs = () => { };
+  const readOnly = false;
+
+  const wrapper = mount(React.createElement(Line, {
+    signs, currentTime, line, signConfigs, setConfigs, readOnly,
+  }, null));
+
+  expect(wrapper.text()).toMatch('Enable all');
+  expect(wrapper.text()).toMatch('Disable all');
+});
+
+test('Doesn\'t show enable / disable all buttons when read-only', () => {
+  const now = Date.now();
+  const signs = {};
+
+  const currentTime = now + 2000;
+  const line = 'Red';
+  const signConfigs = {};
+  const setConfigs = () => { };
+  const readOnly = true;
+
+  const wrapper = mount(React.createElement(Line, {
+    signs, currentTime, line, signConfigs, setConfigs, readOnly,
+  }, null));
+
+  expect(wrapper.text()).not.toMatch('Enable all');
+  expect(wrapper.text()).not.toMatch('Disable all');
 });

--- a/assets/js/SetExpiration.jsx
+++ b/assets/js/SetExpiration.jsx
@@ -37,13 +37,22 @@ function parseDate(str) {
 }
 
 function SetExpiration({
-  realtimeId, signConfig, setConfigs,
+  realtimeId, signConfig, setConfigs, readOnly,
 }) {
-  return (
+  return (signConfig.expires || !readOnly) && (
     <div>
-      <strong>
-        Schedule return to &quot;Auto&quot;
-      </strong>
+      {(!readOnly
+        && (
+          <strong>
+            Schedule return to &quot;Auto&quot;
+          </strong>
+        ))
+       || (
+         <strong>
+           Scheduled return to &quot;Auto&quot;
+         </strong>
+       )
+      }
 
       <DatePicker
         selected={parseDate(signConfig.expires)}
@@ -52,16 +61,20 @@ function SetExpiration({
         timeFormat="HH:mm"
         timeIntervals={15}
         dateFormat="MMM d @ h:mm aa"
+        disabled={readOnly}
       />
-      {signConfig.expires && (
-        <button
-          className="viewer--cancel-expiration-button"
-          type="button"
-          onClick={() => updateConfig(setConfigs, realtimeId, signConfig, null)}
-        >
-          Cancel
-        </button>
-      )
+
+      {signConfig.expires
+        && !readOnly
+        && (
+          <button
+            className="viewer--cancel-expiration-button"
+            type="button"
+            onClick={() => updateConfig(setConfigs, realtimeId, signConfig, null)}
+          >
+            Cancel
+          </button>
+        )
       }
     </div>
   );
@@ -71,6 +84,7 @@ SetExpiration.propTypes = {
   realtimeId: PropTypes.string.isRequired,
   signConfig: signConfigType.isRequired,
   setConfigs: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool.isRequired,
 };
 
 export default SetExpiration;

--- a/assets/js/SetExpiration.test.js
+++ b/assets/js/SetExpiration.test.js
@@ -10,6 +10,8 @@ test('Can set the expiration time', () => {
     requests.push(arg);
   };
 
+  const readOnly = false;
+
   const wrapper = mount(
     React.createElement(SetExpiration, {
       realtimeId: 'rtID',
@@ -20,6 +22,7 @@ test('Can set the expiration time', () => {
         expires: null,
       },
       setConfigs,
+      readOnly,
     }),
   );
 
@@ -37,6 +40,8 @@ test('Can clear the expiration time', () => {
     requests.push(arg);
   };
 
+  const readOnly = false;
+
   const wrapper = mount(
     React.createElement(SetExpiration, {
       realtimeId: 'rtID',
@@ -47,6 +52,7 @@ test('Can clear the expiration time', () => {
         expires: (new Date()).toISOString(),
       },
       setConfigs,
+      readOnly,
     }),
   );
 
@@ -54,4 +60,70 @@ test('Can clear the expiration time', () => {
   expect(requests.length).toBe(1);
   const newConf = requests[0].rtID;
   expect(newConf.expires).toBe(null);
+});
+
+test('Shows widget when no expiration set if not in read-only mode', () => {
+  const setConfigs = () => { };
+
+  const readOnly = false;
+
+  const wrapper = mount(
+    React.createElement(SetExpiration, {
+      realtimeId: 'rtID',
+      signConfig: {
+        mode: 'static_text',
+        line1: 'line1',
+        line2: 'line2',
+        expires: '',
+      },
+      setConfigs,
+      readOnly,
+    }),
+  );
+
+  expect(wrapper.text()).toMatch('Schedule return');
+});
+
+test('Suppresses widget when no expiration set if in read-only mode', () => {
+  const setConfigs = () => { };
+
+  const readOnly = true;
+
+  const wrapper = mount(
+    React.createElement(SetExpiration, {
+      realtimeId: 'rtID',
+      signConfig: {
+        mode: 'static_text',
+        line1: 'line1',
+        line2: 'line2',
+        expires: '',
+      },
+      setConfigs,
+      readOnly,
+    }),
+  );
+
+  expect(wrapper.text()).toBe(null);
+});
+
+test('Shows \'Scheduled\' when expiration is set if in read-only mode', () => {
+  const setConfigs = () => { };
+
+  const readOnly = true;
+
+  const wrapper = mount(
+    React.createElement(SetExpiration, {
+      realtimeId: 'rtID',
+      signConfig: {
+        mode: 'static_text',
+        line1: 'line1',
+        line2: 'line2',
+        expires: (new Date()).toISOString(),
+      },
+      setConfigs,
+      readOnly,
+    }),
+  );
+
+  expect(wrapper.text()).toMatch('Scheduled return');
 });

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -126,6 +126,7 @@ class Sign extends Component {
       signConfig,
       setConfigs,
       realtimeId,
+      readOnly,
     } = this.props;
 
     const {
@@ -143,28 +144,32 @@ class Sign extends Component {
             <span style={fontSize(signId)}>
               {signId}
             </span>
-            <div>
-              <select
-                id={realtimeId}
-                className="viewer--mode-select"
-                value={signConfig.mode}
-                onChange={
-                  (event) => {
-                    setConfigs({ [realtimeId]: makeConfig(event.target.value) });
-                  }
-                }
-              >
-                <option value="auto">
-                  Auto
-                </option>
-                <option value="static_text">
-                  Custom
-                </option>
-                <option value="off">
-                  Off
-                </option>
-              </select>
-            </div>
+            {!readOnly
+              && (
+                <div>
+                  <select
+                    id={realtimeId}
+                    className="viewer--mode-select"
+                    value={signConfig.mode}
+                    onChange={
+                      (event) => {
+                        setConfigs({ [realtimeId]: makeConfig(event.target.value) });
+                      }
+                    }
+                  >
+                    <option value="auto">
+                      Auto
+                    </option>
+                    <option value="static_text">
+                      Custom
+                    </option>
+                    <option value="off">
+                      Off
+                    </option>
+                  </select>
+                </div>
+              )
+            }
           </div>
           <div className="viewer--sign-lines">
             <div className="viewer--sign-line">
@@ -177,6 +182,7 @@ class Sign extends Component {
         </div>
 
         {signConfig.mode === 'static_text'
+          && !readOnly
           && (
             <div className="viewer--static-text-form">
               <div>
@@ -228,6 +234,7 @@ class Sign extends Component {
               realtimeId={realtimeId}
               signConfig={signConfig}
               setConfigs={setConfigs}
+              readOnly={readOnly}
             />
           </div>
         )}
@@ -244,6 +251,7 @@ Sign.propTypes = {
   setConfigs: PropTypes.func.isRequired,
   signConfig: signConfigType.isRequired,
   realtimeId: PropTypes.string.isRequired,
+  readOnly: PropTypes.bool.isRequired,
 };
 
 export default Sign;

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -3,6 +3,28 @@ import { mount } from 'enzyme';
 
 import Sign from './Sign';
 
+function signContentWithExpirations(time1, time2) {
+  return {
+    sign_id: 'RDAV-n',
+    lines: {
+      1: {
+        text: [{
+          content: 'Alewife 1 min',
+          duration: 5,
+        }],
+        expiration: time1,
+      },
+      2: {
+        text: [{
+          content: 'Alewife 3 min',
+          duration: 5,
+        }],
+        expiration: time2,
+      },
+    },
+  };
+}
+
 test('does not show messages that have expired', () => {
   const now = new Date('2019-01-15T20:15:00Z').valueOf();
   const fresh = new Date(now + 5000).toLocaleString();
@@ -11,27 +33,10 @@ test('does not show messages that have expired', () => {
   const signId = 'RDAV-n';
   const line = 'Red';
   const signConfig = { mode: 'auto' };
-  const signContent = {
-    sign_id: 'RDAV-n',
-    lines: {
-      1: {
-        text: [{
-          content: 'Alewife 1 min',
-          duration: 5,
-        }],
-        expiration: fresh,
-      },
-      2: {
-        text: [{
-          content: 'Alewife 3 min',
-          duration: 5,
-        }],
-        expiration: expired,
-      },
-    },
-  };
+  const signContent = signContentWithExpirations(fresh, expired);
   const setConfigs = () => { };
   const realtimeId = 'id';
+  const readOnly = false;
 
   const wrapper = mount(
     React.createElement(Sign, {
@@ -42,6 +47,7 @@ test('does not show messages that have expired', () => {
       signConfig,
       setConfigs,
       realtimeId,
+      readOnly,
     }, null),
   );
 
@@ -49,4 +55,60 @@ test('does not show messages that have expired', () => {
   expect(wrapper.text()).toMatch('3:15');
 
   expect(wrapper.text()).not.toMatch('Alewife 3 min');
+});
+
+test('does not show select in read-only mode', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig = { mode: 'auto' };
+  const signContent = signContentWithExpirations(fresh, fresh);
+  const setConfigs = () => { };
+  const realtimeId = 'id';
+  const readOnly = true;
+
+  const wrapper = mount(
+    React.createElement(Sign, {
+      signId,
+      signContent,
+      currentTime,
+      line,
+      signConfig,
+      setConfigs,
+      realtimeId,
+      readOnly,
+    }, null),
+  );
+
+  expect(wrapper.html()).not.toMatch('select');
+});
+
+test('does show select when not in read-only mode', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig = { mode: 'auto' };
+  const signContent = signContentWithExpirations(fresh, fresh);
+  const setConfigs = () => { };
+  const realtimeId = 'id';
+  const readOnly = false;
+
+  const wrapper = mount(
+    React.createElement(Sign, {
+      signId,
+      signContent,
+      currentTime,
+      line,
+      signConfig,
+      setConfigs,
+      realtimeId,
+      readOnly,
+    }, null),
+  );
+
+  expect(wrapper.html()).toMatch('select');
 });

--- a/assets/js/Station.jsx
+++ b/assets/js/Station.jsx
@@ -15,7 +15,7 @@ function zoneDescription(stationConfig, zone) {
   return zones[zone];
 }
 
-function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfigs) {
+function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfigs, readOnly) {
   if (config.zones[zone]) {
     const key = `${config.id}-${zone}`;
     const signContent = signs[key] || { sign_id: key, lines: {} };
@@ -32,6 +32,7 @@ function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfig
         signConfig={signConfig}
         setConfigs={setConfigs}
         realtimeId={realtimeId}
+        readOnly={readOnly}
       />
     );
   }
@@ -40,7 +41,7 @@ function makeSign(config, zone, signs, currentTime, line, signConfigs, setConfig
 }
 
 function Station({
-  config, signs, currentTime, line, signConfigs, setConfigs,
+  config, signs, currentTime, line, signConfigs, setConfigs, readOnly,
 }) {
   return (
     <div key={config.id}>
@@ -55,16 +56,16 @@ function Station({
       </h3>
       <div className="row">
         <div className="col">
-          {makeSign(config, 's', signs, currentTime, line, signConfigs, setConfigs)}
-          {makeSign(config, 'w', signs, currentTime, line, signConfigs, setConfigs)}
+          {makeSign(config, 's', signs, currentTime, line, signConfigs, setConfigs, readOnly)}
+          {makeSign(config, 'w', signs, currentTime, line, signConfigs, setConfigs, readOnly)}
         </div>
         <div className="col">
-          {makeSign(config, 'c', signs, currentTime, line, signConfigs, setConfigs)}
-          {makeSign(config, 'm', signs, currentTime, line, signConfigs, setConfigs)}
+          {makeSign(config, 'c', signs, currentTime, line, signConfigs, setConfigs, readOnly)}
+          {makeSign(config, 'm', signs, currentTime, line, signConfigs, setConfigs, readOnly)}
         </div>
         <div className="col">
-          {makeSign(config, 'n', signs, currentTime, line, signConfigs, setConfigs)}
-          {makeSign(config, 'e', signs, currentTime, line, signConfigs, setConfigs)}
+          {makeSign(config, 'n', signs, currentTime, line, signConfigs, setConfigs, readOnly)}
+          {makeSign(config, 'e', signs, currentTime, line, signConfigs, setConfigs, readOnly)}
         </div>
       </div>
       <hr />
@@ -90,6 +91,7 @@ Station.propTypes = {
   line: PropTypes.string.isRequired,
   signConfigs: PropTypes.objectOf(signConfigType).isRequired,
   setConfigs: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool.isRequired,
 };
 
 export default Station;

--- a/assets/js/Station.test.js
+++ b/assets/js/Station.test.js
@@ -16,10 +16,11 @@ test('shows the custom configuration information for a station', () => {
   const line = 'Orange';
   const signConfigs = {};
   const setConfigs = () => { };
+  const readOnly = false;
 
   const wrapper = mount(
     React.createElement(Station, {
-      config, signs, currentTime, line, signConfigs, setConfigs,
+      config, signs, currentTime, line, signConfigs, setConfigs, readOnly,
     }),
   );
 

--- a/assets/js/Viewer.jsx
+++ b/assets/js/Viewer.jsx
@@ -4,7 +4,7 @@ import Line from './Line';
 import { signConfigType, signContentType } from './types';
 
 function Viewer({
-  signs, currentTime, line, signConfigs, setConfigs,
+  signs, currentTime, line, signConfigs, setConfigs, readOnly,
 }) {
   return (
     <div>
@@ -14,6 +14,7 @@ function Viewer({
         line={line}
         signConfigs={signConfigs}
         setConfigs={setConfigs}
+        readOnly={readOnly}
       />
     </div>
   );
@@ -25,6 +26,7 @@ Viewer.propTypes = {
   line: PropTypes.string.isRequired,
   signConfigs: PropTypes.objectOf(signConfigType).isRequired,
   setConfigs: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool.isRequired,
 };
 
 export default Viewer;

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -18,6 +18,7 @@ class ViewerApp extends Component {
       signConfigs: props.initialSignConfigs,
       currentTime: Date.now(),
       channel: null,
+      readOnly: props.readOnly,
     };
   }
 
@@ -85,7 +86,7 @@ class ViewerApp extends Component {
 
   render() {
     const {
-      signs, currentTime, line, signConfigs,
+      signs, currentTime, line, signConfigs, readOnly,
     } = this.state;
     return (
       <div className="viewer--main container">
@@ -117,6 +118,7 @@ class ViewerApp extends Component {
               setConfigs={this.setConfigs}
               currentTime={currentTime}
               line={line}
+              readOnly={readOnly}
             />
           )}
       </div>
@@ -127,6 +129,7 @@ class ViewerApp extends Component {
 ViewerApp.propTypes = {
   initialSigns: PropTypes.objectOf(signContentType).isRequired,
   initialSignConfigs: PropTypes.objectOf(signConfigType).isRequired,
+  readOnly: PropTypes.bool.isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.test.js
+++ b/assets/js/ViewerApp.test.js
@@ -40,10 +40,11 @@ test('Shows all signs for a line', () => {
   const currentTime = now + 2000;
   const line = 'Red';
   const initialSignConfigs = {};
+  const readOnly = false;
 
   const wrapper = mount(
     React.createElement(ViewerApp, {
-      initialSigns: signs, currentTime, line, initialSignConfigs,
+      initialSigns: signs, currentTime, line, initialSignConfigs, readOnly,
     }, null),
   );
 
@@ -62,10 +63,11 @@ test('Can enable/disable a sign', () => {
   const currentTime = now + 2000;
   const line = 'Red';
   const initialSignConfigs = { davis_southbound: { mode: 'auto' } };
+  const readOnly = false;
 
   const wrapper = mount(
     React.createElement(ViewerApp, {
-      initialSigns: signs, currentTime, line, initialSignConfigs,
+      initialSigns: signs, currentTime, line, initialSignConfigs, readOnly,
     }, null),
   );
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,7 +10,9 @@ import ViewerApp from './ViewerApp';
 
 const realtimeRoot = document.getElementById('viewer-root');
 if (realtimeRoot) {
-  const { initialSignsData: initialSigns, initialSignConfigs } = window;
-  const viewerApp = React.createElement(ViewerApp, { initialSigns, initialSignConfigs }, null);
+  const { initialSignsData: initialSigns, initialSignConfigs, readOnly } = window;
+  const viewerApp = React.createElement(ViewerApp, {
+    initialSigns, initialSignConfigs, readOnly,
+  }, null);
   ReactDOM.render(viewerApp, realtimeRoot);
 }

--- a/lib/signs_ui_web/auth_manager.ex
+++ b/lib/signs_ui_web/auth_manager.ex
@@ -2,8 +2,10 @@ defmodule SignsUiWeb.AuthManager do
   use Guardian, otp_app: :signs_ui
 
   @type t :: String.t()
+  @type access_level :: :none | :read_only | :admin
 
-  @signs_ui_group "signs-ui-admin"
+  @signs_ui_read_only_group "signs-ui-read-only"
+  @signs_ui_admin_group "signs-ui-admin"
 
   def subject_for_token(resource, _claims) do
     {:ok, resource}
@@ -15,12 +17,17 @@ defmodule SignsUiWeb.AuthManager do
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
-  @spec claims_grant_signs_access?(Guardian.Token.claims()) :: boolean()
-  def claims_grant_signs_access?(%{"groups" => groups}) do
-    not is_nil(groups) and @signs_ui_group in groups
+  @spec claims_access_level(Guardian.Token.claims()) :: access_level()
+  def claims_access_level(%{"groups" => groups}) do
+    cond do
+      is_nil(groups) -> :none
+      @signs_ui_read_only_group in groups -> :read_only
+      @signs_ui_admin_group in groups -> :admin
+      true -> :none
+    end
   end
 
-  def claims_grant_signs_access?(_claims) do
-    false
+  def claims_access_level(_claims) do
+    :none
   end
 end

--- a/lib/signs_ui_web/channels/signs_channel.ex
+++ b/lib/signs_ui_web/channels/signs_channel.ex
@@ -9,25 +9,30 @@ defmodule SignsUiWeb.SignsChannel do
 
   @spec handle_in(String.t(), %{Sign.id() => map()}, any()) :: {:noreply, Phoenix.Socket.t()}
   def handle_in("changeSigns", changes, socket) do
-    if socket_authenticated?(socket) do
-      new_signs = Map.new(changes, fn {id, config} -> {id, Sign.from_config(id, config)} end)
+    case socket_access_level(socket) do
+      :admin ->
+        new_signs = Map.new(changes, fn {id, config} -> {id, Sign.from_config(id, config)} end)
 
-      {:ok, _new_state} = SignsUi.Config.State.update_some(new_signs)
+        {:ok, _new_state} = SignsUi.Config.State.update_some(new_signs)
 
-      username = Guardian.Phoenix.Socket.current_resource(socket)
+        username = Guardian.Phoenix.Socket.current_resource(socket)
 
-      Logger.info("sign_changed: user=#{username} changes=#{inspect(changes)}")
+        Logger.info("sign_changed: user=#{username} changes=#{inspect(changes)}")
 
-      {:noreply, socket}
-    else
-      {:stop, :normal, send_auth_expired_message(socket)}
+        {:noreply, socket}
+
+      :read_only ->
+        {:noreply, socket}
+
+      :none ->
+        {:stop, :normal, send_auth_expired_message(socket)}
     end
   end
 
   intercept(["sign_update"])
 
   def handle_out("sign_update", msg, socket) do
-    if socket_authenticated?(socket) do
+    if socket_access_level(socket) in [:admin, :read_only] do
       push(socket, "sign_update", msg)
       {:noreply, socket}
     else
@@ -35,16 +40,14 @@ defmodule SignsUiWeb.SignsChannel do
     end
   end
 
-  @spec socket_authenticated?(Phoenix.Socket.t()) :: boolean()
-  defp socket_authenticated?(socket) do
+  @spec socket_access_level(Phoenix.Socket.t()) :: SignsUiWeb.AuthManager.access_level()
+  defp socket_access_level(socket) do
     claims = Guardian.Phoenix.Socket.current_claims(socket)
     token = Guardian.Phoenix.Socket.current_token(socket)
 
-    with {:ok, claims} <- SignsUiWeb.AuthManager.decode_and_verify(token, claims),
-         true <- SignsUiWeb.AuthManager.claims_access_level(claims) == :admin do
-      true
-    else
-      _ -> false
+    case SignsUiWeb.AuthManager.decode_and_verify(token, claims) do
+      {:ok, claims} -> SignsUiWeb.AuthManager.claims_access_level(claims)
+      _ -> :none
     end
   end
 

--- a/lib/signs_ui_web/channels/signs_channel.ex
+++ b/lib/signs_ui_web/channels/signs_channel.ex
@@ -41,7 +41,7 @@ defmodule SignsUiWeb.SignsChannel do
     token = Guardian.Phoenix.Socket.current_token(socket)
 
     with {:ok, claims} <- SignsUiWeb.AuthManager.decode_and_verify(token, claims),
-         true <- SignsUiWeb.AuthManager.claims_grant_signs_access?(claims) do
+         true <- SignsUiWeb.AuthManager.claims_access_level(claims) == :admin do
       true
     else
       _ -> false

--- a/lib/signs_ui_web/ensure_signs_ui_group.ex
+++ b/lib/signs_ui_web/ensure_signs_ui_group.ex
@@ -6,7 +6,7 @@ defmodule SignsUiWeb.EnsureSignsUiGroup do
   def call(conn, _opts) do
     claims = Guardian.Plug.current_claims(conn)
 
-    if SignsUiWeb.AuthManager.claims_grant_signs_access?(claims) do
+    if SignsUiWeb.AuthManager.claims_access_level(claims) == :admin do
       conn
     else
       conn

--- a/lib/signs_ui_web/ensure_signs_ui_group.ex
+++ b/lib/signs_ui_web/ensure_signs_ui_group.ex
@@ -6,7 +6,7 @@ defmodule SignsUiWeb.EnsureSignsUiGroup do
   def call(conn, _opts) do
     claims = Guardian.Plug.current_claims(conn)
 
-    if SignsUiWeb.AuthManager.claims_access_level(claims) == :admin do
+    if SignsUiWeb.AuthManager.claims_access_level(claims) in [:read_only, :admin] do
       conn
     else
       conn

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -53,7 +53,8 @@ defmodule SignsUiWeb.Router do
       :auth,
       :ensure_auth,
       :ensure_signs_ui_group,
-      :put_user_token
+      :put_user_token,
+      :put_read_only_view
     ])
 
     get("/viewer", MessagesController, :index)
@@ -76,6 +77,16 @@ defmodule SignsUiWeb.Router do
   defp put_user_token(conn, _) do
     token = Guardian.Plug.current_token(conn)
     assign(conn, :user_token, token)
+  end
+
+  defp put_read_only_view(conn, _) do
+    if conn
+       |> Guardian.Plug.current_claims()
+       |> SignsUiWeb.AuthManager.claims_access_level() == :read_only do
+      assign(conn, :read_only_view, true)
+    else
+      conn
+    end
   end
 
   defp api_auth(conn, _) do

--- a/lib/signs_ui_web/templates/layout/app.html.eex
+++ b/lib/signs_ui_web/templates/layout/app.html.eex
@@ -24,6 +24,11 @@
 
     </div> <!-- /container -->
     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
+    <%= if assigns[:read_only_view] do %>
+      <script>window.readOnly = true;</script>
+    <% else %>
+      <script>window.readOnly = false;</script>
+    <% end %>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/test/signs_ui_web/auth_manager_test.exs
+++ b/test/signs_ui_web/auth_manager_test.exs
@@ -17,4 +17,30 @@ defmodule SignsUiWeb.AuthManagerTest do
       assert {:error, :invalid_claims} == SignsUiWeb.AuthManager.resource_from_claims(%{})
     end
   end
+
+  describe "claims_access_level" do
+    test "works with no group information" do
+      assert SignsUiWeb.AuthManager.claims_access_level(%{}) == :none
+    end
+
+    test "works with nil groups" do
+      assert SignsUiWeb.AuthManager.claims_access_level(%{"groups" => nil}) == :none
+    end
+
+    test "read-only access" do
+      assert SignsUiWeb.AuthManager.claims_access_level(%{"groups" => ["signs-ui-read-only"]}) ==
+               :read_only
+    end
+
+    test "admin access" do
+      assert SignsUiWeb.AuthManager.claims_access_level(%{"groups" => ["signs-ui-admin"]}) ==
+               :admin
+    end
+
+    test "read-only access when both groups present" do
+      assert SignsUiWeb.AuthManager.claims_access_level(%{
+               "groups" => ["signs-ui-admin", "signs-ui-read-only"]
+             }) == :read_only
+    end
+  end
 end

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -27,6 +27,24 @@ defmodule SignsUiWeb.MessagesControllerTest do
 
       assert {:ok, _claims} = Guardian.decode_and_verify(SignsUiWeb.AuthManager, token)
     end
+
+    @tag :authenticated
+    test "doesn't include read-only view when user has admin access", %{conn: conn} do
+      conn = get(conn, messages_path(conn, :index))
+
+      response = html_response(conn, 200)
+
+      assert response =~ "readOnly = false"
+    end
+
+    @tag :authenticated_read_only
+    test "includes read-only view when user doesn't have admin access", %{conn: conn} do
+      conn = get(conn, messages_path(conn, :index))
+
+      response = html_response(conn, 200)
+
+      assert response =~ "readOnly = true"
+    end
   end
 
   describe "create messages" do

--- a/test/signs_ui_web/controllers/unauthorized_controller_test.exs
+++ b/test/signs_ui_web/controllers/unauthorized_controller_test.exs
@@ -2,7 +2,7 @@ defmodule SignsUiWeb.UnauthorizedControllerTest do
   use SignsUiWeb.ConnCase
 
   describe "index/2" do
-    test "renders response" do
+    test "renders response", %{conn: conn} do
       conn = get(conn, unauthorized_path(conn, :index))
 
       assert html_response(conn, 403) =~ "not authorized"

--- a/test/signs_ui_web/ensure_signs_ui_group_test.exs
+++ b/test/signs_ui_web/ensure_signs_ui_group_test.exs
@@ -13,6 +13,11 @@ defmodule SignsUiWeb.EnsureSignsUiGroupTest do
       assert conn == SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
     end
 
+    @tag :authenticated_read_only
+    test "does nothing when user is in the signs-ui-read-only group", %{conn: conn} do
+      assert conn == SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
+    end
+
     test "redirects when user is not in the signs-ui-admin group", %{conn: conn} do
       conn = SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
 

--- a/test/signs_ui_web/ensure_signs_ui_group_test.exs
+++ b/test/signs_ui_web/ensure_signs_ui_group_test.exs
@@ -13,7 +13,7 @@ defmodule SignsUiWeb.EnsureSignsUiGroupTest do
       assert conn == SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
     end
 
-    test "redirects when user is not in the signs-ui-admin group" do
+    test "redirects when user is not in the signs-ui-admin group", %{conn: conn} do
       conn = SignsUiWeb.EnsureSignsUiGroup.call(conn, [])
 
       response = html_response(conn, 302)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -29,13 +29,20 @@ defmodule SignsUiWeb.ConnCase do
 
   setup tags do
     {conn, user} =
-      if tags[:authenticated] do
+      if tags[:authenticated] || tags[:authenticated_read_only] do
         user = "test_user"
+
+        groups =
+          if tags[:authenticated] do
+            ["signs-ui-admin"]
+          else
+            ["signs-ui-read-only"]
+          end
 
         conn =
           Phoenix.ConnTest.build_conn()
           |> init_test_session(%{})
-          |> Guardian.Plug.sign_in(SignsUiWeb.AuthManager, user, %{groups: ["signs-ui-admin"]})
+          |> Guardian.Plug.sign_in(SignsUiWeb.AuthManager, user, %{groups: groups})
 
         {conn, user}
       else


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁️ Read-only type of account for Signs UI](https://app.asana.com/0/584764604969369/1124354947303964/f)

This one should be easy to review commit-by-commit even if the whole thing taken together seems big.

Added logic to handle the read-only view on the back-end. Made sure channel code checks that the user has admin privileges before accepting any changes, and put information on the page indicating whether or not to render read-only view. On the front-end, added a `readOnly` proptype to most of the React elements, and updated them to render accordingly.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
