### PR TITLE
Add headway option to drop-down

### DIFF
--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -160,6 +160,9 @@ class Sign extends Component {
                     <option value="auto">
                       Auto
                     </option>
+                    <option value="headway">
+                      Headways
+                    </option>
                     <option value="static_text">
                       Custom
                     </option>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁️ Allow PIOs to force signs into headway mode](https://app.asana.com/0/584764604969369/915693484951243/f)

Past us was smart and made Signs UI already handle the headway option, it just wasn't available in the dropdown yet.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
