### PR TITLE
Handle refresh tokens

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,8 @@ config :signs_ui, SignsUiWeb.Endpoint,
 # Internal configuration
 config :signs_ui,
   signs_external_post_mod: SignsUi.Config.S3,
-  aws_requestor: ExAws
+  aws_requestor: ExAws,
+  refresh_token_store: SignsUi.RefreshTokenStore
 
 # HTTP config
 config :signs_ui, :redirect_http?, false

--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -10,7 +10,8 @@ defmodule SignsUi.Application do
       SignsUiWeb.Endpoint,
       SignsUi.Config.State,
       {SignsUi.Signs.State, [name: SignsUi.Signs.State]},
-      SignsUi.Config.Expiration
+      SignsUi.Config.Expiration,
+      SignsUi.RefreshTokenStore
     ]
 
     opts = [strategy: :one_for_one, name: SignsUi.Supervisor]

--- a/lib/signs_ui/refresh_token_store.ex
+++ b/lib/signs_ui/refresh_token_store.ex
@@ -1,0 +1,34 @@
+defmodule SignsUi.RefreshTokenStore do
+  @moduledoc """
+  Stores refresh tokens for user authentication. Currently these are
+  just kept in memory because there's only one instance of the
+  application running and deploys / restarts are rare, but if need be
+  the data could be moved into persistent storage in the future.
+  """
+
+  use Agent
+
+  @type state :: %{
+          String.t() => String.t()
+        }
+
+  def start_link(opts \\ []) do
+    name = opts[:name] || __MODULE__
+    Agent.start_link(fn -> %{} end, name: name)
+  end
+
+  @spec put_refresh_token(GenServer.server(), String.t(), String.t()) :: :ok
+  def put_refresh_token(pid \\ __MODULE__, username, refresh_token) do
+    Agent.update(pid, &Map.put(&1, username, refresh_token))
+  end
+
+  @spec get_refresh_token(GenServer.server(), String.t()) :: String.t() | nil
+  def get_refresh_token(pid \\ __MODULE__, username) do
+    Agent.get(pid, &Map.get(&1, username))
+  end
+
+  @spec clear_refresh_token(GenServer.server(), String.t()) :: :ok
+  def clear_refresh_token(pid \\ __MODULE__, username) do
+    Agent.update(pid, &Map.delete(&1, username))
+  end
+end

--- a/lib/signs_ui_web/auth_manager/error_handler.ex
+++ b/lib/signs_ui_web/auth_manager/error_handler.ex
@@ -5,13 +5,16 @@ defmodule SignsUiWeb.AuthManager.ErrorHandler do
   def auth_error(conn, {_type, _reason}, _opts) do
     refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
 
-    refresh_token =
+    username =
       conn
       |> Plug.Conn.fetch_session()
       |> Plug.Conn.get_session(:signs_ui_username)
-      |> refresh_token_store.get_refresh_token()
+
+    refresh_token = refresh_token_store.get_refresh_token(username)
 
     if refresh_token do
+      refresh_token_store.clear_refresh_token(username)
+
       Phoenix.Controller.redirect(
         conn,
         to:

--- a/lib/signs_ui_web/auth_manager/error_handler.ex
+++ b/lib/signs_ui_web/auth_manager/error_handler.ex
@@ -3,9 +3,27 @@ defmodule SignsUiWeb.AuthManager.ErrorHandler do
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_type, _reason}, _opts) do
-    conn
-    |> Phoenix.Controller.redirect(
-      to: SignsUiWeb.Router.Helpers.auth_path(conn, :request, "cognito")
-    )
+    refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
+
+    refresh_token =
+      conn
+      |> Plug.Conn.fetch_session()
+      |> Plug.Conn.get_session(:signs_ui_username)
+      |> refresh_token_store.get_refresh_token()
+
+    if refresh_token do
+      Phoenix.Controller.redirect(
+        conn,
+        to:
+          SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito", %{
+            "refresh_token" => refresh_token
+          })
+      )
+    else
+      Phoenix.Controller.redirect(
+        conn,
+        to: SignsUiWeb.Router.Helpers.auth_path(conn, :request, "cognito")
+      )
+    end
   end
 end

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -26,7 +26,17 @@ defmodule SignsUiWeb.AuthController do
     |> redirect(to: SignsUiWeb.Router.Helpers.messages_path(conn, :index))
   end
 
-  def callback(%{assigns: %{ueberauth_failure: _failure}} = conn, _params) do
-    send_resp(conn, 403, "unauthenticated")
+  def callback(
+        %{assigns: %{ueberauth_failure: %Ueberauth.Failure{errors: errors}}} = conn,
+        _params
+      ) do
+    if Enum.any?(errors, fn e -> e.message_key == "refresh_token_failure" end) do
+      Phoenix.Controller.redirect(
+        conn,
+        to: SignsUiWeb.Router.Helpers.auth_path(conn, :request, "cognito")
+      )
+    else
+      send_resp(conn, 403, "unauthenticated")
+    end
   end
 end

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -22,6 +22,7 @@ defmodule SignsUiWeb.AuthController do
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )
+    |> Plug.Conn.put_session(:signs_ui_username, username)
     |> redirect(to: SignsUiWeb.Router.Helpers.messages_path(conn, :index))
   end
 

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -10,6 +10,11 @@ defmodule SignsUiWeb.AuthController do
 
     current_time = System.system_time(:second)
 
+    if credentials.refresh_token do
+      refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
+      refresh_token_store.put_refresh_token(username, credentials.refresh_token)
+    end
+
     conn
     |> Guardian.Plug.sign_in(
       SignsUiWeb.AuthManager,

--- a/mix.lock
+++ b/mix.lock
@@ -36,6 +36,6 @@
   "timex": {:hex, :timex, "3.3.0", "e0695aa0ddb37d460d93a2db34d332c2c95a40c27edf22fbfea22eb8910a9c8d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.17", "50793e3d85af49736701da1a040c415c97dc1caf6464112fd9bd18f425d3053b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "ueberauth": {:hex, :ueberauth, "0.6.1", "9e90d3337dddf38b1ca2753aca9b1e53d8a52b890191cdc55240247c89230412", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
-  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "7e4a9bc7a4a2c3cd8f45f08b20125c26b982d8bf", []},
+  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "c97f77c5ec3e6ee3a7c7a1cf309fc3c9bc8d200e", []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -36,6 +36,6 @@
   "timex": {:hex, :timex, "3.3.0", "e0695aa0ddb37d460d93a2db34d332c2c95a40c27edf22fbfea22eb8910a9c8d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.17", "50793e3d85af49736701da1a040c415c97dc1caf6464112fd9bd18f425d3053b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "ueberauth": {:hex, :ueberauth, "0.6.1", "9e90d3337dddf38b1ca2753aca9b1e53d8a52b890191cdc55240247c89230412", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
-  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "99817377cd3f4d33613ad5ffb73e371e767f7712", []},
+  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "7e4a9bc7a4a2c3cd8f45f08b20125c26b982d8bf", []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/test/signs_ui/refresh_token_store_test.exs
+++ b/test/signs_ui/refresh_token_store_test.exs
@@ -1,0 +1,44 @@
+defmodule SignsUi.RefreshTokenStoreTest do
+  use ExUnit.Case, async: true
+
+  describe "start_link/1" do
+    test "starts up and lives" do
+      {:ok, pid} = SignsUi.RefreshTokenStore.start_link(name: :refresh_token_start_link_test)
+
+      Process.sleep(100)
+
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "put_refresh_token/3" do
+    test "stores the token in the state" do
+      {:ok, pid} = SignsUi.RefreshTokenStore.start_link(name: :refresh_token_put_test)
+
+      SignsUi.RefreshTokenStore.put_refresh_token(pid, "foo@mbta.com", "bar")
+
+      assert :sys.get_state(pid) == %{"foo@mbta.com" => "bar"}
+    end
+  end
+
+  describe "get_refresh_token/2" do
+    test "gets the token from the state" do
+      {:ok, pid} = SignsUi.RefreshTokenStore.start_link(name: :refresh_token_get_test)
+
+      :sys.replace_state(pid, fn _state -> %{"foo@mbta.com" => "bar"} end)
+
+      assert SignsUi.RefreshTokenStore.get_refresh_token(pid, "foo@mbta.com") == "bar"
+    end
+  end
+
+  describe "clear_refresh_token/2" do
+    test "clears the token from the state" do
+      {:ok, pid} = SignsUi.RefreshTokenStore.start_link(name: :refresh_token_clear_test)
+
+      :sys.replace_state(pid, fn _state -> %{"foo@mbta.com" => "bar"} end)
+
+      assert SignsUi.RefreshTokenStore.clear_refresh_token(pid, "foo@mbta.com") == :ok
+      assert :sys.get_state(pid) == %{}
+    end
+  end
+end

--- a/test/signs_ui_web/auth_manager/error_handler_test.exs
+++ b/test/signs_ui_web/auth_manager/error_handler_test.exs
@@ -1,11 +1,37 @@
 defmodule SignsUiWeb.AuthManager.ErrorHandlerTest do
   use SignsUiWeb.ConnCase
+  use Plug.Test
+  import Test.Support.Helpers
+
+  setup do
+    reassign_env(
+      :refresh_token_store,
+      SignsUiWeb.AuthManager.ErrorHandlerTest.FakeRefreshTokenStore
+    )
+  end
 
   describe "auth_error/3" do
-    test "redirects to Cognito login", %{conn: conn} do
-      conn = SignsUiWeb.AuthManager.ErrorHandler.auth_error(conn, {:some_type, :reason}, [])
+    test "redirects to Cognito login if there's no refresh key", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{signs_ui_username: "foo@mbta.com"})
+        |> SignsUiWeb.AuthManager.ErrorHandler.auth_error({:some_type, :reason}, [])
 
-      assert html_response(conn, 302) =~ "/auth/cognito"
+      assert html_response(conn, 302) =~ "\"/auth/cognito\""
     end
+
+    test "redirects to Cognito callback if there is a refresh key", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{signs_ui_username: "bar@mbta.com"})
+        |> SignsUiWeb.AuthManager.ErrorHandler.auth_error({:some_type, :reason}, [])
+
+      assert html_response(conn, 302) =~ "\"/auth/cognito/callback\?"
+    end
+  end
+
+  defmodule FakeRefreshTokenStore do
+    def get_refresh_token("foo@mbta.com"), do: nil
+    def get_refresh_token("bar@mbta.com"), do: "abcde"
   end
 end

--- a/test/signs_ui_web/auth_manager/error_handler_test.exs
+++ b/test/signs_ui_web/auth_manager/error_handler_test.exs
@@ -33,5 +33,7 @@ defmodule SignsUiWeb.AuthManager.ErrorHandlerTest do
   defmodule FakeRefreshTokenStore do
     def get_refresh_token("foo@mbta.com"), do: nil
     def get_refresh_token("bar@mbta.com"), do: "abcde"
+
+    def clear_refresh_token(_username), do: :ok
   end
 end

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -1,27 +1,37 @@
 defmodule SignsUiWeb.AuthControllerTest do
   use SignsUiWeb.ConnCase
+  import Test.Support.Helpers
+  require Logger
+  import ExUnit.CaptureLog
 
   describe "callback" do
-    test "redirects on success", %{conn: conn} do
+    test "redirects on success and saves refresh token", %{conn: conn} do
+      reassign_env(:refresh_token_store, SignsUiWeb.AuthControllerTest.FakeRefreshTokenStore)
       current_time = System.system_time(:second)
 
       auth = %Ueberauth.Auth{
         uid: "foo@mbta.com",
         credentials: %Ueberauth.Auth.Credentials{
           expires_at: current_time + 1_000,
+          refresh_token: "bar",
           other: %{groups: ["test1"]}
         }
       }
 
-      conn =
-        conn
-        |> assign(:ueberauth_auth, auth)
-        |> get(SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
+      log =
+        capture_log([level: :info], fn ->
+          conn =
+            conn
+            |> assign(:ueberauth_auth, auth)
+            |> get(SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
 
-      response = html_response(conn, 302)
+          response = html_response(conn, 302)
 
-      assert response =~ SignsUiWeb.Router.Helpers.messages_path(conn, :index)
-      assert Guardian.Plug.current_claims(conn)["groups"] == ["test1"]
+          assert response =~ SignsUiWeb.Router.Helpers.messages_path(conn, :index)
+          assert Guardian.Plug.current_claims(conn)["groups"] == ["test1"]
+        end)
+
+      assert log =~ "stored_refresh_token username=foo@mbta.com refresh_token=bar"
     end
 
     test "handles failure", %{conn: conn} do
@@ -43,6 +53,12 @@ defmodule SignsUiWeb.AuthControllerTest do
       response = response(conn, 302)
 
       assert response =~ SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito")
+    end
+  end
+
+  defmodule FakeRefreshTokenStore do
+    def put_refresh_token(username, refresh_token) do
+      Logger.info("stored_refresh_token username=#{username} refresh_token=#{refresh_token}")
     end
   end
 end

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -34,7 +34,7 @@ defmodule SignsUiWeb.AuthControllerTest do
       assert log =~ "stored_refresh_token username=foo@mbta.com refresh_token=bar"
     end
 
-    test "handles failure", %{conn: conn} do
+    test "handles generic failure", %{conn: conn} do
       conn =
         conn
         |> assign(:ueberauth_failure, %Ueberauth.Failure{})
@@ -43,6 +43,19 @@ defmodule SignsUiWeb.AuthControllerTest do
       response = response(conn, 403)
 
       assert response =~ "unauthenticated"
+    end
+
+    test "handles failure to use refresh token", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:ueberauth_failure, %Ueberauth.Failure{
+          errors: [%Ueberauth.Failure.Error{message_key: "refresh_token_failure"}]
+        })
+        |> get(SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
+
+      response = response(conn, 302)
+
+      assert response =~ SignsUiWeb.Router.Helpers.auth_path(conn, :request, "cognito")
     end
   end
 

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,0 +1,24 @@
+defmodule Test.Support.Helpers do
+  @moduledoc "Helpers! For Tests!"
+
+  defmacro reassign_env(var) do
+    quote do
+      old_value = Application.get_env(:signs_ui, unquote(var))
+
+      on_exit(fn ->
+        Application.put_env(:signs_ui, unquote(var), old_value)
+      end)
+    end
+  end
+
+  defmacro reassign_env(var, value) do
+    quote do
+      old_value = Application.get_env(:signs_ui, unquote(var))
+      Application.put_env(:signs_ui, unquote(var), unquote(value))
+
+      on_exit(fn ->
+        Application.put_env(:signs_ui, unquote(var), old_value)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁️ handle token refreshes](https://app.asana.com/0/584764604969369/1123278898060154/f)

1. Created a new GenServer that stores user refresh tokens on the backend. Currently it's just a map in-memory but could use some sort of persistent storage in the future.
2. Store the username in the session, since the Guardian functions don't return any information once the token is expired and we need the username to lookup the refresh token.
3. Upon using the refresh token, clear it from the GenServer state. This is to prevent a loop if it turns out that the token is expired.
4. When we get a failure from Ueberauth, only return a 403 if we weren't trying to use the refresh token. If it was a failure with the refresh token, instead redirect to the normal start of the workflow to allow the user to log back in.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
