### PR TITLE
Clear refresh token when it fails to work, not before using it

### DIFF
--- a/lib/signs_ui_web/auth_manager/error_handler.ex
+++ b/lib/signs_ui_web/auth_manager/error_handler.ex
@@ -5,16 +5,13 @@ defmodule SignsUiWeb.AuthManager.ErrorHandler do
   def auth_error(conn, {_type, _reason}, _opts) do
     refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
 
-    username =
+    refresh_token =
       conn
       |> Plug.Conn.fetch_session()
       |> Plug.Conn.get_session(:signs_ui_username)
-
-    refresh_token = refresh_token_store.get_refresh_token(username)
+      |> refresh_token_store.get_refresh_token()
 
     if refresh_token do
-      refresh_token_store.clear_refresh_token(username)
-
       Phoenix.Controller.redirect(
         conn,
         to:

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -31,6 +31,13 @@ defmodule SignsUiWeb.AuthController do
         _params
       ) do
     if Enum.any?(errors, fn e -> e.message_key == "refresh_token_failure" end) do
+      refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
+
+      conn
+      |> Plug.Conn.fetch_session()
+      |> Plug.Conn.get_session(:signs_ui_username)
+      |> refresh_token_store.clear_refresh_token()
+
       Phoenix.Controller.redirect(
         conn,
         to: SignsUiWeb.Router.Helpers.auth_path(conn, :request, "cognito")

--- a/test/signs_ui_web/auth_manager/error_handler_test.exs
+++ b/test/signs_ui_web/auth_manager/error_handler_test.exs
@@ -33,7 +33,5 @@ defmodule SignsUiWeb.AuthManager.ErrorHandlerTest do
   defmodule FakeRefreshTokenStore do
     def get_refresh_token("foo@mbta.com"), do: nil
     def get_refresh_token("bar@mbta.com"), do: "abcde"
-
-    def clear_refresh_token(_username), do: :ok
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Followup to [👁️ handle token refreshes](https://app.asana.com/0/584764604969369/1123278898060154/f)

It looks like using the refresh token, we don't get the refresh token sent back from Cognito. Therefore one use of the refresh token works, but then it's no longer in the state. We should only clear the refresh token if it actually fails to work.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
