### PR TITLE
show the mode text in read only mode

### DIFF
--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -146,8 +146,8 @@ class Sign extends Component {
             </span>
             {readOnly
               && (
-                <div class="viewer--mode-text">
-                {signConfig.mode}
+                <div className="viewer--mode-text">
+                  {signConfig.mode}
                 </div>
               )
             }

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -144,6 +144,13 @@ class Sign extends Component {
             <span style={fontSize(signId)}>
               {signId}
             </span>
+            {readOnly
+              && (
+                <div class="viewer--mode-text">
+                {signConfig.mode}
+                </div>
+              )
+            }
             {!readOnly
               && (
                 <div>

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -37,6 +37,15 @@ function makeConfig(mode) {
   return { mode: 'off', expires: null };
 }
 
+function displayName(mode) {
+  switch(mode) {
+    case 'static_text':
+      return "Custom";
+    default:
+      return mode.charAt(0).toUpperCase() + mode.slice(1);
+  }
+}
+
 function isValidText(text) {
   return !(/[^a-zA-Z0-9,/!@' +]/.test(text));
 }
@@ -147,7 +156,7 @@ class Sign extends Component {
             {readOnly
               && (
                 <div className="viewer--mode-text">
-                  {signConfig.mode}
+                  {displayName(signConfig.mode)}
                 </div>
               )
             }

--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -38,9 +38,9 @@ function makeConfig(mode) {
 }
 
 function displayName(mode) {
-  switch(mode) {
+  switch (mode) {
     case 'static_text':
-      return "Custom";
+      return 'Custom';
     default:
       return mode.charAt(0).toUpperCase() + mode.slice(1);
   }

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -110,7 +110,7 @@ test('shows the mode the sign is in in read-only mode', () => {
     }, null),
   );
 
-  expect(wrapper.html()).toMatch('auto');
+  expect(wrapper.html()).toMatch('Auto');
 });
 
 test('does show select when not in read-only mode', () => {

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -85,6 +85,34 @@ test('does not show select in read-only mode', () => {
   expect(wrapper.html()).not.toMatch('select');
 });
 
+test('shows the mode the sign is in in read-only mode', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig = { mode: 'auto' };
+  const signContent = signContentWithExpirations(fresh, fresh);
+  const setConfigs = () => { };
+  const realtimeId = 'id';
+  const readOnly = true;
+
+  const wrapper = mount(
+    React.createElement(Sign, {
+      signId,
+      signContent,
+      currentTime,
+      line,
+      signConfig,
+      setConfigs,
+      realtimeId,
+      readOnly,
+    }, null),
+  );
+
+  expect(wrapper.html()).toMatch('auto');
+});
+
 test('does show select when not in read-only mode', () => {
   const now = new Date('2019-01-15T20:15:00Z').valueOf();
   const fresh = new Date(now + 5000).toLocaleString();


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁️ On signs UI, show mode of sign even in read-only view](https://app.asana.com/0/584764604969369/1135057643482290)

i didnt end up moving the text to the bottom because the css to make that happen seemed a little bad.  for whatever reason vertical-align: bottom wasnt working and i didnt want to wrestle with it for hours.
#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
