### PR TITLE
chore: use ueberauth_cognito from Hex rather than GitHub

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule SignsUi.Mixfile do
       {:timex, "~> 3.1"},
       {:guardian, "~> 1.0"},
       {:ueberauth, "~> 0.1"},
-      {:ueberauth_cognito, git: "https://github.com/mbta/ueberauth_cognito.git"},
+      {:ueberauth_cognito, "~> 0.1"},
       {:nimble_parsec, "~> 0.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -37,6 +37,6 @@
   "timex": {:hex, :timex, "3.6.1", "efdf56d0e67a6b956cc57774353b0329c8ab7726766a11547e529357ffdc1d56", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5 or ~> 1.0.0", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "1.0.2", "6c4242c93332b8590a7979eaf5e11e77d971e579805c44931207e32aa6ad3db1", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "ueberauth": {:hex, :ueberauth, "0.6.1", "9e90d3337dddf38b1ca2753aca9b1e53d8a52b890191cdc55240247c89230412", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
-  "ueberauth_cognito": {:git, "https://github.com/mbta/ueberauth_cognito.git", "c97f77c5ec3e6ee3a7c7a1cf309fc3c9bc8d200e", []},
+  "ueberauth_cognito": {:hex, :ueberauth_cognito, "0.1.0", "36fac39cb3e4f31fb8c82352542b7d3ac7e349cf370591244c5f4b384a632450", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:jose, "~> 1.0", [hex: :jose, repo: "hexpm", optional: false]}, {:ueberauth, "~> 0.6", [hex: :ueberauth, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Make signs_ui use ueberauth_cognito from Hex](https://app.asana.com/0/584764604969369/1154769040549705/f)

🎉 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
