### PR TITLE
feat: Log error information to help debug auth issues

### DIFF
--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -1,6 +1,7 @@
 defmodule SignsUiWeb.AuthController do
   use SignsUiWeb, :controller
   plug(Ueberauth)
+  require Logger
 
   @spec callback(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
@@ -30,6 +31,8 @@ defmodule SignsUiWeb.AuthController do
         %{assigns: %{ueberauth_failure: %Ueberauth.Failure{errors: errors}}} = conn,
         _params
       ) do
+    Logger.error("ueberauth_failure #{inspect(errors)}")
+
     if Enum.any?(errors, fn e -> e.message_key == "refresh_token_failure" end) do
       refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
 

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -36,14 +36,17 @@ defmodule SignsUiWeb.AuthControllerTest do
     end
 
     test "handles generic failure", %{conn: conn} do
-      conn =
-        conn
-        |> assign(:ueberauth_failure, %Ueberauth.Failure{})
-        |> get(SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
+      log =
+        capture_log([level: :error], fn ->
+          conn =
+            conn
+            |> assign(:ueberauth_failure, %Ueberauth.Failure{})
+            |> get(SignsUiWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
 
-      response = response(conn, 403)
+          assert response(conn, 403) =~ "unauthenticated"
+        end)
 
-      assert response =~ "unauthenticated"
+      assert log =~ "ueberauth_failure"
     end
 
     test "handles failure to use refresh token", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Log signs-ui auth failure info](https://app.asana.com/0/584764604969369/1155541495551777)

From the user report, he's seeing "unauthenticated", which from the code appears to be right here. I added some logging to help see what's going on.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
