### PR TITLE
feat: Handle old config format and save new

### DIFF
--- a/lib/signs_ui/config/request.ex
+++ b/lib/signs_ui/config/request.ex
@@ -3,8 +3,9 @@ defmodule SignsUi.Config.Request do
   alias SignsUi.Config.S3
   alias SignsUi.Config.Sign
 
-  def get_signs() do
-    case S3.get_object() do
+  @spec get_signs({module(), atom(), []}) :: {:ok, %{String.t() => Sign.t()}} | {:error, any()}
+  def get_signs({mod, fun, args} \\ {S3, :get_object, []}) do
+    case apply(mod, fun, args) do
       {:ok, %{body: json}} ->
         parse(json)
 
@@ -14,11 +15,19 @@ defmodule SignsUi.Config.Request do
     end
   end
 
+  @spec parse(String.t()) :: {:ok, %{String.t() => Sign.t()}} | {:error, any()}
   defp parse(json) do
     case Jason.decode(json) do
       {:ok, response} ->
+        # To handle two formats of signs config:
+        # old: { "sign_id": { ... }, "sign_id2": { ... }}
+        # new: { "signs": { "sign_id" => { sign_config }, ...}}
+        sign_configs = Map.get(response, "signs", response)
+
         {:ok,
-         Map.new(response, fn {sign_id, config} -> {sign_id, Sign.from_json(sign_id, config)} end)}
+         Map.new(sign_configs, fn {sign_id, config} ->
+           {sign_id, Sign.from_json(sign_id, config)}
+         end)}
 
       {:error, reason} ->
         Logger.warn("Could not decode response: #{inspect(reason)}")

--- a/lib/signs_ui/config/signs.ex
+++ b/lib/signs_ui/config/signs.ex
@@ -3,6 +3,7 @@ defmodule SignsUi.Config.Signs do
 
   @spec format_signs_for_json(%{Sign.id() => Sign.t()}) :: map()
   def format_signs_for_json(signs) do
-    Map.new(signs, fn {sign_id, sign} -> {sign_id, Sign.to_json(sign)} end)
+    sign_configs = Map.new(signs, fn {sign_id, sign} -> {sign_id, Sign.to_json(sign)} end)
+    %{"signs" => sign_configs}
   end
 end

--- a/test/signs_ui/config/request_test.exs
+++ b/test/signs_ui/config/request_test.exs
@@ -1,0 +1,50 @@
+defmodule SignsUi.Config.RequestTest do
+  use ExUnit.Case, async: true
+
+  alias SignsUi.Config.Request
+  alias SignsUi.Config.Sign
+
+  defmodule OldFormat do
+    def get_object() do
+      data = %{
+        "sign_id" => %{"id" => "sign_id", "mode" => "auto"}
+      }
+
+      {:ok, %{body: Jason.encode!(data)}}
+    end
+  end
+
+  defmodule NewFormat do
+    def get_object() do
+      data = %{
+        "signs" => %{
+          "sign_id" => %{"id" => "sign_id", "mode" => "auto"}
+        }
+      }
+
+      {:ok, %{body: Jason.encode!(data)}}
+    end
+  end
+
+  describe "get_signs/1" do
+    test "works with old format" do
+      assert {:ok,
+              %{
+                "sign_id" => %Sign{
+                  id: "sign_id",
+                  config: %{mode: :auto}
+                }
+              }} = Request.get_signs({OldFormat, :get_object, []})
+    end
+
+    test "works with new format" do
+      assert {:ok,
+              %{
+                "sign_id" => %Sign{
+                  id: "sign_id",
+                  config: %{mode: :auto}
+                }
+              }} = Request.get_signs({NewFormat, :get_object, []})
+    end
+  end
+end

--- a/test/signs_ui/config/signs_test.exs
+++ b/test/signs_ui/config/signs_test.exs
@@ -12,9 +12,11 @@ defmodule SignsUi.Config.SignsTest do
   describe "format_signs_for_json/1" do
     test "puts all signs in json format" do
       expected = %{
-        "sign1" => %{"id" => "sign1", "mode" => "auto"},
-        "sign2" => %{"id" => "sign2", "mode" => "off", "expires" => nil},
-        "sign3" => %{"id" => "sign3", "mode" => "auto"}
+        "signs" => %{
+          "sign1" => %{"id" => "sign1", "mode" => "auto"},
+          "sign2" => %{"id" => "sign2", "mode" => "off", "expires" => nil},
+          "sign3" => %{"id" => "sign3", "mode" => "auto"}
+        }
       }
 
       assert format_signs_for_json(@signs) == expected


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [make rt-signs and sign-ui compatible with S3 configuration](https://app.asana.com/0/584764604969369/1166302267970957)

Reads the old format on start-up:

```json
{
  "sign_id1": { ... },
  "sign_id2": { ... }
}
```

and writes the new format:

```json
{
  "signs": {
    "sign_id1": { ... },
    "sign_id2": { ... }
  }
}
```

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
