### PR TITLE
Upgrade to Elixir 1.10.3 and Erlang 22.3.4.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 22.1.7
-elixir v1.9.1-otp-22
+erlang 22.3.4
+elixir v1.10.3-otp-22
 nodejs 13.1.0

--- a/lib/signs_ui_web/channels/user_socket.ex
+++ b/lib/signs_ui_web/channels/user_socket.ex
@@ -4,10 +4,6 @@ defmodule SignsUiWeb.UserSocket do
   ## Channels
   channel("signs:*", SignsUiWeb.SignsChannel)
 
-  ## Transports
-  transport(:websocket, Phoenix.Transports.WebSocket, check_origin: false)
-  # transport :longpoll, Phoenix.Transports.LongPoll
-
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
   # verification, you can put default assigns into

--- a/lib/signs_ui_web/endpoint.ex
+++ b/lib/signs_ui_web/endpoint.ex
@@ -1,7 +1,7 @@
 defmodule SignsUiWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :signs_ui
 
-  socket("/socket", SignsUiWeb.UserSocket)
+  socket("/socket", SignsUiWeb.UserSocket, websocket: [check_origin: false])
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/semaphore/setup.sh
+++ b/semaphore/setup.sh
@@ -1,8 +1,8 @@
 # Fail if any command fails
 set -e
 
-ELIXIR_VERSION=1.9.1
-ERLANG_VERSION=22.1.7
+ELIXIR_VERSION=1.10.3
+ERLANG_VERSION=22.3.4
 NODEJS_VERSION=13.1
 
 change-phantomjs-version 2.1.1


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Upgrades to Elixir 1.10.3 and Erlang 22.3.4. Since the `elixir:1.10.3` docker image builds on Erlang 22.3.4 already, I updated our Dockerfile to just build off that directly, rather than building off an erlang image and installing Elixir.

Also, a little commit to fix the compilation warning.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
