### PR TITLE
Allow users to log out

### DIFF
--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -20,6 +20,7 @@ class ViewerApp extends Component {
       currentTime: Date.now(),
       channel: null,
       readOnly: props.readOnly,
+      signOutPath: props.signOutPath,
     };
   }
 
@@ -104,29 +105,34 @@ class ViewerApp extends Component {
 
   render() {
     const {
-      signs, currentTime, line, signConfigs, readOnly, configuredHeadways,
+      signs, currentTime, line, signConfigs, readOnly, configuredHeadways, signOutPath,
     } = this.state;
     return (
       <div className="viewer--main container">
-        <div className="viewer--line-switcher">
-          <button type="button" id="blue-button" onClick={() => this.changeLine('Blue')}>
-            Blue
-          </button>
-          <button type="button" id="red-button" onClick={() => this.changeLine('Red')}>
-            Red
-          </button>
-          <button type="button" id="orange-button" onClick={() => this.changeLine('Orange')}>
-            Orange
-          </button>
-          <button type="button" id="green-button" onClick={() => this.changeLine('Green')}>
-            Green
-          </button>
-          <button type="button" id="mattapan-button" onClick={() => this.changeLine('Mattapan')}>
-            Mattapan
-          </button>
-          <button type="button" id="sl3-button" onClick={() => this.changeLine('SL3')}>
-            Silver Line 3
-          </button>
+        <div className="row">
+          <div className="viewer--line-switcher col-auto mr-auto">
+            <button type="button" id="blue-button" onClick={() => this.changeLine('Blue')}>
+              Blue
+            </button>
+            <button type="button" id="red-button" onClick={() => this.changeLine('Red')}>
+              Red
+            </button>
+            <button type="button" id="orange-button" onClick={() => this.changeLine('Orange')}>
+              Orange
+            </button>
+            <button type="button" id="green-button" onClick={() => this.changeLine('Green')}>
+              Green
+            </button>
+            <button type="button" id="mattapan-button" onClick={() => this.changeLine('Mattapan')}>
+              Mattapan
+            </button>
+            <button type="button" id="sl3-button" onClick={() => this.changeLine('SL3')}>
+              Silver Line 3
+            </button>
+          </div>
+          <div className="col-auto">
+            <a href={signOutPath} id="sign-out-link">sign out</a>
+          </div>
         </div>
         {line
           && (
@@ -151,6 +157,7 @@ ViewerApp.propTypes = {
   initialSignConfigs: PropTypes.objectOf(signConfigType).isRequired,
   initialConfiguredHeadways: PropTypes.objectOf(configuredHeadwayType).isRequired,
   readOnly: PropTypes.bool.isRequired,
+  signOutPath: PropTypes.string.isRequired,
 };
 
 export default ViewerApp;

--- a/assets/js/ViewerApp.test.js
+++ b/assets/js/ViewerApp.test.js
@@ -42,6 +42,7 @@ test('Shows all signs for a line', () => {
   const initialSignConfigs = {};
   const readOnly = false;
   const configuredHeadways = {};
+  const signOutPath = '/path';
 
   const wrapper = mount(
     React.createElement(ViewerApp, {
@@ -51,6 +52,7 @@ test('Shows all signs for a line', () => {
       line,
       initialSignConfigs,
       readOnly,
+      signOutPath,
     }, null),
   );
 
@@ -71,6 +73,7 @@ test('Can enable/disable a sign', () => {
   const initialSignConfigs = { davis_southbound: { mode: 'auto' } };
   const readOnly = false;
   const configuredHeadways = {};
+  const signOutPath = '/path';
 
   const wrapper = mount(
     React.createElement(ViewerApp, {
@@ -80,6 +83,7 @@ test('Can enable/disable a sign', () => {
       line,
       initialSignConfigs,
       readOnly,
+      signOutPath,
     }, null),
   );
 
@@ -87,4 +91,29 @@ test('Can enable/disable a sign', () => {
   expect(wrapper.find('#davis_southbound').props().value).toBe('auto');
   wrapper.find('#davis_southbound').simulate('change', { target: { value: 'off' } });
   expect(wrapper.find('#davis_southbound').props().value).toBe('off');
+});
+
+test('Shows sign out link', () => {
+  const now = Date.now();
+  const signs = someSignContent();
+  const currentTime = now + 2000;
+  const line = 'Red';
+  const initialSignConfigs = { davis_southbound: { mode: 'auto' } };
+  const readOnly = false;
+  const configuredHeadways = {};
+  const signOutPath = '/path';
+
+  const wrapper = mount(
+    React.createElement(ViewerApp, {
+      initialSigns: signs,
+      initialConfiguredHeadways: configuredHeadways,
+      currentTime,
+      line,
+      initialSignConfigs,
+      readOnly,
+      signOutPath,
+    }, null),
+  );
+
+  expect(wrapper.find('#sign-out-link').props().href).toBe('/path');
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -11,10 +11,14 @@ import ViewerApp from './ViewerApp';
 const realtimeRoot = document.getElementById('viewer-root');
 if (realtimeRoot) {
   const {
-    initialSignsData: initialSigns, initialSignConfigs, readOnly, initialConfiguredHeadways,
+    initialSignsData: initialSigns,
+    initialSignConfigs,
+    readOnly,
+    initialConfiguredHeadways,
+    signOutPath,
   } = window;
   const viewerApp = React.createElement(ViewerApp, {
-    initialSigns, initialSignConfigs, readOnly, initialConfiguredHeadways,
+    initialSigns, initialSignConfigs, readOnly, initialConfiguredHeadways, signOutPath,
   }, null);
   ReactDOM.render(viewerApp, realtimeRoot);
 }

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,7 +15,7 @@ use Mix.Config
 # which you typically run after static files are built.
 config :signs_ui, SignsUiWeb.Endpoint,
   load_from_system_env: true,
-  url: [host: "example.com", port: 80],
+  url: [host: "example.com", port: 443, scheme: "https"],
   secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE"),
   cache_static_manifest: "priv/static/cache_manifest.json"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,5 +12,9 @@ config :signs_ui,
   aws_requestor: SignsUi.Mock.AwsRequest,
   realtime_signs_api_key: "placeholder_key"
 
+config :ueberauth, Ueberauth.Strategy.Cognito,
+  auth_domain: "test_auth_domain",
+  client_id: "test_client_secret"
+
 # Print only warnings, errors, and info during test
 config :logger, level: :info

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -27,7 +27,7 @@ defmodule SignsUiWeb.MessagesController do
          Map.new(periods, fn {period_id, config} -> {period_id, Map.from_struct(config)} end)}
       end)
 
-    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout)
+    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito")
 
     render(conn, "index.html",
       signs: signs,

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -27,10 +27,13 @@ defmodule SignsUiWeb.MessagesController do
          Map.new(periods, fn {period_id, config} -> {period_id, Map.from_struct(config)} end)}
       end)
 
+    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout)
+
     render(conn, "index.html",
       signs: signs,
       sign_configs: sign_configs,
-      configured_headways: configured_headways
+      configured_headways: configured_headways,
+      sign_out_path: sign_out_path
     )
   end
 

--- a/lib/signs_ui_web/controllers/unauthorized_controller.ex
+++ b/lib/signs_ui_web/controllers/unauthorized_controller.ex
@@ -3,8 +3,10 @@ defmodule SignsUiWeb.UnauthorizedController do
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
+    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito")
+
     conn
     |> put_status(403)
-    |> render("index.html")
+    |> render("index.html", sign_out_path: sign_out_path)
   end
 end

--- a/lib/signs_ui_web/endpoint.ex
+++ b/lib/signs_ui_web/endpoint.ex
@@ -57,7 +57,15 @@ defmodule SignsUiWeb.Endpoint do
   def init(_key, config) do
     if config[:load_from_system_env] do
       port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
+
+      signs_ui_host =
+        System.get_env("SIGNS_UI_HOST") ||
+          raise "expected the SIGNS_UI_HOST environment variable to be set"
+
+      {:ok,
+       config
+       |> Keyword.put(:http, [:inet6, port: port])
+       |> put_in([:url, :host], signs_ui_host)}
     else
       {:ok, config}
     end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -35,6 +35,7 @@ defmodule SignsUiWeb.Router do
   scope "/auth", SignsUiWeb do
     pipe_through([:redirect_prod_http, :browser])
 
+    get("/logout", AuthController, :logout)
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
   end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -35,9 +35,9 @@ defmodule SignsUiWeb.Router do
   scope "/auth", SignsUiWeb do
     pipe_through([:redirect_prod_http, :browser])
 
-    get("/logout", AuthController, :logout)
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
+    get("/:provider/logout", AuthController, :logout)
   end
 
   scope "/", SignsUiWeb do

--- a/lib/signs_ui_web/templates/messages/index.html.eex
+++ b/lib/signs_ui_web/templates/messages/index.html.eex
@@ -3,3 +3,4 @@
 <script>window.initialSignsData = <%= raw(Jason.encode!(@signs)) %></script>
 <script>window.initialSignConfigs = <%= raw(Jason.encode!(@sign_configs)) %></script>
 <script>window.initialConfiguredHeadways = <%= raw(Jason.encode!(@configured_headways)) %></script>
+<script>window.signOutPath = "<%= @sign_out_path%>"</script>

--- a/lib/signs_ui_web/templates/unauthorized/index.html.eex
+++ b/lib/signs_ui_web/templates/unauthorized/index.html.eex
@@ -5,5 +5,5 @@ realtimeappsdl@mbta.com.
 </div>
 
 <div>
-    <%= link "sign out", to: SignsUiWeb.Router.Helpers.auth_path(@conn, :logout)%>
+    <%= link "sign out", to: @sign_out_path %>
 </div>

--- a/lib/signs_ui_web/templates/unauthorized/index.html.eex
+++ b/lib/signs_ui_web/templates/unauthorized/index.html.eex
@@ -1,3 +1,9 @@
+<div>
 You are not authorized to access the signs viewer. If you believe you
 should have access, please have your supervisor contact
 realtimeappsdl@mbta.com.
+</div>
+
+<div>
+    <%= link "sign out", to: SignsUiWeb.Router.Helpers.auth_path(@conn, :logout)%>
+</div>

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -102,7 +102,7 @@ defmodule SignsUiWeb.AuthControllerTest do
 
       log =
         capture_log([level: :info], fn ->
-          conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout))
+          conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito"))
 
           response = response(conn, 302)
 
@@ -130,7 +130,7 @@ defmodule SignsUiWeb.AuthControllerTest do
 
       Application.put_env(:ueberauth, Ueberauth.Strategy.Cognito, new_config)
 
-      conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout))
+      conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito"))
 
       response = response(conn, 302)
 

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -45,6 +45,15 @@ defmodule SignsUiWeb.MessagesControllerTest do
 
       assert response =~ "readOnly = true"
     end
+
+    @tag :authenticated
+    test "includes path to sign out", %{conn: conn} do
+      conn = get(conn, messages_path(conn, :index))
+
+      response = html_response(conn, 200)
+
+      assert response =~ "signOutPath = \"/auth/logout\""
+    end
   end
 
   describe "create messages" do

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -52,7 +52,7 @@ defmodule SignsUiWeb.MessagesControllerTest do
 
       response = html_response(conn, 200)
 
-      assert response =~ "signOutPath = \"/auth/logout\""
+      assert response =~ "signOutPath = \"/auth/cognito/logout\""
     end
   end
 

--- a/test/signs_ui_web/controllers/unauthorized_controller_test.exs
+++ b/test/signs_ui_web/controllers/unauthorized_controller_test.exs
@@ -5,7 +5,10 @@ defmodule SignsUiWeb.UnauthorizedControllerTest do
     test "renders response", %{conn: conn} do
       conn = get(conn, unauthorized_path(conn, :index))
 
-      assert html_response(conn, 403) =~ "not authorized"
+      html = html_response(conn, 403)
+
+      assert html =~ "not authorized"
+      assert html =~ "/logout"
     end
   end
 end

--- a/test/signs_ui_web/endpoint_test.exs
+++ b/test/signs_ui_web/endpoint_test.exs
@@ -1,0 +1,63 @@
+defmodule SignsUiWeb.EndpointTest do
+  use ExUnit.Case
+
+  describe "init/2" do
+    test "sets application env from system env" do
+      old_port = System.get_env("PORT")
+      old_host = System.get_env("SIGNS_UI_HOST")
+
+      on_exit(fn ->
+        if old_port do
+          System.put_env("PORT", old_port)
+        else
+          System.delete_env("PORT")
+        end
+
+        if old_host do
+          System.put_env("SIGNS_UI_HOST", old_host)
+        else
+          System.delete_env("SIGNS_UI_HOST")
+        end
+      end)
+
+      System.put_env("PORT", "8000")
+      System.put_env("SIGNS_UI_HOST", "myhost.com")
+
+      initial_config = [
+        load_from_system_env: true,
+        url: [host: "example.com", port: 80]
+      ]
+
+      {:ok, config} = SignsUiWeb.Endpoint.init(:supervisor, initial_config)
+
+      assert config[:http] == [:inet6, {:port, "8000"}]
+      assert config[:url][:host] == "myhost.com"
+    end
+
+    test "raises when PORT environment variable isn't set" do
+      assert_raise RuntimeError, "expected the PORT environment variable to be set", fn ->
+        SignsUiWeb.Endpoint.init(:supervisor, load_from_system_env: true)
+      end
+    end
+
+    test "raises when SIGNS_UI_HOST environment variable isn't set" do
+      old_port = System.get_env("PORT")
+
+      on_exit(fn ->
+        if old_port do
+          System.put_env("PORT", old_port)
+        else
+          System.delete_env("PORT")
+        end
+      end)
+
+      System.put_env("PORT", "8000")
+
+      assert_raise RuntimeError,
+                   "expected the SIGNS_UI_HOST environment variable to be set",
+                   fn ->
+                     SignsUiWeb.Endpoint.init(:supervisor, load_from_system_env: true)
+                   end
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 Add sign out to signs-ui](https://app.asana.com/0/584764604969369/1175609300680961/f)

Most of the actual action is in the `AuthController`, which does the actual work of clearing the refresh token, logging out with Guardian, and then redirecting to the Cognito redirect URL with a redirect back to the signs UI main page.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
