### PR TITLE
fix: Change 'sign out' wording to 'refresh credentials'

### DIFF
--- a/lib/signs_ui_web/templates/unauthorized/index.html.eex
+++ b/lib/signs_ui_web/templates/unauthorized/index.html.eex
@@ -5,5 +5,5 @@ realtimeappsdl@mbta.com.
 </div>
 
 <div>
-    <%= link "sign out", to: @sign_out_path %>
+    <%= link "refresh credentials", to: @sign_out_path %>
 </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 rename "sign out" to "refresh credentials" in signs-ui](https://app.asana.com/0/584764604969369/1176912388875424)

Workaround for being unable to sign out in AD.

I stopped here with this trivial change to the wording. I considered going deeper: change the `@sign_out_path` variable name to `@refresh_credentials_path`, then the controller and router, etc, but I figured part of the functionality _is_ to sign out (at least on the Signs UI side), and hopefully in the future we'll be able to sign out of AD as well.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
