### PR TITLE
fix: Change another 'sign out' to 'refresh credentials'

### DIFF
--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -131,7 +131,7 @@ class ViewerApp extends Component {
             </button>
           </div>
           <div className="col-auto">
-            <a href={signOutPath} id="sign-out-link">sign out</a>
+            <a href={signOutPath} id="sign-out-link">refresh credentials</a>
           </div>
         </div>
         {line


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Previously, we changed the "sign out" link to "refresh credentials" on the Unauthorized page, but we need to change it on the "signed in" page as well.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
