### PR TITLE
fix: enable "auto" mode for all signs except eastbound South Station, WTC, and Courthouse

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -2863,13 +2863,13 @@ const stationConfig = {
           n: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
           s: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
           e: {
@@ -2887,13 +2887,13 @@ const stationConfig = {
           c: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
           m: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
         },
@@ -2905,13 +2905,13 @@ const stationConfig = {
           n: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
           s: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
           e: {
@@ -2929,13 +2929,13 @@ const stationConfig = {
           c: {
             value: false,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
           m: {
             value: true,
             modes: {
-              auto: false, custom: false, headway: false, off: true,
+              auto: true, custom: false, headway: false, off: true,
             },
           },
         },


### PR DESCRIPTION
Just updating some config values. The only active sign this affects is Courthouse mezz, but I updated the others to make it consistent. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
