### PR TITLE
fix: use correct zone for south_station_silver_line_arrival_platform

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -1562,7 +1562,7 @@ const stationConfig = {
             },
           },
           w: {
-            value: false,
+            value: 'Arrival Platform',
             modes: {
               auto: true, custom: true, headway: true, off: true,
             },
@@ -1574,7 +1574,7 @@ const stationConfig = {
             },
           },
           m: {
-            value: 'Arrival Platform',
+            value: false,
             modes: {
               auto: true, custom: true, headway: true, off: true,
             },
@@ -4734,7 +4734,7 @@ const arincToRealtimeIdMap = {
   'RDTC-s': 'red_downtown_crossing_southbound',
   'RSOU-n': 'red_south_station_northbound',
   'RSOU-s': 'red_south_station_southbound',
-  'SSOU-m': 'south_station_silver_line_arrival_platform',
+  'SSOU-w': 'south_station_silver_line_arrival_platform',
   'RBRO-m': 'broadway_mezzanine',
   'RBRO-n': 'broadway_northbound',
   'RBRO-s': 'broadway_southbound',


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 Fix "south_station_silver_line_arrival_platform" in Signs UI](https://app.asana.com/0/584764604969369/1198511901859811/f)

Thankfully the theory outlined in the ticket seems to have been correct, and the sign now works!
![Screen Shot 2020-10-23 at 2 01 58 PM](https://user-images.githubusercontent.com/2010157/97038938-91e5ae80-1539-11eb-9feb-5db84db3df62.png)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
