### PR TITLE
Custom sign positions

### DIFF
--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -25,8 +25,11 @@ function name(line) {
   if (line === 'Mattapan') {
     return 'Mattapan';
   }
-  if (line === 'SL3') {
-    return 'SL3';
+  if (line === 'Silver') {
+    return 'Silver Line';
+  }
+  if (line === 'Busway') {
+    return 'Busways';
   }
 
   return '';

--- a/assets/js/Line.test.js
+++ b/assets/js/Line.test.js
@@ -70,7 +70,7 @@ test('Shows batch mode buttons when not read-only', () => {
   expect(wrapper.text()).toMatch('All to off');
 });
 
-test.each([['SL3'], ['Busway']])(
+test.each([['Silver'], ['Busway']])(
   'Does not show headway batch mode button',
   (line) => {
     const now = Date.now();

--- a/assets/js/Station.jsx
+++ b/assets/js/Station.jsx
@@ -30,7 +30,7 @@ function makeSign(
   setConfigs,
   readOnly,
 ) {
-  if (config.zones[zone].value) {
+  if (zone && config.zones[zone].value) {
     const key = `${config.id}-${zone}`;
     const signContent = signs[key] || { sign_id: key, lines: {} };
     const realtimeId = arincToRealtimeId(key, line);
@@ -69,6 +69,12 @@ function Station({
   setConfigs,
   readOnly,
 }) {
+  const zonePositions = config.zonePositions || {
+    left: ['s', 'w'],
+    center: ['c', 'm'],
+    right: ['n', 'e'],
+  };
+
   return (
     <div key={config.id}>
       <h3>
@@ -84,7 +90,7 @@ function Station({
         <div className="col">
           {makeSign(
             config,
-            's',
+            zonePositions.left[0],
             signs,
             currentTime,
             line,
@@ -94,29 +100,7 @@ function Station({
           )}
           {makeSign(
             config,
-            'w',
-            signs,
-            currentTime,
-            line,
-            signConfigs,
-            setConfigs,
-            readOnly,
-          )}
-        </div>
-        <div className="col">
-          {makeSign(
-            config,
-            'c',
-            signs,
-            currentTime,
-            line,
-            signConfigs,
-            setConfigs,
-            readOnly,
-          )}
-          {makeSign(
-            config,
-            'm',
+            zonePositions.left[1],
             signs,
             currentTime,
             line,
@@ -128,7 +112,7 @@ function Station({
         <div className="col">
           {makeSign(
             config,
-            'n',
+            zonePositions.center[0],
             signs,
             currentTime,
             line,
@@ -138,7 +122,29 @@ function Station({
           )}
           {makeSign(
             config,
-            'e',
+            zonePositions.center[1],
+            signs,
+            currentTime,
+            line,
+            signConfigs,
+            setConfigs,
+            readOnly,
+          )}
+        </div>
+        <div className="col">
+          {makeSign(
+            config,
+            zonePositions.right[0],
+            signs,
+            currentTime,
+            line,
+            signConfigs,
+            setConfigs,
+            readOnly,
+          )}
+          {makeSign(
+            config,
+            zonePositions.right[1],
             signs,
             currentTime,
             line,
@@ -163,19 +169,28 @@ const zoneConfig = PropTypes.shape({
   }),
 });
 
-Station.propTypes = {
-  config: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-    zones: PropTypes.shape({
-      n: zoneConfig,
-      e: zoneConfig,
-      s: zoneConfig,
-      w: zoneConfig,
-      c: zoneConfig,
-      m: zoneConfig,
-    }).isRequired,
+const zonePositions = PropTypes.shape({
+  left: PropTypes.arrayOf(PropTypes.oneOf(['n', 'e', 's', 'w', 'c', 'm'])),
+  center: PropTypes.arrayOf(PropTypes.oneOf(['n', 'e', 's', 'w', 'c', 'm'])),
+  right: PropTypes.arrayOf(PropTypes.oneOf(['n', 'e', 's', 'w', 'c', 'm'])),
+});
+
+const StationConfig = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  zonePositions,
+  zones: PropTypes.shape({
+    n: zoneConfig,
+    e: zoneConfig,
+    s: zoneConfig,
+    w: zoneConfig,
+    c: zoneConfig,
+    m: zoneConfig,
   }).isRequired,
+});
+
+Station.propTypes = {
+  config: StationConfig.isRequired,
   signs: PropTypes.objectOf(signContentType).isRequired,
   currentTime: PropTypes.number.isRequired,
   line: PropTypes.string.isRequired,

--- a/assets/js/Station.test.js
+++ b/assets/js/Station.test.js
@@ -37,3 +37,43 @@ test('shows the custom configuration information for a station', () => {
 
   expect(wrapper.text()).toMatch('Entire Station');
 });
+
+test('allows custom reordering of sign positions', () => {
+  const config = {
+    id: 'OGRE',
+    name: 'Green St',
+    zonePositions: {
+      left: ['n'],
+      center: [],
+      right: ['s'],
+    },
+    zones: {
+      n: { value: 'foo' },
+      s: { value: 'bar' },
+      e: { value: false },
+      w: { value: false },
+      c: { value: false },
+      m: { value: false },
+    },
+  };
+  const currentTime = Date.now() + 2000;
+  const signs = {};
+  const line = 'Orange';
+  const signConfigs = {};
+  const setConfigs = () => {};
+  const readOnly = false;
+
+  const wrapper = mount(
+    React.createElement(Station, {
+      config,
+      signs,
+      currentTime,
+      line,
+      signConfigs,
+      setConfigs,
+      readOnly,
+    }),
+  );
+
+  expect(wrapper.text()).toMatch(/foo.*bar/);
+});

--- a/assets/js/ViewerApp.jsx
+++ b/assets/js/ViewerApp.jsx
@@ -126,8 +126,8 @@ class ViewerApp extends Component {
             <button type="button" id="mattapan-button" onClick={() => this.changeLine('Mattapan')}>
               Mattapan
             </button>
-            <button type="button" id="sl3-button" onClick={() => this.changeLine('SL3')}>
-              Silver Line 3
+            <button type="button" id="sl3-button" onClick={() => this.changeLine('Silver')}>
+              Silver Line
             </button>
             <button type="button" id="busway-button" onClick={() => this.changeLine('Busway')}>
               Busway

--- a/assets/js/colors.js
+++ b/assets/js/colors.js
@@ -4,7 +4,7 @@ const lineToColor = {
   Blue: 'rgb(0, 61, 165)',
   Orange: 'rgb(237, 139, 0)',
   Green: 'rgb(0, 132, 61)',
-  SL3: 'rgb(124, 135, 142)',
+  Silver: 'rgb(124, 135, 142)',
   Busway: 'rgb(255, 199, 44)',
 };
 

--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -2853,7 +2853,7 @@ const stationConfig = {
       },
     ],
   },
-  SL3: {
+  Silver: {
     batchModes: { auto: true, headway: false, off: true },
     stations: [
       {
@@ -4832,7 +4832,7 @@ function arincToRealtimeId(stationZone, line) {
   if (stationZone === 'RSOU-m' && line === 'Red') {
     return 'red_south_station_mezzanine';
   }
-  if (stationZone === 'RSOU-m' && line === 'SL3') {
+  if (stationZone === 'RSOU-m' && line === 'Silver') {
     return 'south_station_mezzanine';
   }
 

--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -4566,48 +4566,6 @@ const stationConfig = {
           },
         },
       },
-      {
-        id: 'RBRA',
-        name: 'Braintree',
-        zones: {
-          n: {
-            value: false,
-            modes: {
-              auto: true, custom: false, headway: false, off: true,
-            },
-          },
-          s: {
-            value: false,
-            modes: {
-              auto: true, custom: false, headway: false, off: true,
-            },
-          },
-          e: {
-            value: false,
-            modes: {
-              auto: true, custom: false, headway: false, off: true,
-            },
-          },
-          w: {
-            value: false,
-            modes: {
-              auto: true, custom: false, headway: false, off: true,
-            },
-          },
-          c: {
-            value: false,
-            modes: {
-              auto: true, custom: false, headway: false, off: true,
-            },
-          },
-          m: {
-            value: 'Busway',
-            modes: {
-              auto: true, custom: false, headway: false, off: true,
-            },
-          },
-        },
-      },
     ],
   },
 };

--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -2999,13 +2999,13 @@ const stationConfig = {
             },
           },
           e: {
-            value: true,
+            value: 'Outbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
           },
           w: {
-            value: true,
+            value: 'Inbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
@@ -3041,13 +3041,13 @@ const stationConfig = {
             },
           },
           e: {
-            value: true,
+            value: 'Outbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
           },
           w: {
-            value: true,
+            value: 'Inbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
@@ -3083,13 +3083,13 @@ const stationConfig = {
             },
           },
           e: {
-            value: true,
+            value: 'Outbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
           },
           w: {
-            value: true,
+            value: 'Inbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
@@ -3131,7 +3131,7 @@ const stationConfig = {
             },
           },
           w: {
-            value: true,
+            value: 'Inbound',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },

--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -4297,6 +4297,11 @@ const stationConfig = {
       {
         id: 'SDUD',
         name: 'Nubian',
+        zonePositions: {
+          left: ['w', 'c'],
+          center: ['s', 'm'],
+          right: ['e', 'n'],
+        },
         zones: {
           n: {
             value: 'Platform F',
@@ -4339,6 +4344,11 @@ const stationConfig = {
       {
         id: 'GLEC',
         name: 'Lechmere',
+        zonePositions: {
+          left: ['n'],
+          center: [],
+          right: ['m'],
+        },
         zones: {
           n: {
             value: 'North',
@@ -4347,7 +4357,7 @@ const stationConfig = {
             },
           },
           s: {
-            value: 'South',
+            value: false,
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
@@ -4371,7 +4381,7 @@ const stationConfig = {
             },
           },
           m: {
-            value: false,
+            value: 'South',
             modes: {
               auto: true, custom: false, headway: false, off: true,
             },
@@ -4381,6 +4391,11 @@ const stationConfig = {
       {
         id: 'SHAR',
         name: 'Harvard',
+        zonePositions: {
+          left: ['m'],
+          center: [],
+          right: ['n'],
+        },
         zones: {
           n: {
             value: 'Upper',
@@ -4507,6 +4522,11 @@ const stationConfig = {
       {
         id: 'SFOR',
         name: 'Forest Hills',
+        zonePositions: {
+          left: ['n'],
+          center: [],
+          right: ['s'],
+        },
         zones: {
           n: {
             value: 'Upper (Fence)',
@@ -4840,7 +4860,7 @@ const arincToRealtimeIdMap = {
   'SDUD-c': 'bus.Nubian_Platform_E_east',
   'SDUD-m': 'bus.Nubian_Platform_E_west',
   'GLEC-n': 'bus.Lechmere_bus_north',
-  'GLEC-s': 'bus.Lechmere_bus_south',
+  'GLEC-m': 'bus.Lechmere_bus_south',
   'SHAR-n': 'bus.Harvard_upper',
   'SHAR-m': 'bus.Harvard_lower',
   'MMAT-n': 'bus.Mattapan_south',


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 Better arrangement of busway signs in Signs UI](https://app.asana.com/0/584764604969369/1198221951853376/f), but also [👁 Temporarily remove Braintree from busways page](https://app.asana.com/0/584764604969369/1198511901859809/f) and [👁 Re-label Chelsea signs in Signs UI](https://app.asana.com/0/584764604969369/1198511901859807/f).

Allows customizing of which signs end up in which columns. Split across several commits for the other small tickets that I folded into this one.

I stuck with allowing just two rows per sign for now given that ARINC only (to the best of our knowledge) supports six zones, hence 2 * 3 total signs per station. If anyone feels strongly against that approach though I could make it support arbitrarily-many rows.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
