### PR TITLE
fix: correctly parse ARINC POSTs with empty pages

### DIFF
--- a/lib/signs_ui/messages/sign_content.ex
+++ b/lib/signs_ui/messages/sign_content.ex
@@ -23,7 +23,7 @@ defmodule SignsUi.Messages.SignContent do
   page_text =
     ignore(string("-"))
     |> ignore(string("\""))
-    |> optional(ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+], min: 1))
+    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+], min: 0)
     |> ignore(string("\""))
     |> optional(
       ignore(string("."))

--- a/test/signs_ui/messages/sign_content_test.exs
+++ b/test/signs_ui/messages/sign_content_test.exs
@@ -62,6 +62,11 @@ defmodule SignsUi.Messages.SignContentTest do
                SignContent.new("XYZ", ~s(e1~w1-"pg1".3-"pg2".5))
     end
 
+    test "parses pages with empty text" do
+      assert {:ok, %SignContent{pages: [{"pg1", 3}, {"", 5}]}} =
+               SignContent.new("XYZ", ~s(e1~w1-"pg1".3-"".5))
+    end
+
     test "parses text with a + in it" do
       assert {:ok, %SignContent{pages: ["30+ min"]}} = SignContent.new("XYZ", ~s(e1~w1-"30+ min"))
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 parser should handle original busway posts](https://app.asana.com/0/584764604969369/1198902184175981/f)

The get_pages function was being passed a page of form `{:page_text,
[5]}` rather than `{:page_text, ["", 5]}` for an empty page of duration
5. Fixed the parser to make the text a required string of length 0 or
more rather than an optional string of length 1 or more.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
