### PR TITLE
chore: Only allow SWTC mezzanine sign to be "off"

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -2977,7 +2977,7 @@ const stationConfig = {
           m: {
             value: true,
             modes: {
-              auto: true, custom: false, headway: false, off: true,
+              auto: false, custom: false, headway: false, off: true,
             },
           },
         },


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 Only allow SWTC mezzanine sign to be "off"](https://app.asana.com/0/584764604969369/1198874127770575/f)

This sign is already set to "off" in both dev and prod.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
