### PR TITLE
fix: do not show "Schedule return to Auto" field if sign cannot be set to auto

### DIFF
--- a/assets/js/Sign.jsx
+++ b/assets/js/Sign.jsx
@@ -260,7 +260,7 @@ class Sign extends Component {
             </div>
           </div>
         )}
-        {signConfig.mode !== 'auto' && (
+        {signConfig.mode !== 'auto' && modes.auto && (
           <div className="viewer--schedule-expires">
             <SetExpiration
               realtimeId={realtimeId}

--- a/assets/js/Sign.test.js
+++ b/assets/js/Sign.test.js
@@ -241,3 +241,81 @@ test.each([
     expect(wrapper.find(`option[value="${x}"]`).exists()).toEqual(expected[x]);
   });
 });
+
+test('shows the return to auto time field if sign can be set to auto', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig = { mode: 'custom' };
+  const signContent = signContentWithExpirations(fresh, fresh);
+  const setConfigs = () => { };
+  const realtimeId = 'id';
+  const readOnly = false;
+  const modes = {
+    auto: true,
+    custom: true,
+    headway: true,
+    off: true,
+  };
+
+  const wrapper = mount(
+    React.createElement(
+      Sign,
+      {
+        signId,
+        signContent,
+        currentTime,
+        line,
+        modes,
+        signConfig,
+        setConfigs,
+        realtimeId,
+        readOnly,
+      },
+      null,
+    ),
+  );
+
+  expect(wrapper.html()).toMatch('Schedule return to "Auto"');
+});
+
+test('does not show the return to auto time field if sign can be set to auto', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig = { mode: 'off' };
+  const signContent = signContentWithExpirations(fresh, fresh);
+  const setConfigs = () => { };
+  const realtimeId = 'id';
+  const readOnly = false;
+  const modes = {
+    auto: false,
+    custom: false,
+    headway: false,
+    off: true,
+  };
+
+  const wrapper = mount(
+    React.createElement(
+      Sign,
+      {
+        signId,
+        signContent,
+        currentTime,
+        line,
+        modes,
+        signConfig,
+        setConfigs,
+        realtimeId,
+        readOnly,
+      },
+      null,
+    ),
+  );
+
+  expect(wrapper.html()).not.toMatch('Schedule return to "Auto"');
+});


### PR DESCRIPTION

#### Summary of changes
**Asana Ticket:** [👁  signs that don't allow "auto" shouldn't have the return to auto time field](https://app.asana.com/0/584764604969369/1198902001848254/f)

Simply conditionally rendering the field and adding tests.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
