### PR TITLE
fix: only apply batch mode updates to applicable signs

### DIFF
--- a/assets/js/Line.jsx
+++ b/assets/js/Line.jsx
@@ -41,10 +41,11 @@ function setAllStationsMode(setConfigFn, stations, line, mode) {
   stations.forEach((station) => {
     ['n', 's', 'e', 'w', 'm', 'c'].forEach((zone) => {
       const realtimeId = arincToRealtimeId(`${station.id}-${zone}`, line);
+      const { modes } = station.zones[zone];
       if (realtimeId) {
-        if (mode === 'auto') {
+        if (mode === 'auto' && modes.auto) {
           statuses[realtimeId] = { mode: 'auto' };
-        } else if (mode === 'off' || mode === 'headway') {
+        } else if ((mode === 'off' || mode === 'headway') && modes[mode]) {
           statuses[realtimeId] = { mode, expires: null };
         }
       }
@@ -63,8 +64,9 @@ function Line({
   readOnly,
   configuredHeadways,
   setConfiguredHeadways,
+  stationConfigs,
 }) {
-  const stations = (stationConfig[line] && stationConfig[line].stations) || [];
+  const stations = stationConfigs || (stationConfig[line] && stationConfig[line].stations) || [];
   const batchModes = (stationConfig[line] && stationConfig[line].batchModes) || {};
   const branches = branchConfig[line] || [];
   const batchMode = React.useMemo(() => {
@@ -192,6 +194,22 @@ Line.propTypes = {
   setConfigs: PropTypes.func.isRequired,
   readOnly: PropTypes.bool.isRequired,
   setConfiguredHeadways: PropTypes.func.isRequired,
+  stationConfigs: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    zones: PropTypes.objectOf(PropTypes.shape({
+      [PropTypes.string]: PropTypes.shape({
+        auto: PropTypes.bool,
+        off: PropTypes.bool,
+        custom: PropTypes.bool,
+        headway: PropTypes.bool,
+      }),
+    })),
+  })),
+};
+
+Line.defaultProps = {
+  stationConfigs: null,
 };
 
 export default Line;

--- a/assets/js/Line.test.js
+++ b/assets/js/Line.test.js
@@ -311,3 +311,106 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
 
   expect(wrapper.find(ConfiguredHeadwaysForm)).toHaveLength(1);
 });
+
+test('Sign config is not affected by batch updates if sign does not support mode', () => {
+  const now = Date.now();
+  const signs = {};
+
+  const currentTime = now + 2000;
+  const line = 'Red';
+  const signConfigs = {};
+  const setConfigs = jest.fn(() => true);
+  const setConfiguredHeadways = () => {};
+  const readOnly = false;
+  const configuredHeadways = {};
+  const stationConfigs = [{
+    id: 'RDAV',
+    name: 'Alewife',
+    zones: {
+      n: {
+        value: false,
+        modes: {
+          auto: true, custom: true, headway: false, off: false,
+        },
+      },
+      s: {
+        value: false,
+        modes: {
+          auto: false, custom: true, headway: true, off: false,
+        },
+      },
+      m: {
+        value: true,
+        modes: {
+          auto: false, custom: true, headway: false, off: true,
+        },
+      },
+      e: {
+        value: false,
+        modes: {
+          auto: false, custom: true, headway: false, off: true,
+        },
+      },
+      w: {
+        value: false,
+        modes: {
+          auto: false, custom: true, headway: false, off: false,
+        },
+      },
+      c: {
+        value: true,
+        modes: {
+          auto: false, custom: true, headway: false, off: false,
+        },
+      },
+
+    },
+  }];
+
+  const wrapper = mount(
+    React.createElement(
+      Line,
+      {
+        signs,
+        currentTime,
+        line,
+        signConfigs,
+        setConfigs,
+        readOnly,
+        configuredHeadways,
+        setConfiguredHeadways,
+        stationConfigs,
+      },
+      null,
+    ),
+  );
+
+  const offInput = wrapper.find('input#off');
+  offInput.simulate('change');
+  expect(setConfigs.mock.calls.length).toEqual(1);
+  expect(setConfigs).toHaveBeenCalledWith({
+    davis_mezzanine: {
+      expires: null,
+      mode: 'off',
+    },
+  });
+
+  const autoInput = wrapper.find('input#auto');
+  autoInput.simulate('change');
+  expect(setConfigs.mock.calls.length).toEqual(2);
+  expect(setConfigs).toHaveBeenCalledWith({
+    davis_northbound: {
+      mode: 'auto',
+    },
+  });
+
+  const headwayInput = wrapper.find('input#headway');
+  headwayInput.simulate('change');
+  expect(setConfigs.mock.calls.length).toEqual(3);
+  expect(setConfigs).toHaveBeenCalledWith({
+    davis_southbound: {
+      expires: null,
+      mode: 'headway',
+    },
+  });
+});


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 "All to Auto" shouldn't affect those signs locked to "off"](https://app.asana.com/0/584764604969369/1198875302524077/f)

Small change to only add a sign to the signs to be updated by a batch mode update if the sign allows the mode being applied. Also updated the `Line` component to optionally take a `stationsConfig` prop for testing. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
