### PR TITLE
feat: enable multiple API keys for message posts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,7 @@ config :signs_ui, SignsUiWeb.AuthManager, secret_key: {System, :get_env, ["SIGNS
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:user_id]
+  metadata: [:messages_api_user, :user_id]
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,7 +10,7 @@ config :signs_ui,
   signs_external_post_mod: SignsUi.Mock.Write,
   local_write_path: "test/mock_write.json",
   aws_requestor: SignsUi.Mock.AwsRequest,
-  realtime_signs_api_key: "placeholder_key"
+  messages_api_keys: "test_user_1:test_key_1,test_user_2:test_key_2"
 
 config :signs_ui, SignsUiWeb.AuthManager,
   issuer: "signs_ui",

--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -28,6 +28,6 @@ defmodule SignsUi.Application do
   defp set_runtime_config do
     Config.update_env(:aws_signs_bucket, System.get_env("AWS_SIGNS_BUCKET"))
     Config.update_env(:aws_signs_path, System.get_env("AWS_SIGNS_PATH"))
-    Config.update_env(:realtime_signs_api_key, System.get_env("REALTIME_SIGNS_API_KEY"))
+    Config.update_env(:messages_api_keys, System.get_env("MESSAGES_API_KEYS"))
   end
 end

--- a/lib/signs_ui_web/plugs/api_auth.ex
+++ b/lib/signs_ui_web/plugs/api_auth.ex
@@ -1,0 +1,28 @@
+defmodule SignsUiWeb.Plugs.ApiAuth do
+  @moduledoc "Authenticates API requests using a set of keys defined in the environment."
+
+  import Plug.Conn
+  require Logger
+
+  # coveralls-ignore-start
+  def init(opts), do: opts
+  # coveralls-ignore-end
+
+  def call(conn, _opts) do
+    with [key] <- get_req_header(conn, "x-api-key"),
+         user when not is_nil(user) <- Map.get(keys(), key) do
+      Logger.metadata(messages_api_user: user)
+      conn
+    else
+      _ -> conn |> send_resp(401, "unauthorized") |> halt()
+    end
+  end
+
+  defp keys do
+    Application.get_env(:signs_ui, :messages_api_keys)
+    |> String.split(",")
+    |> Stream.map(&String.split(&1, ":"))
+    |> Stream.map(fn [user, key] -> {key, user} end)
+    |> Enum.into(%{})
+  end
+end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -15,7 +15,7 @@ defmodule SignsUiWeb.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
-    plug(:api_auth)
+    plug(SignsUiWeb.Plugs.ApiAuth)
   end
 
   pipeline :redirect_prod_http do
@@ -91,20 +91,6 @@ defmodule SignsUiWeb.Router do
       assign(conn, :read_only_view, true)
     else
       conn
-    end
-  end
-
-  defp api_auth(conn, _) do
-    secret_key = Application.get_env(:signs_ui, :realtime_signs_api_key)
-
-    case get_req_header(conn, "x-api-key") do
-      [^secret_key] ->
-        conn
-
-      _ ->
-        conn
-        |> send_resp(401, "unauthorized")
-        |> halt()
     end
   end
 end

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -57,13 +57,18 @@ defmodule SignsUiWeb.MessagesControllerTest do
   end
 
   describe "create messages" do
-    test "responds with the 201 when its valid", %{conn: conn} do
-      conn =
-        conn
-        |> add_api_req_header()
-        |> post(messages_path(conn, :create), @update_attrs)
+    test "responds with 201 and logs the access", %{conn: conn} do
+      log =
+        capture_log([level: :info], fn ->
+          conn =
+            conn
+            |> add_api_req_header()
+            |> post(messages_path(conn, :create), @update_attrs)
 
-      assert response(conn, 201)
+          assert response(conn, 201)
+        end)
+
+      assert log =~ "messages_api_user=test_user_2"
     end
 
     test "responds with 201 when receiving an unknown message type", %{conn: conn} do
@@ -103,6 +108,6 @@ defmodule SignsUiWeb.MessagesControllerTest do
   end
 
   defp add_api_req_header(conn) do
-    %{conn | req_headers: [{"x-api-key", "placeholder_key"}]}
+    %{conn | req_headers: [{"x-api-key", "test_key_2"}]}
   end
 end


### PR DESCRIPTION
**Asana Ticket:** [👁 Give bus-realtime a different API key for talking to signs-ui](https://app.asana.com/0/584764604969369/1198875302524079)

This expects a `MESSAGES_API_KEYS` variable in the environment with a format like `user1:key1,user2:key2,...`. The "user" is a label only used for logging; there is no change to how clients authenticate.

⚠️ ~~**Don't merge** until the subtask to update the environment with the new variable is done.~~ It's done!

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
