### PR TITLE
fix: Crash when updating headways

### DIFF
--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -100,7 +100,7 @@ defmodule SignsUi.Config.State do
     SignsUiWeb.Endpoint.broadcast!(
       "signs:all",
       "new_configured_headways_state",
-      new_configured_headways
+      Config.ConfiguredHeadways.format_configured_headways_for_json(new_configured_headways)
     )
 
     new_state

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -4,6 +4,7 @@ defmodule SignsUi.Config.StateTest do
   alias SignsUi.Config
   alias SignsUi.Config.Sign
   alias SignsUi.Config.ConfiguredHeadway
+  alias SignsUi.Config.ConfiguredHeadways
 
   setup do
     {:ok, claims} =
@@ -93,17 +94,18 @@ defmodule SignsUi.Config.StateTest do
 
       {:ok, new_state} =
         update_configured_headways(pid, %{
-          "red_trunk" => %ConfiguredHeadway{range_low: 13, range_high: 15}
+          "red_trunk" => %{"peak" => %ConfiguredHeadway{range_low: 13, range_high: 15}}
         })
 
       assert new_state.configured_headways == %{
-               "red_trunk" => %ConfiguredHeadway{range_low: 13, range_high: 15}
+               "red_trunk" => %{"peak" => %ConfiguredHeadway{range_low: 13, range_high: 15}}
              }
 
       expected_broadcast =
         pid
         |> get_all()
         |> Map.get(:configured_headways)
+        |> ConfiguredHeadways.format_configured_headways_for_json()
 
       assert_broadcast("new_configured_headways_state", ^expected_broadcast)
     end
@@ -115,19 +117,20 @@ defmodule SignsUi.Config.StateTest do
 
       {:ok, new_state} =
         update_configured_headways(pid, %{
-          "red_trunk" => %ConfiguredHeadway{range_low: 13, range_high: 15},
-          "red_ashmont" => %ConfiguredHeadway{range_low: 27, range_high: 30}
+          "red_trunk" => %{"peak" => %ConfiguredHeadway{range_low: 13, range_high: 15}},
+          "red_ashmont" => %{"peak" => %ConfiguredHeadway{range_low: 27, range_high: 30}}
         })
 
       assert new_state.configured_headways == %{
-               "red_trunk" => %ConfiguredHeadway{range_low: 13, range_high: 15},
-               "red_ashmont" => %ConfiguredHeadway{range_low: 27, range_high: 30}
+               "red_trunk" => %{"peak" => %ConfiguredHeadway{range_low: 13, range_high: 15}},
+               "red_ashmont" => %{"peak" => %ConfiguredHeadway{range_low: 27, range_high: 30}}
              }
 
       expected_broadcast =
         pid
         |> get_all()
         |> Map.get(:configured_headways)
+        |> ConfiguredHeadways.format_configured_headways_for_json()
 
       assert_broadcast("new_configured_headways_state", ^expected_broadcast)
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] signs-ui crash when changing headways](https://app.asana.com/0/584764604969369/1198997335405917)

The issue was that we were broadcasting the headways over the websockets which has an implicit `Jason.encode!/1`. However, the data had `ConfiguredHeadway` structs in it, so it went 💥 . This passes it through the `format_configured_headways_for_json` function we use elsewhere to properly encode it.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
