### PR TITLE
fix: 'All to Auto' on Red Line page shouldn't affect SL sign

### DIFF
--- a/assets/js/mbta.js
+++ b/assets/js/mbta.js
@@ -1546,19 +1546,19 @@ const stationConfig = {
           n: {
             value: false,
             modes: {
-              auto: true, custom: true, headway: true, off: true,
+              auto: false, custom: false, headway: false, off: false,
             },
           },
           s: {
             value: false,
             modes: {
-              auto: true, custom: true, headway: true, off: true,
+              auto: false, custom: false, headway: false, off: false,
             },
           },
           e: {
             value: false,
             modes: {
-              auto: true, custom: true, headway: true, off: true,
+              auto: false, custom: false, headway: false, off: false,
             },
           },
           w: {
@@ -1570,13 +1570,13 @@ const stationConfig = {
           c: {
             value: false,
             modes: {
-              auto: true, custom: true, headway: true, off: true,
+              auto: false, custom: false, headway: false, off: false,
             },
           },
           m: {
             value: false,
             modes: {
-              auto: true, custom: true, headway: true, off: true,
+              auto: false, custom: false, headway: false, off: false,
             },
           },
         },


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] signs-ui: "all to auto" on red line sets SSOU-e to auto, too?](https://app.asana.com/0/584764604969369/1199149180791693)

Using the "All to Auto" feature on the Red Line page also set the Silver Line South Station EB sign to "auto", which is one of the signs that is supposed to be "off" or "custom" only.

The issue was that `SSOU` is also a station on the Red Line page because the west zone displays red line predictions. The format of `mbta.js` is such that it had configuration values for `SSOU-e`, (even though `value` was `false`), such that `auto` was allowed. As a quick fix, I changed all the modes to `false` for the non- Red Line zones of `SSOU`.

I started down a small refactor: although I understand the initial reasoning for including every zone for every station, I think it would be better to only include the zones that appear on the page. Otherwise, as is the case here with `SSOU` (and possibly future signs if we get to more cross-mode work?), we have a non-normalized data representation, where `SSOU-e` was being configured in two separate places. I also was planning to change `value` (since it will only ever be `true` or a string) to `label`, and have `true` be unnecessary, and the code would just say "EB" or whatever, but a string could be provided to override it.

However, I realized both these changes would conflict with the large-ish open PR of adding typescript, so I figured they could be done after that, if desired.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
