### PR TITLE
fix: show clock in frontend view even when signs have no content

### DIFF
--- a/assets/js/Sign.tsx
+++ b/assets/js/Sign.tsx
@@ -87,7 +87,7 @@ function line1DisplayText(
 
     return `${text.padEnd(19)}${timeString(currentTime)}`;
   }
-  return '';
+  return `${' '.repeat(19)}${timeString(currentTime)}`;
 }
 
 function line2DisplayText(

--- a/assets/test/Sign.test.ts
+++ b/assets/test/Sign.test.ts
@@ -331,3 +331,42 @@ test('does not show the return to auto time field if sign can be set to auto', (
 
   expect(wrapper.html()).not.toMatch('Schedule return to "Auto"');
 });
+
+test('shows clock even when no other content is present', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const expired = new Date(now).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig: SignConfig = { mode: 'auto' };
+  const signContent = signContentWithExpirations(expired, expired);
+  const setConfigs = () => true;
+  const realtimeId = 'id';
+  const readOnly = false;
+  const modes = {
+    auto: true,
+    custom: true,
+    headway: true,
+    off: true,
+  };
+
+  const wrapper = mount(
+    React.createElement(
+      Sign,
+      {
+        signId,
+        signContent,
+        currentTime,
+        line,
+        signConfig,
+        setConfigs,
+        realtimeId,
+        readOnly,
+        modes,
+      },
+      null,
+    ),
+  );
+
+  expect(wrapper.text()).toMatch('3:15');
+});


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 when signs are "all to off" time on signs should remain](https://app.asana.com/0/584764604969369/1199130832412093/f)

The function to generate the top line text was only filling in the clock if there was content on the line. The fix was a simple matter of making sure that the clock also gets filled in if there's no content, rather than just returning the empty string.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
