### PR TITLE
fix: adjust Sign component state when changing mode

### DIFF
--- a/assets/js/Sign.tsx
+++ b/assets/js/Sign.tsx
@@ -236,8 +236,15 @@ class Sign extends React.Component<
                   className="viewer--mode-select"
                   value={signConfig.mode}
                   onChange={(event) => {
+                    const newConfig = makeConfig(event.target.value as 'auto' | 'headway' | 'off' | 'static_text');
+                    this.setState({
+                      tipText: false,
+                      staticLine1: newConfig.line1 || '',
+                      staticLine2: newConfig.line2 || '',
+                      customChanges: false,
+                    });
                     setConfigs({
-                      [realtimeId]: makeConfig(event.target.value as 'auto' | 'headway' | 'off' | 'static_text'),
+                      [realtimeId]: newConfig,
                     });
                   }}
                 >
@@ -279,6 +286,7 @@ class Sign extends React.Component<
             )}
             <div>
               <input
+                id={`${realtimeId}-line1-input`}
                 className="viewer--line-input"
                 type="text"
                 maxLength={18}
@@ -289,6 +297,7 @@ class Sign extends React.Component<
             </div>
             <div>
               <input
+                id={`${realtimeId}-line2-input`}
                 className="viewer--line-input"
                 type="text"
                 maxLength={24}

--- a/assets/test/ViewerApp.test.tsx
+++ b/assets/test/ViewerApp.test.tsx
@@ -100,6 +100,43 @@ test('Can enable/disable a sign', () => {
   expect(wrapper.find('#davis_southbound').props().value).toBe('off');
 });
 
+test('Disabling a sign clears any static text', () => {
+  const now = Date.now();
+  const signs = someSignContent(now);
+  const initialSignConfigs: SignConfigs = {
+    davis_southbound: { mode: 'static_text', line1: 'foo', line2: 'bar' },
+  };
+  const readOnly = false;
+  const configuredHeadways = {};
+  const signOutPath = '/path';
+
+  const wrapper = mount(
+    React.createElement(
+      ViewerApp,
+      {
+        initialSigns: signs,
+        initialConfiguredHeadways: configuredHeadways,
+        initialChelseaBridgeAnnouncements: false,
+        initialSignConfigs,
+        readOnly,
+        signOutPath,
+      },
+      null,
+    ),
+  );
+
+  wrapper.find('#red-button').simulate('click');
+  wrapper
+    .find('#davis_southbound')
+    .simulate('change', { target: { value: 'off' } });
+  expect(wrapper.find('#davis_southbound').props().value).toBe('off');
+  wrapper
+    .find('#davis_southbound')
+    .simulate('change', { target: { value: 'static_text' } });
+  expect(wrapper.find('#davis_southbound-line1-input').props().value).toBe('');
+  expect(wrapper.find('#davis_southbound-line2-input').props().value).toBe('');
+});
+
 test('Shows sign out link', () => {
   const now = Date.now();
   const signs = someSignContent(now);


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 browser shouldn't retain custom text when it's not there](https://app.asana.com/0/584764604969369/1199125805769944/f)

It turns out that the state of the component wasn't being kept in sync with the overall change in the sign configs. I updated it so that the `onChange` function of the mode dropdown makes sure to keep the relevant keys of state up-to-date. This suggests that maybe we should refactor things a bit so that there aren't values in the state and props that need to be kept identical, but I'm not sure what the best approach is there.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
