### PR TITLE
Disable bridge toggle if in read-only mode

### DIFF
--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -124,7 +124,9 @@ function Line({
 
       {line === 'Silver' && (
       <label className="mt-1 mb-4">
-        Chelsea Drawbridge Announcements
+        Chelsea Drawbridge Announcements:
+        {readOnly && <em><span className="ml-3">{chelseaBridgeAnnouncements === 'auto' ? 'Auto' : 'Off'}</span></em>}
+        {!readOnly && (
         <div className="switch">
           <input
             name="chelsea_bridge"
@@ -137,6 +139,7 @@ function Line({
           />
           <span className="switch-label">Switch</span>
         </div>
+        )}
       </label>
       )}
       {!readOnly && (

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -424,115 +424,58 @@ test('Sign config is not affected by batch updates if sign does not support mode
 });
 
 
-test('can toggle chelsea bridge announcements on and off on Silver Line page', () => {	
-  const setChelseaBridgeAnnouncements = jest.fn(() => true);	
-  const wrapper = mount(	
-    React.createElement(	
-      Line,	
-      {	
-        signs: {},	
-        currentTime: Date.now() + 2000,	
-        line: 'Silver',	
-        signConfigs: {},	
-        setConfigs: jest.fn(() => true),	
-        readOnly: false,	
-        configuredHeadways: {},	
-        setConfiguredHeadways: () => {},	
-        chelseaBridgeAnnouncements: 'off',	
-        setChelseaBridgeAnnouncements,	
-      },	
-      null,	
-    ),	
-  );	
+test('can toggle chelsea bridge announcements on and off on Silver Line page', () => {
+  const setChelseaBridgeAnnouncements = jest.fn(() => true);
+  const wrapper = mount(
+    React.createElement(
+      Line,
+      {
+        signs: {},
+        currentTime: Date.now() + 2000,
+        line: 'Silver',
+        signConfigs: {},
+        setConfigs: jest.fn(() => true),
+        readOnly: false,
+        configuredHeadways: {},
+        setConfiguredHeadways: () => {},
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements,
+      },
+      null,
+    ),
+  );
 
-  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');	
-  chelseaInput.simulate('change', { target: { checked: true } });	
-  expect(setChelseaBridgeAnnouncements.mock.calls.length).toEqual(1);	
-  expect(setChelseaBridgeAnnouncements).toHaveBeenCalledWith('auto');	
+  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');
+  chelseaInput.simulate('change', { target: { checked: true } });
+  expect(setChelseaBridgeAnnouncements.mock.calls.length).toEqual(1);
+  expect(setChelseaBridgeAnnouncements).toHaveBeenCalledWith('auto');
 
-  chelseaInput.simulate('change', { target: { checked: false } });	
-  expect(setChelseaBridgeAnnouncements.mock.calls.length).toEqual(2);	
-  expect(setChelseaBridgeAnnouncements).toHaveBeenCalledWith('off');	
-});	
-
-test('does not show chelsea bridge announcements toggle on non-Silver Line pages', () => {	
-  const setChelseaBridgeAnnouncements = jest.fn(() => true);	
-  const wrapper = mount(	
-    React.createElement(	
-      Line,	
-      {	
-        signs: {},	
-        currentTime: Date.now() + 2000,	
-        line: 'Red',	
-        signConfigs: {},	
-        setConfigs: jest.fn(() => true),	
-        readOnly: false,	
-        configuredHeadways: {},	
-        setConfiguredHeadways: () => {},	
-        chelseaBridgeAnnouncements: 'off',	
-        setChelseaBridgeAnnouncements,	
-      },	
-      null,	
-    ),	
-  );	
-
-  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');	
-  expect(chelseaInput.exists()).toEqual(false);	
+  chelseaInput.simulate('change', { target: { checked: false } });
+  expect(setChelseaBridgeAnnouncements.mock.calls.length).toEqual(2);
+  expect(setChelseaBridgeAnnouncements).toHaveBeenCalledWith('off');
 });
 
+test('does not show chelsea bridge announcements toggle on non-Silver Line pages', () => {
+  const setChelseaBridgeAnnouncements = jest.fn(() => true);
+  const wrapper = mount(
+    React.createElement(
+      Line,
+      {
+        signs: {},
+        currentTime: Date.now() + 2000,
+        line: 'Red',
+        signConfigs: {},
+        setConfigs: jest.fn(() => true),
+        readOnly: false,
+        configuredHeadways: {},
+        setConfiguredHeadways: () => {},
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements,
+      },
+      null,
+    ),
+  );
 
-test('can toggle chelsea bridge announcements on and off on Silver Line page', () => {	
-  const setChelseaBridgeAnnouncements = jest.fn(() => true);	
-  const wrapper = mount(	
-    React.createElement(	
-      Line,	
-      {	
-        signs: {},	
-        currentTime: Date.now() + 2000,	
-        line: 'Silver',	
-        signConfigs: {},	
-        setConfigs: jest.fn(() => true),	
-        readOnly: false,	
-        configuredHeadways: {},	
-        setConfiguredHeadways: () => {},	
-        chelseaBridgeAnnouncements: 'off',	
-        setChelseaBridgeAnnouncements,	
-      },	
-      null,	
-    ),	
-  );	
-
-  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');	
-  chelseaInput.simulate('change', { target: { checked: true } });	
-  expect(setChelseaBridgeAnnouncements.mock.calls.length).toEqual(1);	
-  expect(setChelseaBridgeAnnouncements).toHaveBeenCalledWith('auto');	
-
-  chelseaInput.simulate('change', { target: { checked: false } });	
-  expect(setChelseaBridgeAnnouncements.mock.calls.length).toEqual(2);	
-  expect(setChelseaBridgeAnnouncements).toHaveBeenCalledWith('off');	
-});	
-
-test('does not show chelsea bridge announcements toggle on non-Silver Line pages', () => {	
-  const setChelseaBridgeAnnouncements = jest.fn(() => true);	
-  const wrapper = mount(	
-    React.createElement(	
-      Line,	
-      {	
-        signs: {},	
-        currentTime: Date.now() + 2000,	
-        line: 'Red',	
-        signConfigs: {},	
-        setConfigs: jest.fn(() => true),	
-        readOnly: false,	
-        configuredHeadways: {},	
-        setConfiguredHeadways: () => {},	
-        chelseaBridgeAnnouncements: 'off',	
-        setChelseaBridgeAnnouncements,	
-      },	
-      null,	
-    ),	
-  );	
-
-  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');	
-  expect(chelseaInput.exists()).toEqual(false);	
+  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');
+  expect(chelseaInput.exists()).toEqual(false);
 });

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -479,3 +479,27 @@ test('does not show chelsea bridge announcements toggle on non-Silver Line pages
   const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');
   expect(chelseaInput.exists()).toEqual(false);
 });
+
+test('does not show chelsea bridge toggle if in read-only mode', () => {
+  const wrapper = mount(
+    React.createElement(
+      Line,
+      {
+        signs: {},
+        currentTime: Date.now() + 2000,
+        line: 'Silver',
+        signConfigs: {},
+        setConfigs: () => {},
+        readOnly: true,
+        configuredHeadways: {},
+        setConfiguredHeadways: () => {},
+        chelseaBridgeAnnouncements: 'auto',
+        setChelseaBridgeAnnouncements: () => {},
+      }
+    )
+  )
+
+  expect(wrapper.text()).toMatch('Chelsea Drawbridge Announcements:Auto');
+  const chelseaInput = wrapper.find('input[name="chelsea_bridge"]');
+  expect(chelseaInput.exists()).toEqual(false);
+})


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 read-only shouldn't be able to click bridge toggle](https://app.asana.com/0/584764604969369/1199112192455310)

Since we use custom CSS to provide the toggle, it didn't support being disabled out of the box. You can disable the underlying input, which prevents the slider from moving, but it still *looks* like it works, which is the original problem. I opted to just remove the form element altogether and put a textual description of its value there, like what we do for the Auto / Off / Headway / Custom select box.

<img width="344" alt="Screen Shot 2020-11-20 at 10 31 45 AM" src="https://user-images.githubusercontent.com/384428/99825453-adce7700-2b1c-11eb-9bc1-f6dbcc879042.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
