### PR TITLE
fix: Bring back the bridge toggle CSS

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,3 +2,4 @@
 @import 'base.css';
 @import 'phoenix.css';
 @import 'viewer.css';
+@import 'toggle_switch.css';

--- a/assets/css/toggle_switch.css
+++ b/assets/css/toggle_switch.css
@@ -1,0 +1,57 @@
+.toggle_switch--container {
+  margin-left: 8px;
+  position: relative;
+  display: inline-block;
+}
+
+.toggle_switch--input {
+  display: none;
+}
+
+.toggle_switch--label {
+  margin-bottom: 0;
+  display: block;
+  width: 48px;
+  height: 24px;
+  text-indent: -150%;
+  clip: rect(0 0 0 0);
+  color: transparent;
+  user-select: none;
+}
+
+.toggle_switch--label::before,
+.toggle_switch--label::after {
+  content: '';
+  display: block;
+  position: absolute;
+  cursor: pointer;
+}
+
+.toggle_switch--label::before {
+  width: 100%;
+  height: 100%;
+  background-color: #dedede;
+  border-radius: 9999em;
+  -webkit-transition: background-color 0.25s ease;
+  transition: background-color 0.25s ease;
+}
+
+.toggle_switch--label::after {
+  top: 0;
+  left: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #fff;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.45);
+  -webkit-transition: left 0.25s ease;
+  transition: left 0.25s ease;
+}
+
+.toggle_switch--input:checked + .toggle_switch--label::before {
+  background-color: #3f87f6;
+}
+
+.toggle_switch--input:checked + .toggle_switch--label::after {
+  left: 24px;
+}

--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -139,11 +139,11 @@ function Line({
             </em>
           )}
           {!readOnly && (
-            <div className="switch">
+            <div className="toggle_switch--container">
               <input
                 name="chelsea_bridge"
                 type="checkbox"
-                className="switch-input"
+                className="toggle_switch--input"
                 checked={chelseaBridgeAnnouncements === 'auto'}
                 onChange={(e) => {
                   setChelseaBridgeAnnouncements(
@@ -151,7 +151,7 @@ function Line({
                   );
                 }}
               />
-              <span className="switch-label">Switch</span>
+              <span className="toggle_switch--label">Switch</span>
             </div>
           )}
         </label>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Oops, so [this file](https://github.com/mbta/signs_ui/pull/496/files#diff-ff5b12d43002c0561378c7a62adcbe9384b5270f2fb1d2ea531802a55a98e7d8L86) in #496 was not quite as vestigial as I had thought. The little "toggle slider" widget for the Chelsea Drawbridge used a bit of it:

<img width="370" alt="Screen Shot 2021-04-26 at 10 42 24 AM" src="https://user-images.githubusercontent.com/384428/116111291-21505380-a67c-11eb-9ccc-99b47b5d885a.png">

This PR brings back the specific classes used by that component, and breaks it out into a little "toggle switch" component, following the other conventions of the app, of having the component name prefix the classes like `toggle_switch--`, and un-nesting the classes now that they're namespaced and specific.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
