### PR TITLE
feat: AlertPicker allows user to associate Alert ID with sign

### DIFF
--- a/assets/css/alert_picker.css
+++ b/assets/css/alert_picker.css
@@ -1,0 +1,55 @@
+.alert_picker--container {
+  border: 1px solid #6f6f6f;
+  border-radius: 6px;
+  display: flex;
+  background-color: white;
+  min-height: 10rem;
+  position: absolute;
+  width: 20rem;
+  z-index: 10;
+}
+
+.alert_picker--sidebar {
+  background-color: rgb(109, 107, 107);
+  color: white;
+  flex: none;
+  width: 6rem;
+}
+
+.alert_picker--alert_id {
+  background-color: rgb(109, 107, 107);
+  border: none;
+  color: white;
+  padding-left: 1rem;
+  width: 100%;
+}
+
+.alert_picker--alert_id-active {
+  background-color: white;
+  color: rgb(15, 114, 193);
+}
+
+.alert_picker--content {
+  padding: 0.5rem;
+}
+
+.alert_picker--created_at {
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
+.alert_picker--no_alerts {
+  color: black;
+  line-height: 1.1;
+  margin-left: 1rem;
+  font-size: 0.8rem;
+}
+
+.alert_picker--input {
+  width: 8rem;
+}
+
+.alert_picker--form {
+  display: flex;
+  align-items: center;
+}

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,5 +1,7 @@
 /* This file is for your main application css. */
 @import 'base.css';
+@import 'alert_picker.css';
 @import 'phoenix.css';
+@import 'set_expiration.css';
 @import 'viewer.css';
 @import 'toggle_switch.css';

--- a/assets/css/set_expiration.css
+++ b/assets/css/set_expiration.css
@@ -1,0 +1,3 @@
+.set_expiration--label-disabled {
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/assets/js/AlertPicker.tsx
+++ b/assets/js/AlertPicker.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { RouteAlerts } from './types';
+import { formatTime } from './helpers';
+
+interface AlertPickerPopupProps {
+  alerts: RouteAlerts;
+  setIsOpen: (isOpen: boolean) => void;
+  onChange: (alertId: string) => void;
+}
+
+function AlertPickerPopup({
+  alerts,
+  onChange,
+  setIsOpen,
+}: AlertPickerPopupProps): JSX.Element | null {
+  const alertIds = Object.keys(alerts);
+  const [hoveredAlertId, setHoveredAlertId] = React.useState<string>(
+    alertIds[0],
+  );
+
+  const ref = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className="alert_picker--container">
+      <div className="alert_picker--sidebar">
+        {alertIds.map((alertId) => (
+          <button
+            className={`alert_picker--alert_id${
+              alertId === hoveredAlertId ? ' alert_picker--alert_id-active' : ''
+            }`}
+            key={alertId}
+            onMouseEnter={() => setHoveredAlertId(alertId)}
+            onClick={() => {
+              onChange(alertId);
+            }}
+            value={alertId}
+            type="button"
+          >
+            {alertId}
+          </button>
+        ))}
+      </div>
+      <div className="alert_picker--content">
+        {hoveredAlertId === null ? (
+          'No alert selected'
+        ) : (
+          <>
+            <div>{alerts[hoveredAlertId].service_effect}</div>
+            <div className="alert_picker--created_at">
+              Created {formatTime(alerts[hoveredAlertId].created_at)}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface AlertPickerProps {
+  alertId: string;
+  alerts: RouteAlerts;
+  onChange: (alertId: string) => void;
+  disabled: boolean;
+}
+
+function AlertPicker({
+  alertId,
+  alerts,
+  onChange,
+  disabled,
+}: AlertPickerProps): JSX.Element | null {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  // if alerts change out from under us, AlertPickerPopup should re-render,
+  // since it relies on the presence of alerts.
+  const popupKey = JSON.stringify(Object.keys(alerts).sort());
+
+  const isNoAlerts = Object.keys(alerts).length === 0;
+
+  if (isOpen) {
+    return (
+      <AlertPickerPopup
+        key={popupKey}
+        setIsOpen={setIsOpen}
+        alerts={alerts}
+        onChange={(newAlertId) => {
+          setIsOpen(false);
+          onChange(newAlertId);
+        }}
+      />
+    );
+  }
+  return (
+    <div className="alert_picker--form">
+      <input
+        className="alert_picker--input"
+        aria-label="Alert ID picker"
+        disabled={disabled}
+        type="text"
+        value={alertId || ''}
+        onClick={() => {
+          setIsOpen(true);
+        }}
+        readOnly
+      />
+      {isNoAlerts ? (
+        <div className="alert_picker--no_alerts">
+          There are currently no active alerts for this line.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default AlertPicker;

--- a/assets/js/ConfiguredHeadwaysForm.tsx
+++ b/assets/js/ConfiguredHeadwaysForm.tsx
@@ -249,3 +249,4 @@ ConfiguredHeadwaysForm.defaultProps = {
 };
 
 export default React.memo(ConfiguredHeadwaysForm);
+export { ConfiguredHeadwaysFormProps };

--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -3,6 +3,7 @@ import ConfiguredHeadwaysForm from './ConfiguredHeadwaysForm';
 import Station from './Station';
 import { stationConfig, arincToRealtimeId, branchConfig } from './mbta';
 import {
+  RouteAlerts,
   SignContent,
   ConfiguredHeadways,
   SignConfigs,
@@ -66,6 +67,7 @@ function setAllStationsMode(
 }
 
 interface LineProps {
+  alerts: RouteAlerts;
   signs: SignContent;
   currentTime: number;
   line: string;
@@ -80,6 +82,7 @@ interface LineProps {
 }
 
 function Line({
+  alerts,
   signs,
   currentTime,
   line,
@@ -233,6 +236,7 @@ function Line({
       {stations.map((station: StationConfig) => (
         <Station
           key={station.id}
+          alerts={alerts}
           config={station}
           signs={signs}
           currentTime={currentTime}

--- a/assets/js/SetExpiration.tsx
+++ b/assets/js/SetExpiration.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ReactDatePicker from 'react-datepicker';
-import { SignConfig, SignConfigs } from './types';
+import { RouteAlerts, SignConfig, SignConfigs } from './types';
 
 function stringify(expires: Date | null) {
   if (expires) {
@@ -44,6 +44,7 @@ function parseDate(str: string | null | undefined) {
 }
 
 interface SetExpirationProps {
+  alerts: RouteAlerts;
   realtimeId: string;
   signConfig: SignConfig;
   setConfigs: (x: SignConfigs) => void;

--- a/assets/js/SetExpiration.tsx
+++ b/assets/js/SetExpiration.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ReactDatePicker from 'react-datepicker';
 import { RouteAlerts, SignConfig, SignConfigs } from './types';
+import AlertPicker from './AlertPicker';
 
 function stringify(expires: Date | null) {
   if (expires) {
@@ -15,6 +16,7 @@ function updateConfig(
   realtimeId: string,
   signConfig: SignConfig,
   expires: Date | [Date, Date] | null,
+  alertId: string | null,
 ) {
   if (Array.isArray(expires)) {
     return;
@@ -24,6 +26,7 @@ function updateConfig(
   const newConfig = {
     ...signConfig,
     expires: expirationConfig,
+    alert_id: alertId,
   };
 
   setConfigsFn({
@@ -49,39 +52,101 @@ interface SetExpirationProps {
   signConfig: SignConfig;
   setConfigs: (x: SignConfigs) => void;
   readOnly: boolean;
+  showAlertSelector: boolean;
 }
 
 function SetExpiration({
+  alerts,
   realtimeId,
   signConfig,
   setConfigs,
   readOnly,
+  showAlertSelector,
 }: SetExpirationProps): JSX.Element | null {
-  return !!signConfig.expires || !readOnly ? (
+  const isDateTimeSelected = !!signConfig.expires;
+  const isAlertSelected = !!signConfig.alert_id;
+  const isNoAlerts = Object.keys(alerts).length === 0;
+
+  return isDateTimeSelected || isAlertSelected || !readOnly ? (
     <div>
       {(!readOnly && <strong>Schedule return to &quot;Auto&quot;</strong>) || (
         <strong>Scheduled return to &quot;Auto&quot;</strong>
       )}
-
-      <ReactDatePicker
-        selected={parseDate(signConfig.expires)}
-        onChange={(dt) => updateConfig(setConfigs, realtimeId, signConfig, dt)}
-        showTimeSelect
-        timeFormat="HH:mm"
-        timeIntervals={15}
-        dateFormat="MMM d @ h:mm aa"
-        disabled={readOnly}
-      />
-
-      {signConfig.expires && !readOnly && (
-        <button
-          className="viewer--cancel-expiration-button"
-          type="button"
-          onClick={() => updateConfig(setConfigs, realtimeId, signConfig, null)}
+      <form>
+        <label
+          className={isAlertSelected ? 'set_expiration--label-disabled' : ''}
         >
-          Cancel
-        </button>
-      )}
+          <input
+            className="mr-1"
+            type="radio"
+            checked={isDateTimeSelected}
+            disabled={isAlertSelected}
+            readOnly
+          />
+          Date and time
+          <div>
+            <ReactDatePicker
+              selected={parseDate(signConfig.expires)}
+              onChange={(dt) =>
+                updateConfig(setConfigs, realtimeId, signConfig, dt, null)
+              }
+              showTimeSelect
+              timeFormat="HH:mm"
+              timeIntervals={15}
+              dateFormat="MMM d @ h:mm aa"
+              disabled={readOnly || isAlertSelected}
+            />
+          </div>
+          {isDateTimeSelected && !readOnly && (
+            <button
+              className="set_expiration--cancel"
+              type="button"
+              onClick={() =>
+                updateConfig(setConfigs, realtimeId, signConfig, null, null)
+              }
+            >
+              Cancel
+            </button>
+          )}
+        </label>
+        {showAlertSelector ? (
+          <label
+            className={
+              isDateTimeSelected || isNoAlerts
+                ? 'set_expiration--label-disabled'
+                : ''
+            }
+          >
+            <input
+              className="mr-1"
+              type="radio"
+              checked={isAlertSelected}
+              disabled={isDateTimeSelected || isNoAlerts}
+              readOnly
+            />
+            At the end of an alert effect period
+            <AlertPicker
+              alertId={signConfig.alert_id || ''}
+              alerts={alerts}
+              onChange={(alertId) =>
+                updateConfig(setConfigs, realtimeId, signConfig, null, alertId)
+              }
+              disabled={readOnly || isDateTimeSelected || isNoAlerts}
+            />
+            {isAlertSelected && !readOnly && (
+              <button
+                className="set_expiration--cancel"
+                type="button"
+                onClick={() =>
+                  updateConfig(setConfigs, realtimeId, signConfig, null, null)
+                }
+              >
+                Cancel
+              </button>
+            )}
+          </label>
+        ) : null}
+      </form>
     </div>
   ) : null;
 }

--- a/assets/js/Sign.tsx
+++ b/assets/js/Sign.tsx
@@ -5,6 +5,8 @@ import { SignConfig, SignConfigs, SingleSignContent } from './types';
 import { choosePage } from './helpers';
 import SetExpiration from './SetExpiration';
 
+type SignModeOptions = 'auto' | 'headway' | 'off' | 'static_text';
+
 function isNotExpired(expiration: string, currentTime: number) {
   return Date.parse(expiration) - currentTime > 0;
 }
@@ -23,9 +25,7 @@ function fontSize(signId: string | boolean | undefined) {
   return {};
 }
 
-function makeConfig(
-  mode: 'auto' | 'headway' | 'off' | 'static_text',
-): SignConfig {
+function makeConfig(mode: SignModeOptions): SignConfig {
   if (mode === 'auto') {
     return { mode: 'auto' };
   }
@@ -49,7 +49,7 @@ function makeConfig(
   return { mode: 'off', expires: null };
 }
 
-function displayName(mode: 'auto' | 'headway' | 'off' | 'static_text') {
+function displayName(mode: SignModeOptions) {
   switch (mode) {
     case 'static_text':
       return 'Custom';
@@ -346,3 +346,4 @@ class Sign extends React.Component<
 }
 
 export default Sign;
+export { SignModeOptions };

--- a/assets/js/Sign.tsx
+++ b/assets/js/Sign.tsx
@@ -63,6 +63,16 @@ function displayName(mode: SignModeOptions) {
   }
 }
 
+function shouldShowAlertSelector(line: string): boolean {
+  return (
+    line === 'Red' ||
+    line === 'Blue' ||
+    line === 'Orange' ||
+    line === 'Green' ||
+    line === 'Mattapan'
+  );
+}
+
 function isValidText(text: string) {
   return !/[^a-zA-Z0-9,/!@' +]/.test(text);
 }
@@ -345,6 +355,7 @@ class Sign extends React.Component<
               signConfig={signConfig}
               setConfigs={setConfigs}
               readOnly={readOnly}
+              showAlertSelector={shouldShowAlertSelector(line)}
             />
           </div>
         )}

--- a/assets/js/Sign.tsx
+++ b/assets/js/Sign.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import dateFormat from 'dateformat';
 import lineToColor from './colors';
-import { SignConfig, SignConfigs, SingleSignContent } from './types';
+import {
+  RouteAlerts,
+  SignConfig,
+  SignConfigs,
+  SingleSignContent,
+} from './types';
 import { choosePage } from './helpers';
 import SetExpiration from './SetExpiration';
 
@@ -117,6 +122,7 @@ function line2DisplayText(
 }
 
 interface SignProps {
+  alerts: RouteAlerts;
   signId: string | boolean | undefined;
   modes: {
     auto: boolean;
@@ -199,6 +205,7 @@ class Sign extends React.Component<
 
   render(): JSX.Element {
     const {
+      alerts,
       signId,
       signContent,
       currentTime,
@@ -333,6 +340,7 @@ class Sign extends React.Component<
         {signConfig.mode !== 'auto' && modes.auto && (
           <div className="viewer--schedule-expires">
             <SetExpiration
+              alerts={alerts}
               realtimeId={realtimeId}
               signConfig={signConfig}
               setConfigs={setConfigs}

--- a/assets/js/Station.tsx
+++ b/assets/js/Station.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Sign from './Sign';
 import { arincToRealtimeId } from './mbta';
 import {
+  RouteAlerts,
   SignConfig,
   SignConfigs,
   SignContent,
@@ -38,6 +39,7 @@ function zoneDescription(
 }
 
 function makeSign(
+  alerts: RouteAlerts,
   config: StationConfig,
   zone: Zone,
   signs: {
@@ -71,6 +73,7 @@ function makeSign(
 
     return (
       <Sign
+        alerts={alerts}
         key={key}
         modes={zoneConfig.modes}
         signId={zoneDescription(config, zone)}
@@ -89,6 +92,7 @@ function makeSign(
 }
 
 interface StationProps {
+  alerts: RouteAlerts;
   config: StationConfig;
   signs: SignContent;
   currentTime: number;
@@ -99,6 +103,7 @@ interface StationProps {
 }
 
 function Station({
+  alerts,
   config,
   signs,
   currentTime,
@@ -121,6 +126,7 @@ function Station({
       <div className="row">
         <div className="col">
           {makeSign(
+            alerts,
             config,
             zonePositions.left[0],
             signs,
@@ -131,6 +137,7 @@ function Station({
             readOnly,
           )}
           {makeSign(
+            alerts,
             config,
             zonePositions.left[1],
             signs,
@@ -143,6 +150,7 @@ function Station({
         </div>
         <div className="col">
           {makeSign(
+            alerts,
             config,
             zonePositions.center[0],
             signs,
@@ -153,6 +161,7 @@ function Station({
             readOnly,
           )}
           {makeSign(
+            alerts,
             config,
             zonePositions.center[1],
             signs,
@@ -165,6 +174,7 @@ function Station({
         </div>
         <div className="col">
           {makeSign(
+            alerts,
             config,
             zonePositions.right[0],
             signs,
@@ -175,6 +185,7 @@ function Station({
             readOnly,
           )}
           {makeSign(
+            alerts,
             config,
             zonePositions.right[1],
             signs,

--- a/assets/js/Viewer.tsx
+++ b/assets/js/Viewer.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import Line from './Line';
-import { SignContent, ConfiguredHeadways, SignConfigs } from './types';
+import { Alerts, SignContent, ConfiguredHeadways, SignConfigs } from './types';
+import { alertsForLine } from './helpers';
 
 interface ViewerProps {
+  alerts: Alerts;
   signs: SignContent;
   currentTime: number;
   line: string;
@@ -16,6 +18,7 @@ interface ViewerProps {
 }
 
 function Viewer({
+  alerts,
   signs,
   currentTime,
   line,
@@ -30,6 +33,7 @@ function Viewer({
   return (
     <div>
       <Line
+        alerts={alertsForLine(alerts, line)}
         signs={signs}
         currentTime={currentTime}
         line={line}

--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -11,6 +11,7 @@ declare global {
 }
 
 interface ViewerAppProps {
+  initialAlerts: Alerts;
   initialSigns: SignContent;
   initialSignConfigs: SignConfigs;
   initialConfiguredHeadways: ConfiguredHeadways;
@@ -47,7 +48,7 @@ class ViewerApp extends React.Component<
     this.changeLine = this.changeLine.bind(this);
     this.updateTime = this.updateTime.bind(this);
     this.state = {
-      alerts: {},
+      alerts: props.initialAlerts,
       signs: props.initialSigns,
       signConfigs: props.initialSignConfigs,
       configuredHeadways: props.initialConfiguredHeadways,
@@ -86,9 +87,8 @@ class ViewerApp extends React.Component<
       this.setState({ configuredHeadways: state });
     });
 
-    channel.on('new_alert_state', (state) => {
-      console.log(state); // eslint-disable-line no-console
-      this.setState({ alerts: state });
+    channel.on('new_alert_state', (alertState) => {
+      this.setState({ alerts: alertState });
     });
 
     channel.on('auth_expired', () => {
@@ -155,6 +155,7 @@ class ViewerApp extends React.Component<
 
   render(): JSX.Element {
     const {
+      alerts,
       signs,
       currentTime,
       line,
@@ -226,6 +227,7 @@ class ViewerApp extends React.Component<
         </div>
         {line && (
           <Viewer
+            alerts={alerts}
             signs={signs}
             signConfigs={signConfigs}
             configuredHeadways={configuredHeadways}

--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -7,11 +7,12 @@ import './toggle-all';
 import 'phoenix_html';
 
 import ViewerApp from './ViewerApp';
-import { ConfiguredHeadways, SignConfigs, SignContent } from './types';
+import { Alerts, ConfiguredHeadways, SignConfigs, SignContent } from './types';
 
 declare global {
   interface Window {
     signOutPath: string;
+    initialAlertsData: Alerts;
     initialSignsData: SignContent;
     initialSignConfigs: SignConfigs;
     readOnly: boolean;
@@ -23,6 +24,7 @@ declare global {
 const realtimeRoot = document.getElementById('viewer-root');
 if (realtimeRoot) {
   const {
+    initialAlertsData: initialAlerts,
     initialSignsData: initialSigns,
     initialSignConfigs,
     initialChelseaBridgeAnnouncements,
@@ -33,6 +35,7 @@ if (realtimeRoot) {
   const viewerApp = React.createElement(
     ViewerApp,
     {
+      initialAlerts,
       initialSigns,
       initialSignConfigs,
       readOnly,

--- a/assets/js/helpers.ts
+++ b/assets/js/helpers.ts
@@ -1,3 +1,5 @@
+import { RouteAlerts, Alerts } from './types';
+
 function choosePage(
   pages: { content: string; duration: number }[],
   elapsedSeconds: number,
@@ -19,5 +21,20 @@ function choosePage(
   return '';
 }
 
+function alertsForLine(alerts: Alerts, line: string): RouteAlerts {
+  if (['Red', 'Orange', 'Blue', 'Mattapan'].includes(line)) {
+    return alerts[line] || {};
+  }
+  if (line === 'Green') {
+    return {
+      ...(alerts['Green-B'] || {}),
+      ...(alerts['Green-C'] || {}),
+      ...(alerts['Green-D'] || {}),
+      ...(alerts['Green-E'] || {}),
+    };
+  }
+  return {};
+}
+
 /* eslint-disable import/prefer-default-export */
-export { choosePage };
+export { choosePage, alertsForLine };

--- a/assets/js/helpers.ts
+++ b/assets/js/helpers.ts
@@ -36,5 +36,55 @@ function alertsForLine(alerts: Alerts, line: string): RouteAlerts {
   return {};
 }
 
-/* eslint-disable import/prefer-default-export */
-export { choosePage, alertsForLine };
+function formatTime(dtIso8601: string | null): string {
+  if (dtIso8601 === null) {
+    return '';
+  }
+
+  const dt = new Date(dtIso8601);
+
+  const today = new Date();
+  let datePart;
+  let timePart;
+
+  if (
+    dt.getFullYear() === today.getFullYear() &&
+    dt.getMonth() === today.getMonth() &&
+    dt.getDate() === today.getDate()
+  ) {
+    datePart = 'today';
+  } else {
+    const month = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ][dt.getMonth()];
+    datePart = `${month} ${dt.getDate()}`;
+  }
+
+  const minutes =
+    dt.getMinutes() < 10 ? `0${dt.getMinutes()}` : dt.getMinutes().toString();
+
+  if (dt.getHours() === 0) {
+    timePart = `12:${minutes} AM`;
+  } else if (dt.getHours() < 12) {
+    timePart = `${dt.getHours()}:${minutes} AM`;
+  } else if (dt.getHours() === 12) {
+    timePart = `12:${minutes} PM`;
+  } else {
+    timePart = `${dt.getHours() - 12}:${minutes} PM`;
+  }
+
+  return `${datePart} @ ${timePart}`;
+}
+
+export { choosePage, alertsForLine, formatTime };

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -89,4 +89,5 @@ export {
   SignContent,
   ConfiguredHeadways,
   Zone,
+  ZoneConfig,
 };

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -70,17 +70,23 @@ type ConfiguredHeadways = {
   };
 };
 
+type Alert = {
+  id: string;
+  created_at: string | null;
+  service_effect: string;
+};
+
+type RouteAlerts = {
+  [id: string]: Alert;
+};
+
 type Alerts = {
-  [routeId: string]: {
-    [id: string]: {
-      id: string;
-      created_at: string;
-      service_effect: string;
-    };
-  };
+  [routeId: string]: RouteAlerts;
 };
 
 export {
+  Alert,
+  RouteAlerts,
   Alerts,
   StationConfig,
   SignConfig,

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -38,7 +38,9 @@
         "yup": "^0.29.1"
       },
       "devDependencies": {
+        "@testing-library/dom": "^7.30.4",
         "@testing-library/react": "^11.0.4",
+        "@testing-library/user-event": "^13.1.8",
         "babel-jest": "^26.1.0",
         "enzyme": "^3.3.0",
         "enzyme-adapter-react-16": "^1.1.1",
@@ -1198,9 +1200,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "7.30.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.3.tgz",
-      "integrity": "sha512-7JhIg2MW6WPwyikH2iL3o7z+FTVgSOd2jqCwTAHqK7Qal2gRRYiUQyURAxtbK9VXm/UTyG9bRihv8C5Tznr2zw==",
+      "version": "7.30.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.4.tgz",
+      "integrity": "sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1301,6 +1303,22 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.8.tgz",
+      "integrity": "sha512-M04HgOlJvxILf5xyrkJaEQfFOtcvhy3usLldQIEg9zgFIYQofSmFGVfFlS7BWowqlBGLrItwGMlPXCoBgoHSiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {
@@ -14938,9 +14956,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.30.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.3.tgz",
-      "integrity": "sha512-7JhIg2MW6WPwyikH2iL3o7z+FTVgSOd2jqCwTAHqK7Qal2gRRYiUQyURAxtbK9VXm/UTyG9bRihv8C5Tznr2zw==",
+      "version": "7.30.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.4.tgz",
+      "integrity": "sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -15012,6 +15030,15 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^7.28.1"
+      }
+    },
+    "@testing-library/user-event": {
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.8.tgz",
+      "integrity": "sha512-M04HgOlJvxILf5xyrkJaEQfFOtcvhy3usLldQIEg9zgFIYQofSmFGVfFlS7BWowqlBGLrItwGMlPXCoBgoHSiw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@types/aria-query": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "deploy": "webpack --mode production",
-    "lint": "eslint js/** --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint js/** --fix --ext .js,.jsx,.ts,.tsx",
+    "lint:check": "eslint js/** --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc --noEmit",
     "check": "npm run typecheck && npm run lint && npm run format:check",
     "format": "prettier --write \"{.,**}/*.{js,json,ts,tsx,css,scss}\"",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "devDependencies": {
+    "@testing-library/dom": "^7.30.4",
     "@testing-library/react": "^11.0.4",
+    "@testing-library/user-event": "^13.1.8",
     "babel-jest": "^26.1.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/assets/test/AlertPicker.test.ts
+++ b/assets/test/AlertPicker.test.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AlertPicker from '../js/AlertPicker';
+
+test('can choose an alert from the pop-up', () => {
+  let chosenAlertId = null;
+
+  render(
+    React.createElement(AlertPicker, {
+      alerts: {
+        alert1: {
+          id: 'alert1',
+          service_effect: "there's a problem",
+          created_at: null,
+        },
+        alert2: {
+          id: 'alert2',
+          service_effect: 'some problem',
+          created_at: null,
+        },
+      },
+      alertId: '',
+      onChange: (alertId) => {
+        chosenAlertId = alertId;
+      },
+      disabled: false,
+    }),
+  );
+
+  userEvent.click(screen.getByRole('textbox', { name: /alert id picker/i }));
+  userEvent.click(screen.getByRole('button', { name: 'alert1' }));
+
+  expect(chosenAlertId).toEqual('alert1');
+});

--- a/assets/test/ConfiguredHeadwaysForm.test.ts
+++ b/assets/test/ConfiguredHeadwaysForm.test.ts
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { render, waitFor, fireEvent } from '@testing-library/react';
-import ConfiguredHeadwaysForm from '../js/ConfiguredHeadwaysForm';
+import ConfiguredHeadwaysForm, {
+  ConfiguredHeadwaysFormProps,
+} from '../js/ConfiguredHeadwaysForm';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable camelcase */
 
-let branches;
-let timePeriods;
-let readOnly;
-let configuredHeadways;
-let setConfiguredHeadways;
+let branches: ConfiguredHeadwaysFormProps['branches'];
+let timePeriods: ConfiguredHeadwaysFormProps['timePeriods'];
+let readOnly: ConfiguredHeadwaysFormProps['readOnly'];
+let configuredHeadways: ConfiguredHeadwaysFormProps['configuredHeadways'];
+let setConfiguredHeadways: ConfiguredHeadwaysFormProps['setConfiguredHeadways'];
 window.confirm = jest.fn(() => true);
 
 beforeEach(() => {
@@ -19,8 +21,8 @@ beforeEach(() => {
     { id: 'branch_2', name: 'Branch' },
   ];
   timePeriods = [
-    { id: 'morning', name: 'Morning' },
-    { id: 'evening', name: 'Evening' },
+    { id: 'morning', name: 'Morning', description: 'morning' },
+    { id: 'evening', name: 'Evening', description: 'evening' },
   ];
   setConfiguredHeadways = jest.fn(() => true);
   readOnly = false;

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -33,6 +33,8 @@ test('Shows all signs for a line', () => {
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -66,6 +68,8 @@ test('Shows batch mode buttons when not read-only', () => {
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -101,6 +105,8 @@ test.each([['Silver'], ['Busway']])(
           readOnly,
           configuredHeadways,
           setConfiguredHeadways,
+          chelseaBridgeAnnouncements: 'off',
+          setChelseaBridgeAnnouncements: () => {},
         },
         null,
       ),
@@ -139,6 +145,8 @@ test('Shows "Mixed" batch mode buttons when multiple modes are chosen', () => {
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -177,6 +185,8 @@ test('Does not show "Mixed" batch mode buttons when one mode is chosen', () => {
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -212,6 +222,8 @@ test("Doesn't show batch mode buttons when read-only", () => {
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -246,6 +258,8 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -278,6 +292,8 @@ test('Doesn\t show ConfiguredHeadwaysForm if current line has no branches config
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -310,6 +326,8 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
         readOnly,
         configuredHeadways,
         setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),
@@ -340,7 +358,6 @@ test('Sign config is not affected by batch updates if sign does not support mode
       },
       zones: {
         n: {
-          value: false,
           modes: {
             auto: true,
             custom: true,
@@ -349,7 +366,6 @@ test('Sign config is not affected by batch updates if sign does not support mode
           },
         },
         s: {
-          value: false,
           modes: {
             auto: false,
             custom: true,
@@ -358,7 +374,6 @@ test('Sign config is not affected by batch updates if sign does not support mode
           },
         },
         m: {
-          value: true,
           modes: {
             auto: false,
             custom: true,
@@ -367,7 +382,6 @@ test('Sign config is not affected by batch updates if sign does not support mode
           },
         },
         e: {
-          value: false,
           modes: {
             auto: false,
             custom: true,
@@ -376,7 +390,6 @@ test('Sign config is not affected by batch updates if sign does not support mode
           },
         },
         w: {
-          value: false,
           modes: {
             auto: false,
             custom: true,
@@ -385,7 +398,6 @@ test('Sign config is not affected by batch updates if sign does not support mode
           },
         },
         c: {
-          value: true,
           modes: {
             auto: false,
             custom: true,
@@ -410,6 +422,8 @@ test('Sign config is not affected by batch updates if sign does not support mode
         configuredHeadways,
         setConfiguredHeadways,
         stationConfigs,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
       },
       null,
     ),

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -25,6 +25,7 @@ test('Shows all signs for a line', () => {
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -60,6 +61,7 @@ test('Shows batch mode buttons when not read-only', () => {
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -97,6 +99,7 @@ test.each([['Silver'], ['Busway']])(
       React.createElement(
         Line,
         {
+          alerts: {},
           signs,
           currentTime,
           line,
@@ -137,6 +140,7 @@ test('Shows "Mixed" batch mode buttons when multiple modes are chosen', () => {
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -177,6 +181,7 @@ test('Does not show "Mixed" batch mode buttons when one mode is chosen', () => {
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -214,6 +219,7 @@ test("Doesn't show batch mode buttons when read-only", () => {
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -250,6 +256,7 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -284,6 +291,7 @@ test('Doesn\t show ConfiguredHeadwaysForm if current line has no branches config
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -318,6 +326,7 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -413,6 +422,7 @@ test('Sign config is not affected by batch updates if sign does not support mode
     React.createElement(
       Line,
       {
+        alerts: {},
         signs,
         currentTime,
         line,
@@ -465,6 +475,7 @@ test('can toggle chelsea bridge announcements on and off on Silver Line page', (
     React.createElement(
       Line,
       {
+        alerts: {},
         signs: {},
         currentTime: Date.now() + 2000,
         line: 'Silver',
@@ -496,6 +507,7 @@ test('does not show chelsea bridge announcements toggle on non-Silver Line pages
     React.createElement(
       Line,
       {
+        alerts: {},
         signs: {},
         currentTime: Date.now() + 2000,
         line: 'Red',
@@ -518,6 +530,7 @@ test('does not show chelsea bridge announcements toggle on non-Silver Line pages
 test('does not show chelsea bridge toggle if in read-only mode', () => {
   const wrapper = mount(
     React.createElement(Line, {
+      alerts: {},
       signs: {},
       currentTime: Date.now() + 2000,
       line: 'Silver',

--- a/assets/test/SetExpiration.test.ts
+++ b/assets/test/SetExpiration.test.ts
@@ -12,6 +12,7 @@ test('Can set the expiration time', () => {
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
+      alerts: {},
       realtimeId: 'rtID',
       signConfig: {
         id: '1',
@@ -40,6 +41,7 @@ test('Can clear the expiration time', () => {
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
+      alerts: {},
       realtimeId: 'rtID',
       signConfig: {
         id: '1',
@@ -68,6 +70,7 @@ test('Shows widget when no expiration set if not in read-only mode', () => {
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
+      alerts: {},
       realtimeId: 'rtID',
       signConfig: {
         id: '1',
@@ -91,6 +94,7 @@ test('Suppresses widget when no expiration set if in read-only mode', () => {
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
+      alerts: {},
       realtimeId: 'rtID',
       signConfig: {
         id: '1',
@@ -114,6 +118,7 @@ test("Shows 'Scheduled' when expiration is set if in read-only mode", () => {
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
+      alerts: {},
       realtimeId: 'rtID',
       signConfig: {
         id: '1',

--- a/assets/test/SetExpiration.test.ts
+++ b/assets/test/SetExpiration.test.ts
@@ -25,6 +25,7 @@ test('Can set the expiration time', () => {
         requests.push(arg);
       },
       readOnly,
+      showAlertSelector: true,
     }),
   );
 
@@ -54,10 +55,11 @@ test('Can clear the expiration time', () => {
         requests.push(arg);
       },
       readOnly,
+      showAlertSelector: true,
     }),
   );
 
-  wrapper.find('.viewer--cancel-expiration-button').simulate('click');
+  wrapper.find('.set_expiration--cancel').simulate('click');
   expect(requests.length).toBe(1);
   const newConf = requests[0].rtID;
   expect(newConf.expires).toBe(null);
@@ -81,6 +83,7 @@ test('Shows widget when no expiration set if not in read-only mode', () => {
       },
       setConfigs,
       readOnly,
+      showAlertSelector: true,
     }),
   );
 
@@ -105,6 +108,7 @@ test('Suppresses widget when no expiration set if in read-only mode', () => {
       },
       setConfigs,
       readOnly,
+      showAlertSelector: true,
     }),
   );
 
@@ -129,6 +133,7 @@ test("Shows 'Scheduled' when expiration is set if in read-only mode", () => {
       },
       setConfigs,
       readOnly,
+      showAlertSelector: true,
     }),
   );
 

--- a/assets/test/SetExpiration.test.ts
+++ b/assets/test/SetExpiration.test.ts
@@ -8,11 +8,6 @@ import { SignConfigs } from '../js/types';
 
 test('Can set the expiration time', () => {
   const requests: SignConfigs[] = [];
-
-  const setConfigs = (arg) => {
-    requests.push(arg);
-  };
-
   const readOnly = false;
 
   const wrapper = mount(
@@ -25,7 +20,9 @@ test('Can set the expiration time', () => {
         line2: 'line2',
         expires: null,
       },
-      setConfigs,
+      setConfigs: (arg) => {
+        requests.push(arg);
+      },
       readOnly,
     }),
   );
@@ -39,11 +36,6 @@ test('Can set the expiration time', () => {
 
 test('Can clear the expiration time', () => {
   const requests: SignConfigs[] = [];
-
-  const setConfigs = (arg) => {
-    requests.push(arg);
-  };
-
   const readOnly = false;
 
   const wrapper = mount(
@@ -56,7 +48,9 @@ test('Can clear the expiration time', () => {
         line2: 'line2',
         expires: new Date().toISOString(),
       },
-      setConfigs,
+      setConfigs: (arg) => {
+        requests.push(arg);
+      },
       readOnly,
     }),
   );

--- a/assets/test/Sign.test.ts
+++ b/assets/test/Sign.test.ts
@@ -56,6 +56,7 @@ test('does not show messages that have expired', () => {
     React.createElement(
       Sign,
       {
+        alerts: {},
         signId,
         signContent,
         currentTime,
@@ -101,6 +102,7 @@ test('does not show select in read-only mode', () => {
     React.createElement(
       Sign,
       {
+        alerts: {},
         modes,
         signId,
         signContent,
@@ -143,6 +145,7 @@ test('shows the mode the sign is in in read-only mode', () => {
     React.createElement(
       Sign,
       {
+        alerts: {},
         modes,
         signId,
         signContent,
@@ -182,6 +185,7 @@ test('does show select when not in read-only mode', () => {
     React.createElement(
       Sign,
       {
+        alerts: {},
         signId,
         signContent,
         currentTime,
@@ -269,6 +273,7 @@ test.each([
       React.createElement(
         Sign,
         {
+          alerts: {},
           signId,
           signContent,
           currentTime,
@@ -313,6 +318,7 @@ test('shows the return to auto time field if sign can be set to auto', () => {
     React.createElement(
       Sign,
       {
+        alerts: {},
         signId,
         signContent,
         currentTime,
@@ -352,6 +358,7 @@ test('does not show the return to auto time field if sign can be set to auto', (
     React.createElement(
       Sign,
       {
+        alerts: {},
         signId,
         signContent,
         currentTime,
@@ -391,6 +398,7 @@ test('shows clock even when no other content is present', () => {
     React.createElement(
       Sign,
       {
+        alerts: {},
         signId,
         signContent,
         currentTime,

--- a/assets/test/Sign.test.ts
+++ b/assets/test/Sign.test.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 
-import Sign from '../js/Sign';
-import { SignConfig, SingleSignContent } from '../js/types';
+import Sign, { SignModeOptions } from '../js/Sign';
+import { ZoneConfig, SignConfig, SingleSignContent } from '../js/types';
 
 function signContentWithExpirations(
   time1: string,
@@ -236,47 +236,60 @@ test.each([
       off: true,
     },
   ],
-])('shows configured mode select options', (modesOverride, expected) => {
-  const now = new Date('2019-01-15T20:15:00Z').valueOf();
-  const fresh = new Date(now + 5000).toLocaleString();
-  const currentTime = now + 2000;
-  const signId = 'RDAV-n';
-  const line = 'Red';
-  const signConfig: SignConfig = { mode: 'auto' };
-  const signContent = signContentWithExpirations(fresh, fresh);
-  const setConfigs = () => true;
-  const realtimeId = 'id';
-  const readOnly = false;
-  const modes = {
-    auto: false,
-    headway: false,
-    custom: false,
-    off: false,
-    ...modesOverride,
-  };
+])(
+  'shows configured mode select options',
+  (
+    modesOverride,
+    expected: {
+      auto: boolean;
+      static_text: boolean;
+      headway: boolean;
+      off: boolean;
+    },
+  ) => {
+    const now = new Date('2019-01-15T20:15:00Z').valueOf();
+    const fresh = new Date(now + 5000).toLocaleString();
+    const currentTime = now + 2000;
+    const signId = 'RDAV-n';
+    const line = 'Red';
+    const signConfig: SignConfig = { mode: 'auto' };
+    const signContent = signContentWithExpirations(fresh, fresh);
+    const setConfigs = () => true;
+    const realtimeId = 'id';
+    const readOnly = false;
+    const modes: ZoneConfig['modes'] = {
+      auto: false,
+      headway: false,
+      custom: false,
+      off: false,
+      ...modesOverride,
+    };
 
-  const wrapper = mount(
-    React.createElement(
-      Sign,
-      {
-        signId,
-        signContent,
-        currentTime,
-        line,
-        signConfig,
-        setConfigs,
-        realtimeId,
-        readOnly,
-        modes,
-      },
-      null,
-    ),
-  );
-  expect(wrapper.html()).toMatch('select');
-  Object.keys(expected).forEach((x) => {
-    expect(wrapper.find(`option[value="${x}"]`).exists()).toEqual(expected[x]);
-  });
-});
+    const wrapper = mount(
+      React.createElement(
+        Sign,
+        {
+          signId,
+          signContent,
+          currentTime,
+          line,
+          signConfig,
+          setConfigs,
+          realtimeId,
+          readOnly,
+          modes,
+        },
+        null,
+      ),
+    );
+    expect(wrapper.html()).toMatch('select');
+    (Object.keys(expected) as Array<SignModeOptions>).forEach((x) => {
+      expect(wrapper.find(`option[value="${x}"]`).exists()).toEqual(
+        expected[x],
+      );
+    });
+  },
+);
 
 test('shows the return to auto time field if sign can be set to auto', () => {
   const now = new Date('2019-01-15T20:15:00Z').valueOf();

--- a/assets/test/Station.test.ts
+++ b/assets/test/Station.test.ts
@@ -32,6 +32,7 @@ test('shows the custom configuration information for a station', () => {
 
   const wrapper = mount(
     React.createElement(Station, {
+      alerts: {},
       config,
       signs,
       currentTime,
@@ -74,6 +75,7 @@ test('allows custom reordering of sign positions', () => {
 
   const wrapper = mount(
     React.createElement(Station, {
+      alerts: {},
       config,
       signs,
       currentTime,

--- a/assets/test/ViewerApp.test.tsx
+++ b/assets/test/ViewerApp.test.tsx
@@ -49,7 +49,7 @@ test('Shows all signs for a line', () => {
       {
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
-        initialChelseaBridgeAnnouncements: false,
+        initialChelseaBridgeAnnouncements: 'off',
         initialSignConfigs,
         readOnly,
         signOutPath,
@@ -83,7 +83,7 @@ test('Can enable/disable a sign', () => {
       {
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
-        initialChelseaBridgeAnnouncements: false,
+        initialChelseaBridgeAnnouncements: 'off',
         initialSignConfigs,
         readOnly,
         signOutPath,
@@ -116,7 +116,7 @@ test('Disabling a sign clears any static text', () => {
       {
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
-        initialChelseaBridgeAnnouncements: false,
+        initialChelseaBridgeAnnouncements: 'off',
         initialSignConfigs,
         readOnly,
         signOutPath,
@@ -153,7 +153,7 @@ test('Shows sign out link', () => {
       {
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
-        initialChelseaBridgeAnnouncements: false,
+        initialChelseaBridgeAnnouncements: 'off',
         initialSignConfigs,
         readOnly,
         signOutPath,

--- a/assets/test/ViewerApp.test.tsx
+++ b/assets/test/ViewerApp.test.tsx
@@ -47,6 +47,7 @@ test('Shows all signs for a line', () => {
     React.createElement(
       ViewerApp,
       {
+        initialAlerts: {},
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
         initialChelseaBridgeAnnouncements: 'off',
@@ -81,6 +82,7 @@ test('Can enable/disable a sign', () => {
     React.createElement(
       ViewerApp,
       {
+        initialAlerts: {},
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
         initialChelseaBridgeAnnouncements: 'off',
@@ -114,6 +116,7 @@ test('Disabling a sign clears any static text', () => {
     React.createElement(
       ViewerApp,
       {
+        initialAlerts: {},
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
         initialChelseaBridgeAnnouncements: 'off',
@@ -151,6 +154,7 @@ test('Shows sign out link', () => {
     React.createElement(
       ViewerApp,
       {
+        initialAlerts: {},
         initialSigns: signs,
         initialConfiguredHeadways: configuredHeadways,
         initialChelseaBridgeAnnouncements: 'off',

--- a/assets/test/helpers.test.ts
+++ b/assets/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { choosePage, alertsForLine } from '../js/helpers';
+import { choosePage, alertsForLine, formatTime } from '../js/helpers';
 
 test('choosePage returns the first page when there is only one', () => {
   const pages = [{ content: 'the page', duration: 5 }];
@@ -55,4 +55,25 @@ test('alertsForLine combines alerts across Green branches', () => {
 test('alertsForLine returns empty object for unknown line', () => {
   const alerts = {};
   expect(alertsForLine(alerts, 'Unknown')).toEqual({});
+});
+
+test('formatTime returns empty string if null', () => {
+  expect(formatTime(null)).toEqual('');
+});
+
+test('formatTime says "Today" if today', () => {
+  const dt = new Date().toISOString();
+  expect(formatTime(dt).startsWith('today')).toBe(true);
+});
+
+test('formatTime formats the minutes with two digits', () => {
+  expect(formatTime('2021-05-01T12:05:00Z')).toEqual('May 1 @ 8:05 AM');
+  expect(formatTime('2021-05-01T12:15:00Z')).toEqual('May 1 @ 8:15 AM');
+});
+
+test('formatTime converts 24 hours to AM/PM correctly', () => {
+  expect(formatTime('2021-05-01T04:30:00Z')).toEqual('May 1 @ 12:30 AM');
+  expect(formatTime('2021-05-01T10:30:00Z')).toEqual('May 1 @ 6:30 AM');
+  expect(formatTime('2021-05-01T16:30:00Z')).toEqual('May 1 @ 12:30 PM');
+  expect(formatTime('2021-05-01T19:30:00Z')).toEqual('May 1 @ 3:30 PM');
 });

--- a/assets/test/helpers.test.ts
+++ b/assets/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { choosePage } from '../js/helpers';
+import { choosePage, alertsForLine } from '../js/helpers';
 
 test('choosePage returns the first page when there is only one', () => {
   const pages = [{ content: 'the page', duration: 5 }];
@@ -25,4 +25,34 @@ test('choosePage cycles through pages as time elapses', () => {
   expect(choosePage(pages, 9.5)).toEqual('page one');
   expect(choosePage(pages, 10.5)).toEqual('page one');
   expect(choosePage(pages, 100.5)).toEqual('page one');
+});
+
+function makeAlert(id: string) {
+  return { id, created_at: null, service_effect: 'something is wrong' };
+}
+
+test('alertsForLine returns alerts that are present for a line', () => {
+  const alerts = { Red: { '1234': makeAlert('1234') } };
+  expect(alertsForLine(alerts, 'Red')).toEqual({ '1234': makeAlert('1234') });
+});
+
+test('alertsForLine returns empty object for a line with no alerts', () => {
+  const alerts = {};
+  expect(alertsForLine(alerts, 'Red')).toEqual({});
+});
+
+test('alertsForLine combines alerts across Green branches', () => {
+  const alerts = {
+    'Green-B': { '123': makeAlert('123') },
+    'Green-C': { '456': makeAlert('456') },
+  };
+  expect(alertsForLine(alerts, 'Green')).toEqual({
+    '123': makeAlert('123'),
+    '456': makeAlert('456'),
+  });
+});
+
+test('alertsForLine returns empty object for unknown line', () => {
+  const alerts = {};
+  expect(alertsForLine(alerts, 'Unknown')).toEqual({});
 });

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -56,7 +56,7 @@
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     },
     "include": [
-        "js"
+        "js", "test"
     ],
     "exclude": [
         "node_modules"

--- a/lib/signs_ui/alerts/state.ex
+++ b/lib/signs_ui/alerts/state.ex
@@ -20,14 +20,19 @@ defmodule SignsUi.Alerts.State do
     GenStage.start_link(__MODULE__, init_opts, start_opts)
   end
 
-  @impl GenStage
-  def init(opts) do
-    {:consumer, %{}, opts}
-  end
-
   @spec active_alert_ids(GenStage.stage()) :: MapSet.t(Alert.id())
   def active_alert_ids(pid \\ __MODULE__) do
     GenStage.call(pid, :active_alert_ids)
+  end
+
+  @spec all(GenStage.stage()) :: Display.t()
+  def all(pid \\ __MODULE__) do
+    GenStage.call(pid, :all)
+  end
+
+  @impl GenStage
+  def init(opts) do
+    {:consumer, %{}, opts}
   end
 
   @impl GenStage
@@ -35,6 +40,11 @@ defmodule SignsUi.Alerts.State do
     alert_ids = state |> Map.keys() |> MapSet.new()
 
     {:reply, alert_ids, [], state}
+  end
+
+  @impl GenStage
+  def handle_call(:all, _from, state) do
+    {:reply, Display.format_state(state), [], state}
   end
 
   @impl GenStage

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -8,6 +8,7 @@ defmodule SignsUiWeb.MessagesController do
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     signs = State.list_signs()
+    alerts = SignsUi.Alerts.State.all()
 
     config = SignsUi.Config.State.get_all()
 
@@ -31,6 +32,7 @@ defmodule SignsUiWeb.MessagesController do
     sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito")
 
     render(conn, "index.html",
+      alerts: alerts,
       signs: signs,
       sign_configs: sign_configs,
       configured_headways: configured_headways,

--- a/lib/signs_ui_web/templates/messages/index.html.eex
+++ b/lib/signs_ui_web/templates/messages/index.html.eex
@@ -1,10 +1,12 @@
 <div id="viewer-root"></div>
 
+<% alerts_data = Base.encode64(Jason.encode!(@alerts)) %>
 <% signs_data = Base.encode64(Jason.encode!(@signs)) %>
 <% sign_configs = Base.encode64(Jason.encode!(@sign_configs)) %>
 <% configured_headways = Base.encode64(Jason.encode!(@configured_headways)) %>
 <% chelsea_bridge_announcements = Base.encode64(Jason.encode!(@chelsea_bridge_announcements)) %>
 
+<script>window.initialAlertsData = JSON.parse(atob("<%= alerts_data %>"))</script>
 <script>window.initialSignsData = JSON.parse(atob("<%= signs_data %>"))</script>
 <script>window.initialSignConfigs = JSON.parse(atob("<%= sign_configs %>"))</script>
 <script>window.initialConfiguredHeadways = JSON.parse(atob("<%= configured_headways %>"))</script>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Signs-UI frontend allows PIOs to associate an alert with custom text](https://app.asana.com/0/584764604969369/1200160485026824)

Best reviewed commit by commit. They are:

* A tweak to our `package.json` scripts, so that `npm run lint` actually fixes files if it can, and `npm run lint:check` does a non-destructive check that things are already in order, akin to the `format` and `format:check` that we have already.
* Update our tsconfig.json to also include our test directory. This means the `npm run check` task, which invokes `tsc` will also raise type errors in our tests. There were a number of existing type errors that this raised, so this commit fixes those up.
* The third commit just loads sample Alert data for the Orange Line to play around with on the front end, and will be removed before merging.
* Serializes the current alerts onto the page when it loads, for the initial data, akin to how it's done for, e.g., the signs, and passes that data down through the props of the React app components to `SetExpiration` where the actual Alert Picker will eventually live.
* Finally, the last commit actually implements the Alert Picker. You can play around with it with `mix phx.server` and checking out the Orange Line (or the other lines to see the behavior when there's no alerts).

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
