### PR TITLE
feat: sign_groups key added to SignsUi.Config.State.t

### DIFF
--- a/lib/signs_ui/config/request.ex
+++ b/lib/signs_ui/config/request.ex
@@ -9,15 +9,16 @@ defmodule SignsUi.Config.Request do
   alias SignsUi.Config.S3
   alias SignsUi.Config.Sign
 
-  @spec get_signs({module(), atom(), []}) ::
+  @spec get_state({module(), atom(), []}) ::
           {:ok,
            %{
              signs: %{String.t() => Sign.t()},
              configured_headways: ConfiguredHeadways.t(),
-             chelsea_bridge_announcements: String.t()
+             chelsea_bridge_announcements: String.t(),
+             sign_groups: map()
            }}
           | {:error, any()}
-  def get_signs({mod, fun, args} \\ {S3, :get_object, []}) do
+  def get_state({mod, fun, args} \\ {S3, :get_object, []}) do
     case apply(mod, fun, args) do
       {:ok, %{body: json}} ->
         parse(json)
@@ -33,7 +34,8 @@ defmodule SignsUi.Config.Request do
            %{
              signs: %{String.t() => Sign.t()},
              configured_headways: ConfiguredHeadways.t(),
-             chelsea_bridge_announcements: String.t()
+             chelsea_bridge_announcements: String.t(),
+             sign_groups: map()
            }}
           | {:error, any()}
   defp parse(json) do
@@ -46,6 +48,15 @@ defmodule SignsUi.Config.Request do
         configured_headways = Map.get(response, "configured_headways", %{})
         chelsea_bridge_announcements = Map.get(response, "chelsea_bridge_announcements", "off")
 
+        sign_groups =
+          Map.get(response, "sign_groups", %{
+            "Red" => %{},
+            "Blue" => %{},
+            "Orange" => %{},
+            "Green" => %{},
+            "Mattapan" => %{}
+          })
+
         {:ok,
          %{
            signs:
@@ -54,7 +65,8 @@ defmodule SignsUi.Config.Request do
              end),
            configured_headways:
              ConfiguredHeadways.parse_configured_headways_json(configured_headways),
-           chelsea_bridge_announcements: chelsea_bridge_announcements
+           chelsea_bridge_announcements: chelsea_bridge_announcements,
+           sign_groups: sign_groups
          }}
 
       {:error, reason} ->

--- a/lib/signs_ui/config/s3.ex
+++ b/lib/signs_ui/config/s3.ex
@@ -9,7 +9,8 @@ defmodule SignsUi.Config.S3 do
   def update(%{
         signs: signs,
         configured_headways: configured_headways,
-        chelsea_bridge_announcements: chelsea_bridge_announcements
+        chelsea_bridge_announcements: chelsea_bridge_announcements,
+        sign_groups: sign_groups
       }) do
     json =
       Jason.encode(
@@ -17,7 +18,8 @@ defmodule SignsUi.Config.S3 do
           "signs" => Config.Signs.format_signs_for_json(signs),
           "configured_headways" =>
             Config.ConfiguredHeadways.format_configured_headways_for_json(configured_headways),
-          "chelsea_bridge_announcements" => chelsea_bridge_announcements
+          "chelsea_bridge_announcements" => chelsea_bridge_announcements,
+          "sign_groups" => sign_groups
         },
         pretty: true
       )

--- a/test/signs_ui/config/request_test.exs
+++ b/test/signs_ui/config/request_test.exs
@@ -37,7 +37,7 @@ defmodule SignsUi.Config.RequestTest do
                   }
                 },
                 configured_headways: %{}
-              }} = Request.get_signs({OldFormat, :get_object, []})
+              }} = Request.get_state({OldFormat, :get_object, []})
     end
 
     test "works with new format" do
@@ -50,7 +50,7 @@ defmodule SignsUi.Config.RequestTest do
                   }
                 },
                 configured_headways: %{}
-              }} = Request.get_signs({NewFormat, :get_object, []})
+              }} = Request.get_state({NewFormat, :get_object, []})
     end
   end
 end

--- a/test/signs_ui/config/s3_test.exs
+++ b/test/signs_ui/config/s3_test.exs
@@ -11,7 +11,14 @@ defmodule SignsUi.Config.S3Test do
           "sign2" => %Sign{id: "sign2", config: %{mode: :auto}}
         },
         configured_headways: %{},
-        chelsea_bridge_announcements: "auto"
+        chelsea_bridge_announcements: "auto",
+        sign_groups: %{
+          "Red" => %{},
+          "Blue" => %{},
+          "Orange" => %{},
+          "Green" => %{},
+          "Mattapan" => %{}
+        }
       }
 
       {:ok, object} = update(config)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Data model changes](https://app.asana.com/0/584764604969369/1200222628914553/f)

`sign_groups` has been added to the state and JSON requests.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
