### PR TITLE
Sign groups expire

### DIFF
--- a/lib/signs_ui/config/expiration.ex
+++ b/lib/signs_ui/config/expiration.ex
@@ -44,10 +44,13 @@ defmodule SignsUi.Config.Expiration do
     config_state = Config.State.get_all(state.sign_state_server)
     sign_updates = expire_signs(config_state, state.time_fetcher, state.alert_fetcher)
 
-    active_sign_groups =
+    {active, expired} =
       SignGroups.active(config_state.sign_groups, state.time_fetcher.(), state.alert_fetcher.())
 
-    Logger.info(["active_sign_groups: ", inspect(active_sign_groups)])
+    if expired != [] do
+      Logger.info(["expired_sign_groups: ", inspect(expired)])
+      {:ok, _new_state} = Config.State.update_sign_groups(state.sign_state_server, active)
+    end
 
     if sign_updates != %{} do
       Logger.info("Cleaning expired settings for sign IDs: #{inspect(Map.keys(sign_updates))}")

--- a/lib/signs_ui/config/expiration.ex
+++ b/lib/signs_ui/config/expiration.ex
@@ -4,6 +4,7 @@ defmodule SignsUi.Config.Expiration do
   """
   use GenServer
   require Logger
+  alias SignsUi.Config
   alias SignsUi.Config.Sign
 
   @type state :: %{
@@ -39,10 +40,8 @@ defmodule SignsUi.Config.Expiration do
 
   @spec handle_info(:process_expired, state()) :: {:noreply, state()}
   def handle_info(:process_expired, state) do
-    updates =
-      state.sign_state_server
-      |> SignsUi.Config.State.get_all()
-      |> expire_signs(state.time_fetcher, state.alert_fetcher)
+    sign_state = Config.State.get_all(state.sign_state_server)
+    updates = expire_signs(sign_state, state.time_fetcher, state.alert_fetcher)
 
     if updates != %{} do
       Logger.info("Cleaning expired settings for sign IDs: #{inspect(Map.keys(updates))}")

--- a/lib/signs_ui/config/expiration.ex
+++ b/lib/signs_ui/config/expiration.ex
@@ -44,12 +44,12 @@ defmodule SignsUi.Config.Expiration do
     config_state = Config.State.get_all(state.sign_state_server)
     sign_updates = expire_signs(config_state, state.time_fetcher, state.alert_fetcher)
 
-    {active, expired} =
-      SignGroups.active(config_state.sign_groups, state.time_fetcher.(), state.alert_fetcher.())
+    group_updates =
+      SignGroups.expired(config_state.sign_groups, state.time_fetcher.(), state.alert_fetcher.())
 
-    if expired != [] do
-      Logger.info(["expired_sign_groups: ", inspect(expired)])
-      {:ok, _new_state} = Config.State.update_sign_groups(state.sign_state_server, active)
+    if group_updates != %{} do
+      Logger.info(["expired_sign_groups: ", inspect(Map.keys(group_updates))])
+      {:ok, _new_state} = Config.State.update_sign_groups(state.sign_state_server, group_updates)
     end
 
     if sign_updates != %{} do

--- a/lib/signs_ui/config/request.ex
+++ b/lib/signs_ui/config/request.ex
@@ -36,11 +36,11 @@ defmodule SignsUi.Config.Request do
 
         sign_groups =
           Map.get(response, "sign_groups", %{
-            "Red" => SignGroup.empty(),
-            "Blue" => SignGroup.empty(),
-            "Orange" => SignGroup.empty(),
-            "Green" => SignGroup.empty(),
-            "Mattapan" => SignGroup.empty()
+            "Red" => %{},
+            "Blue" => %{},
+            "Orange" => %{},
+            "Green" => %{},
+            "Mattapan" => %{}
           })
 
         {:ok,

--- a/lib/signs_ui/config/request.ex
+++ b/lib/signs_ui/config/request.ex
@@ -8,7 +8,7 @@ defmodule SignsUi.Config.Request do
   alias SignsUi.Config.ConfiguredHeadways
   alias SignsUi.Config.S3
   alias SignsUi.Config.Sign
-  alias SignsUi.Config.SignGroup
+  alias SignsUi.Config.SignGroups
   alias SignsUi.Config.State
 
   @spec get_state({module(), atom(), []}) :: {:ok, State.t()} | {:error, any()}
@@ -52,7 +52,7 @@ defmodule SignsUi.Config.Request do
            configured_headways:
              ConfiguredHeadways.parse_configured_headways_json(configured_headways),
            chelsea_bridge_announcements: chelsea_bridge_announcements,
-           sign_groups: sign_groups
+           sign_groups: SignGroups.from_json(sign_groups)
          }}
 
       {:error, reason} ->

--- a/lib/signs_ui/config/request.ex
+++ b/lib/signs_ui/config/request.ex
@@ -8,16 +8,10 @@ defmodule SignsUi.Config.Request do
   alias SignsUi.Config.ConfiguredHeadways
   alias SignsUi.Config.S3
   alias SignsUi.Config.Sign
+  alias SignsUi.Config.SignGroup
+  alias SignsUi.Config.State
 
-  @spec get_state({module(), atom(), []}) ::
-          {:ok,
-           %{
-             signs: %{String.t() => Sign.t()},
-             configured_headways: ConfiguredHeadways.t(),
-             chelsea_bridge_announcements: String.t(),
-             sign_groups: map()
-           }}
-          | {:error, any()}
+  @spec get_state({module(), atom(), []}) :: {:ok, State.t()} | {:error, any()}
   def get_state({mod, fun, args} \\ {S3, :get_object, []}) do
     case apply(mod, fun, args) do
       {:ok, %{body: json}} ->
@@ -29,15 +23,7 @@ defmodule SignsUi.Config.Request do
     end
   end
 
-  @spec parse(String.t()) ::
-          {:ok,
-           %{
-             signs: %{String.t() => Sign.t()},
-             configured_headways: ConfiguredHeadways.t(),
-             chelsea_bridge_announcements: String.t(),
-             sign_groups: map()
-           }}
-          | {:error, any()}
+  @spec parse(String.t()) :: {:ok, State.t()} | {:error, any()}
   defp parse(json) do
     case Jason.decode(json) do
       {:ok, response} ->
@@ -50,11 +36,11 @@ defmodule SignsUi.Config.Request do
 
         sign_groups =
           Map.get(response, "sign_groups", %{
-            "Red" => %{},
-            "Blue" => %{},
-            "Orange" => %{},
-            "Green" => %{},
-            "Mattapan" => %{}
+            "Red" => SignGroup.empty(),
+            "Blue" => SignGroup.empty(),
+            "Orange" => SignGroup.empty(),
+            "Green" => SignGroup.empty(),
+            "Mattapan" => SignGroup.empty()
           })
 
         {:ok,

--- a/lib/signs_ui/config/s3.ex
+++ b/lib/signs_ui/config/s3.ex
@@ -5,7 +5,7 @@ defmodule SignsUi.Config.S3 do
 
   alias SignsUi.Config
 
-  @spec update(SignsUi.Config.State.t()) :: ExAws.Operation.S3.t() | {:error, any}
+  @spec update(SignsUi.Config.State.t()) :: {:ok, any()} | {:error, any()}
   def update(%{
         signs: signs,
         configured_headways: configured_headways,
@@ -27,7 +27,8 @@ defmodule SignsUi.Config.S3 do
     do_update(json)
   end
 
-  def do_update({:error, reason, _}) do
+  @spec do_update({:ok, String.t()} | {:error, any()}) :: {:ok, any()} | {:error, any()}
+  def do_update({:error, reason}) do
     {:error, reason}
   end
 
@@ -36,11 +37,13 @@ defmodule SignsUi.Config.S3 do
     bucket_name |> ExAws.S3.put_object(path_name, json) |> aws_requestor.request()
   end
 
+  @spec get_object() :: {:ok, any()} | {:error, any()}
   def get_object do
     {aws_requestor, bucket_name, path_name} = get_aws_vars()
     bucket_name |> ExAws.S3.get_object(path_name) |> aws_requestor.request()
   end
 
+  @spec get_aws_vars() :: {module(), String.t(), String.t()}
   defp get_aws_vars do
     bucket_name = Application.get_env(:signs_ui, :aws_signs_bucket)
     path_name = Application.get_env(:signs_ui, :aws_signs_path)

--- a/lib/signs_ui/config/sign_group.ex
+++ b/lib/signs_ui/config/sign_group.ex
@@ -3,6 +3,7 @@ defmodule SignsUi.Config.SignGroup do
   Represents a sign group.
   """
 
+  require Logger
   alias SignsUi.Alerts.Alert
   alias SignsUi.Config.Sign
 
@@ -31,5 +32,30 @@ defmodule SignsUi.Config.SignGroup do
   def expired?(%{alert_id: alert_id}, _current_time, alerts)
       when not is_nil(alert_id) do
     not MapSet.member?(alerts, alert_id)
+  end
+
+  @spec from_json(%{String.t() => any()}) :: t()
+  def from_json(map) do
+    %__MODULE__{
+      sign_ids: map["sign_ids"],
+      line1: map["line1"],
+      line2: map["line2"],
+      expires: expiration_from_iso8601(map["expires"]),
+      alert_id: map["alert_id"]
+    }
+  end
+
+  @spec expiration_from_iso8601(String.t() | nil) :: DateTime.t() | nil
+  defp expiration_from_iso8601(nil), do: nil
+
+  defp expiration_from_iso8601(expiration) do
+    case DateTime.from_iso8601(expiration) do
+      {:ok, dt, 0} ->
+        dt
+
+      _ ->
+        Logger.warning("Invalid sign group expiration time #{inspect(expiration)} received.")
+        nil
+    end
   end
 end

--- a/lib/signs_ui/config/sign_group.ex
+++ b/lib/signs_ui/config/sign_group.ex
@@ -1,0 +1,30 @@
+defmodule SignsUi.Config.SignGroup do
+  @moduledoc """
+  Represents a sign group.
+  """
+
+  alias SignsUi.Alerts.Alert
+  alias SignsUi.Config.Sign
+
+  @enforce_keys [:sign_ids, :line1, :line2, :expires, :alert_id]
+  @derive Jason.Encoder
+  defstruct @enforce_keys
+
+  @type t() :: %__MODULE__{
+          sign_ids: [Sign.id()],
+          line1: String.t() | nil,
+          line2: String.t() | nil,
+          expires: DateTime.t() | nil,
+          alert_id: Alert.id() | nil
+        }
+
+  def empty do
+    %__MODULE__{
+      sign_ids: [],
+      line1: nil,
+      line2: nil,
+      expires: nil,
+      alert_id: nil
+    }
+  end
+end

--- a/lib/signs_ui/config/sign_group.ex
+++ b/lib/signs_ui/config/sign_group.ex
@@ -8,7 +8,8 @@ defmodule SignsUi.Config.SignGroup do
   alias SignsUi.Config.Sign
 
   @derive Jason.Encoder
-  defstruct [:line1, :line2, :expires, :alert_id, sign_ids: []]
+  @enforce_keys [:route_id]
+  defstruct [:line1, :line2, :expires, :alert_id, :route_id, sign_ids: []]
 
   @type t() :: %__MODULE__{
           sign_ids: [Sign.id()],
@@ -38,6 +39,7 @@ defmodule SignsUi.Config.SignGroup do
   def from_json(map) do
     %__MODULE__{
       sign_ids: map["sign_ids"],
+      route_id: map["route_id"],
       line1: map["line1"],
       line2: map["line2"],
       expires: expiration_from_iso8601(map["expires"]),

--- a/lib/signs_ui/config/sign_group.ex
+++ b/lib/signs_ui/config/sign_group.ex
@@ -6,9 +6,8 @@ defmodule SignsUi.Config.SignGroup do
   alias SignsUi.Alerts.Alert
   alias SignsUi.Config.Sign
 
-  @enforce_keys [:sign_ids, :line1, :line2, :expires, :alert_id]
   @derive Jason.Encoder
-  defstruct @enforce_keys
+  defstruct [:line1, :line2, :expires, :alert_id, sign_ids: []]
 
   @type t() :: %__MODULE__{
           sign_ids: [Sign.id()],

--- a/lib/signs_ui/config/sign_group.ex
+++ b/lib/signs_ui/config/sign_group.ex
@@ -9,10 +9,12 @@ defmodule SignsUi.Config.SignGroup do
 
   @derive Jason.Encoder
   @enforce_keys [:route_id]
-  defstruct [:line1, :line2, :expires, :alert_id, :route_id, sign_ids: []]
+  defstruct @enforce_keys ++ [:line1, :line2, :expires, :alert_id, sign_ids: []]
 
+  @type route_id() :: String.t()
   @type t() :: %__MODULE__{
           sign_ids: [Sign.id()],
+          route_id: route_id(),
           line1: String.t() | nil,
           line2: String.t() | nil,
           expires: DateTime.t() | nil,
@@ -38,7 +40,7 @@ defmodule SignsUi.Config.SignGroup do
   @spec from_json(%{String.t() => any()}) :: t()
   def from_json(map) do
     %__MODULE__{
-      sign_ids: map["sign_ids"],
+      sign_ids: Map.get(map, "sign_ids", []),
       route_id: map["route_id"],
       line1: map["line1"],
       line2: map["line2"],
@@ -52,7 +54,7 @@ defmodule SignsUi.Config.SignGroup do
 
   defp expiration_from_iso8601(expiration) do
     case DateTime.from_iso8601(expiration) do
-      {:ok, dt, 0} ->
+      {:ok, dt, _offset} ->
         dt
 
       _ ->

--- a/lib/signs_ui/config/sign_group.ex
+++ b/lib/signs_ui/config/sign_group.ex
@@ -17,13 +17,19 @@ defmodule SignsUi.Config.SignGroup do
           alert_id: Alert.id() | nil
         }
 
-  def empty do
-    %__MODULE__{
-      sign_ids: [],
-      line1: nil,
-      line2: nil,
-      expires: nil,
-      alert_id: nil
-    }
+  @spec expired?(t(), DateTime.t(), MapSet.t(Alert.id())) :: boolean()
+  def expired?(%{expires: expiration, alert_id: alert_id}, _current_time, _alerts)
+      when is_nil(expiration) and is_nil(alert_id) do
+    false
+  end
+
+  def expired?(%{expires: expiration}, current_time, _alerts)
+      when not is_nil(expiration) do
+    DateTime.compare(current_time, expiration) != :lt
+  end
+
+  def expired?(%{alert_id: alert_id}, _current_time, alerts)
+      when not is_nil(alert_id) do
+    not MapSet.member?(alerts, alert_id)
   end
 end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -1,4 +1,8 @@
 defmodule SignsUi.Config.SignGroups do
+  @moduledoc """
+  Represents the state of all current sign groups.
+  """
+
   alias SignsUi.Alerts.Alert
   alias SignsUi.Config.SignGroup
 
@@ -6,6 +10,9 @@ defmodule SignsUi.Config.SignGroups do
   @type unix_time() :: String.t()
   @type t() :: %{route_id() => %{unix_time() => SignGroup.t()}}
 
+  @doc """
+  Returns all the active (not expired) groups.
+  """
   @spec active(t(), DateTime.t(), MapSet.t(Alert.id())) :: t()
   def active(sign_groups, current_time, alerts) do
     for {route, groups} <- sign_groups,

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -19,7 +19,7 @@ defmodule SignsUi.Config.SignGroups do
         {created_at, group} <- groups,
         SignGroup.expired?(group, current_time, alerts),
         reduce: sign_groups do
-      acc -> Map.update(acc, route, nil, &Map.delete(&1, created_at))
+      acc -> acc[route][created_at] |> pop_in() |> elem(1)
     end
   end
 end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -19,9 +19,16 @@ defmodule SignsUi.Config.SignGroups do
         {created_at, group} <- groups,
         SignGroup.expired?(group, current_time, alerts),
         reduce: {sign_groups, []} do
-      {active, expired} ->
-        {removed, updated} = pop_in(active[route][created_at])
+      {current, expired} ->
+        {removed, updated} = pop_in(current[route][created_at])
         {updated, [removed | expired]}
+    end
+  end
+
+  @spec from_json(%{route_id() => %{unix_time() => %{String.t() => any()}}}) :: t()
+  def from_json(map) do
+    for {route, groups} <- map, into: %{} do
+      {route, Map.new(groups, fn {time, group} -> {time, SignGroup.from_json(group)} end)}
     end
   end
 end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -1,0 +1,18 @@
+defmodule SignsUi.Config.SignGroups do
+  alias SignsUi.Alerts.Alert
+  alias SignsUi.Config.SignGroup
+
+  @type route_id() :: String.t()
+  @type unix_time() :: String.t()
+  @type t() :: %{route_id() => %{unix_time() => SignGroup.t()}}
+
+  @spec active(t(), DateTime.t(), MapSet.t(Alert.id())) :: t()
+  def active(sign_groups, current_time, alerts) do
+    for {route, groups} <- sign_groups,
+        {created_at, group} <- groups,
+        SignGroup.expired?(group, current_time, alerts),
+        reduce: sign_groups do
+      acc -> Map.update(acc, route, nil, &Map.delete(&1, created_at))
+    end
+  end
+end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -12,16 +12,14 @@ defmodule SignsUi.Config.SignGroups do
   @type display() :: %{route_id() => t()}
 
   @doc """
-  Returns all the active (not expired) groups.
+  Returns a map of expired group timestamps to empty maps.
   """
-  @spec active(t(), DateTime.t(), MapSet.t(Alert.id())) :: {t(), [SignGroup.t()]}
-  def active(sign_groups, current_time, alerts) do
+  @spec expired(t(), DateTime.t(), MapSet.t(Alert.id())) :: t()
+  def expired(sign_groups, current_time, alerts) do
     for {created_at, group} <- sign_groups,
         SignGroup.expired?(group, current_time, alerts),
-        reduce: {sign_groups, []} do
-      {current, expired} ->
-        {removed, updated} = pop_in(current[created_at])
-        {updated, [removed | expired]}
+        into: %{} do
+      {created_at, %{}}
     end
   end
 

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -9,7 +9,7 @@ defmodule SignsUi.Config.SignGroups do
   @type route_id() :: String.t()
   @type unix_time() :: String.t()
   @type t() :: %{unix_time() => SignGroup.t() | %{}}
-  @type display() :: %{route_id() => t()}
+  @type by_route() :: %{route_id() => t()}
 
   @doc """
   Returns a map of expired group timestamps to empty maps.
@@ -26,5 +26,13 @@ defmodule SignsUi.Config.SignGroups do
   @spec from_json(t()) :: t()
   def from_json(groups) do
     Map.new(groups, fn {time, group} -> {time, SignGroup.from_json(group)} end)
+  end
+
+  @spec by_route(t()) :: by_route()
+  def by_route(groups) do
+    groups
+    |> Enum.group_by(fn {_created_at, %SignGroup{route_id: route_id}} -> route_id end)
+    |> Enum.map(fn {route_id, groups} -> {route_id, Map.new(groups)} end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -13,13 +13,15 @@ defmodule SignsUi.Config.SignGroups do
   @doc """
   Returns all the active (not expired) groups.
   """
-  @spec active(t(), DateTime.t(), MapSet.t(Alert.id())) :: t()
+  @spec active(t(), DateTime.t(), MapSet.t(Alert.id())) :: {t(), [SignGroup.t()]}
   def active(sign_groups, current_time, alerts) do
     for {route, groups} <- sign_groups,
         {created_at, group} <- groups,
         SignGroup.expired?(group, current_time, alerts),
-        reduce: sign_groups do
-      acc -> acc[route][created_at] |> pop_in() |> elem(1)
+        reduce: {sign_groups, []} do
+      {active, expired} ->
+        {removed, updated} = pop_in(active[route][created_at])
+        {updated, [removed | expired]}
     end
   end
 end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -35,4 +35,16 @@ defmodule SignsUi.Config.SignGroups do
     |> Enum.map(fn {route_id, groups} -> {route_id, Map.new(groups)} end)
     |> Enum.into(%{})
   end
+
+  @spec update(t(), {unix_time(), SignGroup.t() | %{}}) :: t()
+  def update(groups, {created_at, map}) when map == %{}, do: Map.delete(groups, created_at)
+
+  def update(groups, {created_at, %SignGroup{sign_ids: new_sign_ids} = group}) do
+    groups
+    |> Enum.map(fn {created_at, %SignGroup{sign_ids: sign_ids} = group} ->
+      {created_at, %{group | sign_ids: Enum.filter(sign_ids, &(&1 not in new_sign_ids))}}
+    end)
+    |> Enum.into(%{})
+    |> Map.put(created_at, group)
+  end
 end

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -36,10 +36,10 @@ defmodule SignsUi.Config.SignGroups do
     |> Enum.into(%{})
   end
 
-  @spec update(t(), {unix_time(), SignGroup.t() | %{}}) :: t()
-  def update(groups, {created_at, map}) when map == %{}, do: Map.delete(groups, created_at)
+  @spec update({unix_time(), SignGroup.t() | %{}}, t()) :: t()
+  def update({created_at, map}, groups) when map == %{}, do: Map.delete(groups, created_at)
 
-  def update(groups, {created_at, %SignGroup{sign_ids: new_sign_ids} = group}) do
+  def update({created_at, %SignGroup{sign_ids: new_sign_ids} = group}, groups) do
     groups
     |> Enum.map(fn {created_at, %SignGroup{sign_ids: sign_ids} = group} ->
       {created_at, %{group | sign_ids: Enum.filter(sign_ids, &(&1 not in new_sign_ids))}}

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -8,27 +8,25 @@ defmodule SignsUi.Config.SignGroups do
 
   @type route_id() :: String.t()
   @type unix_time() :: String.t()
-  @type t() :: %{route_id() => %{unix_time() => SignGroup.t()}}
+  @type t() :: %{unix_time() => SignGroup.t() | %{}}
+  @type display() :: %{route_id() => t()}
 
   @doc """
   Returns all the active (not expired) groups.
   """
   @spec active(t(), DateTime.t(), MapSet.t(Alert.id())) :: {t(), [SignGroup.t()]}
   def active(sign_groups, current_time, alerts) do
-    for {route, groups} <- sign_groups,
-        {created_at, group} <- groups,
+    for {created_at, group} <- sign_groups,
         SignGroup.expired?(group, current_time, alerts),
         reduce: {sign_groups, []} do
       {current, expired} ->
-        {removed, updated} = pop_in(current[route][created_at])
+        {removed, updated} = pop_in(current[created_at])
         {updated, [removed | expired]}
     end
   end
 
-  @spec from_json(%{route_id() => %{unix_time() => %{String.t() => any()}}}) :: t()
-  def from_json(map) do
-    for {route, groups} <- map, into: %{} do
-      {route, Map.new(groups, fn {time, group} -> {time, SignGroup.from_json(group)} end)}
-    end
+  @spec from_json(t()) :: t()
+  def from_json(groups) do
+    Map.new(groups, fn {time, group} -> {time, SignGroup.from_json(group)} end)
   end
 end

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -21,17 +21,26 @@ defmodule SignsUi.Config.State do
     GenServer.start_link(__MODULE__, [], name: name)
   end
 
+  @doc """
+  Gets all the current state.
+  """
   @spec get_all(GenServer.server()) :: t()
   def get_all(pid \\ __MODULE__) do
     GenServer.call(pid, :get_all)
   end
 
+  @doc """
+  Updates the state with new sign configurations by merging them in.
+  """
   @spec update_sign_configs(GenServer.server(), %{Config.Sign.id() => Config.Sign.t()}) ::
           {:ok, t()}
   def update_sign_configs(pid \\ __MODULE__, changes) do
     GenServer.call(pid, {:update_sign_configs, changes})
   end
 
+  @doc """
+  Sets configured headways to the provided value.
+  """
   @spec update_configured_headways(GenServer.server(), %{
           String.t() => Config.ConfiguredHeadway.t()
         }) ::
@@ -40,6 +49,9 @@ defmodule SignsUi.Config.State do
     GenServer.call(pid, {:update_configured_headways, changes})
   end
 
+  @doc """
+  Sets Chelsea Bridge announcements to the provided value.
+  """
   @spec update_chelsea_bridge_announcements(GenServer.server(), %{
           String.t() => String.t()
         }) ::
@@ -48,6 +60,9 @@ defmodule SignsUi.Config.State do
     GenServer.call(pid, {:update_chelsea_bridge_announcements, changes})
   end
 
+  @doc """
+  Applies the given SignGroups changes (inserts, updates, and deletes).
+  """
   @spec update_sign_groups(GenServer.server(), SignGroups.t()) :: {:ok, t()}
   def update_sign_groups(pid \\ __MODULE__, changes) do
     GenServer.call(pid, {:update_sign_groups, changes})

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -23,6 +23,7 @@ defmodule SignsUi.Config.State do
     GenServer.start_link(__MODULE__, [], name: name)
   end
 
+  @spec get_all(GenServer.server()) :: t()
   def get_all(pid \\ __MODULE__) do
     GenServer.call(pid, :get_all)
   end

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -87,7 +87,7 @@ defmodule SignsUi.Config.State do
   end
 
   def handle_call({:update_sign_groups, changes}, _from, old_state) do
-    new_state = Map.put(old_state, :sign_groups, changes)
+    new_state = %{old_state | sign_groups: changes}
     {:ok, _} = save_state(new_state)
 
     SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", changes)

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -140,11 +140,8 @@ defmodule SignsUi.Config.State do
   end
 
   @spec save_sign_group_changes(SignGroups.t(), t()) :: t()
-  defp save_sign_group_changes(removed, old_state) do
-    new_groups =
-      old_state.sign_groups
-      |> Enum.filter(fn {created_at, _group} -> created_at not in Map.keys(removed) end)
-      |> Enum.into(%{})
+  defp save_sign_group_changes(changes, old_state) do
+    new_groups = Enum.reduce(changes, old_state.sign_groups, &SignGroups.update/2)
 
     new_state = %{old_state | sign_groups: new_groups}
 

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -150,7 +150,11 @@ defmodule SignsUi.Config.State do
 
     {:ok, _} = save_state(new_state)
 
-    SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", new_groups)
+    SignsUiWeb.Endpoint.broadcast!(
+      "sign_groups:all",
+      "new_sign_groups_state",
+      SignGroups.by_route(new_groups)
+    )
 
     new_state
   end

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -87,10 +87,7 @@ defmodule SignsUi.Config.State do
   end
 
   def handle_call({:update_sign_groups, changes}, _from, old_state) do
-    new_state = %{old_state | sign_groups: changes}
-    {:ok, _} = save_state(new_state)
-
-    SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", changes)
+    new_state = save_sign_group_changes(changes, old_state)
     {:reply, {:ok, new_state}, new_state}
   end
 
@@ -138,6 +135,16 @@ defmodule SignsUi.Config.State do
       "new_chelsea_bridge_announcements_state",
       %{chelsea_bridge_announcements: value}
     )
+
+    new_state
+  end
+
+  @spec save_sign_group_changes(SignGroups.t(), t()) :: t()
+  defp save_sign_group_changes(changes, old_state) do
+    new_state = %{old_state | sign_groups: changes}
+    {:ok, _} = save_state(new_state)
+
+    SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", changes)
 
     new_state
   end

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -48,6 +48,11 @@ defmodule SignsUi.Config.State do
     GenServer.call(pid, {:update_chelsea_bridge_announcements, changes})
   end
 
+  @spec update_sign_groups(GenServer.server(), SignGroups.t()) :: {:ok, t()}
+  def update_sign_groups(pid \\ __MODULE__, changes) do
+    GenServer.call(pid, {:update_sign_groups, changes})
+  end
+
   @spec init(any()) :: {:ok, t()} | {:stop, any()}
   def init(_) do
     case Config.Request.get_state() do
@@ -78,6 +83,14 @@ defmodule SignsUi.Config.State do
 
   def handle_call({:update_chelsea_bridge_announcements, changes}, _from, old_state) do
     new_state = save_chelsea_bridge_announcements(changes, old_state)
+    {:reply, {:ok, new_state}, new_state}
+  end
+
+  def handle_call({:update_sign_groups, changes}, _from, old_state) do
+    new_state = Map.put(old_state, :sign_groups, changes)
+    {:ok, _} = save_state(new_state)
+
+    SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", changes)
     {:reply, {:ok, new_state}, new_state}
   end
 

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -7,15 +7,13 @@ defmodule SignsUi.Config.State do
 
   alias SignsUi.Config
   alias SignsUi.Config.ConfiguredHeadways
-  alias SignsUi.Config.SignGroup
-
-  @type route_id() :: String.t()
+  alias SignsUi.Config.SignGroups
 
   @type t :: %{
           signs: %{Config.Sign.id() => Config.Sign.t()},
           configured_headways: ConfiguredHeadways.t(),
           chelsea_bridge_announcements: String.t(),
-          sign_groups: %{route_id() => %{String.t() => SignGroup.t()}}
+          sign_groups: SignGroups.t()
         }
 
   def start_link(opts \\ []) do

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -6,16 +6,16 @@ defmodule SignsUi.Config.State do
   require Logger
 
   alias SignsUi.Config
+  alias SignsUi.Config.ConfiguredHeadways
+  alias SignsUi.Config.SignGroup
+
+  @type route_id() :: String.t()
 
   @type t :: %{
-          signs: %{
-            Config.Sign.id() => Config.Sign.t()
-          },
-          configured_headways: %{
-            String.t() => %{String.t() => Config.ConfiguredHeadway.t()}
-          },
+          signs: %{Config.Sign.id() => Config.Sign.t()},
+          configured_headways: ConfiguredHeadways.t(),
           chelsea_bridge_announcements: String.t(),
-          sign_groups: map()
+          sign_groups: %{route_id() => SignGroup.t()}
         }
 
   def start_link(opts \\ []) do

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -15,7 +15,7 @@ defmodule SignsUi.Config.State do
           signs: %{Config.Sign.id() => Config.Sign.t()},
           configured_headways: ConfiguredHeadways.t(),
           chelsea_bridge_announcements: String.t(),
-          sign_groups: %{route_id() => SignGroup.t()}
+          sign_groups: %{route_id() => %{String.t() => SignGroup.t()}}
         }
 
   def start_link(opts \\ []) do

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -140,11 +140,17 @@ defmodule SignsUi.Config.State do
   end
 
   @spec save_sign_group_changes(SignGroups.t(), t()) :: t()
-  defp save_sign_group_changes(changes, old_state) do
-    new_state = %{old_state | sign_groups: changes}
+  defp save_sign_group_changes(removed, old_state) do
+    new_groups =
+      old_state.sign_groups
+      |> Enum.filter(fn {created_at, _group} -> created_at not in Map.keys(removed) end)
+      |> Enum.into(%{})
+
+    new_state = %{old_state | sign_groups: new_groups}
+
     {:ok, _} = save_state(new_state)
 
-    SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", changes)
+    SignsUiWeb.Endpoint.broadcast!("sign_groups:all", "new_sign_groups_state", new_groups)
 
     new_state
   end

--- a/lib/signs_ui/mock/aws_request.ex
+++ b/lib/signs_ui/mock/aws_request.ex
@@ -48,19 +48,7 @@ defmodule SignsUi.Mock.AwsRequest do
         }
       },
       "chelsea_bridge_announcements" => "auto",
-      "sign_groups" => %{
-        "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
-        "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
-        "1222" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert", route_id: "Red"},
-        "55534" => %SignsUi.Config.SignGroup{
-          route_id: "Red",
-          expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-        },
-        "34334" => %SignsUi.Config.SignGroup{
-          route_id: "Red",
-          expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
-        }
-      }
+      "sign_groups" => %{}
     }
 
     {:ok, %{body: Jason.encode!(config)}}

--- a/lib/signs_ui/mock/aws_request.ex
+++ b/lib/signs_ui/mock/aws_request.ex
@@ -47,7 +47,20 @@ defmodule SignsUi.Mock.AwsRequest do
           }
         }
       },
-      "chelsea_bridge_announcements" => "auto"
+      "chelsea_bridge_announcements" => "auto",
+      "sign_groups" => %{
+        "Red" => %{
+          "5555" => %SignsUi.Config.SignGroup{},
+          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert"},
+          "1222" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert"},
+          "55534" => %SignsUi.Config.SignGroup{
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+          },
+          "34334" => %SignsUi.Config.SignGroup{
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
+          }
+        }
+      }
     }
 
     {:ok, %{body: Jason.encode!(config)}}

--- a/lib/signs_ui/mock/aws_request.ex
+++ b/lib/signs_ui/mock/aws_request.ex
@@ -50,13 +50,15 @@ defmodule SignsUi.Mock.AwsRequest do
       "chelsea_bridge_announcements" => "auto",
       "sign_groups" => %{
         "Red" => %{
-          "5555" => %SignsUi.Config.SignGroup{},
-          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert"},
-          "1222" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert"},
+          "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
+          "1222" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert", route_id: "Red"},
           "55534" => %SignsUi.Config.SignGroup{
+            route_id: "Red",
             expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
           },
           "34334" => %SignsUi.Config.SignGroup{
+            route_id: "Red",
             expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
           }
         }

--- a/lib/signs_ui/mock/aws_request.ex
+++ b/lib/signs_ui/mock/aws_request.ex
@@ -49,18 +49,16 @@ defmodule SignsUi.Mock.AwsRequest do
       },
       "chelsea_bridge_announcements" => "auto",
       "sign_groups" => %{
-        "Red" => %{
-          "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
-          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
-          "1222" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert", route_id: "Red"},
-          "55534" => %SignsUi.Config.SignGroup{
-            route_id: "Red",
-            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-          },
-          "34334" => %SignsUi.Config.SignGroup{
-            route_id: "Red",
-            expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
-          }
+        "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+        "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
+        "1222" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert", route_id: "Red"},
+        "55534" => %SignsUi.Config.SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+        },
+        "34334" => %SignsUi.Config.SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
         }
       }
     }

--- a/test/signs_ui/config/expiration_test.exs
+++ b/test/signs_ui/config/expiration_test.exs
@@ -5,7 +5,7 @@ defmodule SignsUi.Config.ExpirationTest do
   alias SignsUi.Signs.Sign
   alias SignsUi.Config.Sign
 
-  describe "expire_signs/2" do
+  describe "expire_signs/3" do
     test "produces correct updates when times expire" do
       {:ok, time1, 0} = DateTime.from_iso8601("2019-01-15T12:00:00Z")
       {:ok, time2, 0} = DateTime.from_iso8601("2019-01-15T14:00:00Z")
@@ -57,9 +57,7 @@ defmodule SignsUi.Config.ExpirationTest do
                fn -> MapSet.new([]) end
              ) == expected_updates
     end
-  end
 
-  describe "expire_signs_via_alert/2" do
     test "produces correct updates when alerts expire" do
       sign_state = %{
         signs: %{
@@ -203,6 +201,38 @@ defmodule SignsUi.Config.ExpirationTest do
       assert new_state.signs["harvard_northbound"].config.mode == :auto
       assert new_state.signs["harvard_southbound"].config.mode == :static_text
       assert new_state.signs["central_southbound"].config.mode == :static_text
+    end
+
+    test "only removes expired sign groups" do
+      {:ok, _pid} = SignsUi.Config.State.start_link(name: :sign_state_test)
+
+      state = %{
+        time_fetcher: fn ->
+          DateTime.new!(~D[2021-05-21], ~T[17:32:00])
+        end,
+        loop_ms: 5_000,
+        sign_state_server: :sign_state_test,
+        alert_fetcher: fn -> MapSet.new(["active_alert"]) end
+      }
+
+      log =
+        capture_log([level: :info], fn ->
+          {:noreply, _state} = SignsUi.Config.Expiration.handle_info(:process_expired, state)
+        end)
+
+      assert log =~ "expired_sign_groups"
+
+      new_state = SignsUi.Config.State.get_all(:sign_state_test)
+
+      assert new_state.sign_groups == %{
+               "Red" => %{
+                 "5555" => %SignsUi.Config.SignGroup{},
+                 "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert"},
+                 "55534" => %SignsUi.Config.SignGroup{
+                   expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+                 }
+               }
+             }
     end
   end
 end

--- a/test/signs_ui/config/expiration_test.exs
+++ b/test/signs_ui/config/expiration_test.exs
@@ -225,13 +225,11 @@ defmodule SignsUi.Config.ExpirationTest do
       new_state = SignsUi.Config.State.get_all(:sign_state_test)
 
       assert new_state.sign_groups == %{
-               "Red" => %{
-                 "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
-                 "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
-                 "55534" => %SignsUi.Config.SignGroup{
-                   route_id: "Red",
-                   expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-                 }
+               "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+               "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
+               "55534" => %SignsUi.Config.SignGroup{
+                 route_id: "Red",
+                 expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
                }
              }
     end

--- a/test/signs_ui/config/expiration_test.exs
+++ b/test/signs_ui/config/expiration_test.exs
@@ -204,7 +204,23 @@ defmodule SignsUi.Config.ExpirationTest do
     end
 
     test "only removes expired sign groups" do
-      {:ok, _pid} = SignsUi.Config.State.start_link(name: :sign_state_test)
+      {:ok, pid} = SignsUi.Config.State.start_link(name: :sign_state_test)
+
+      SignsUi.Config.State.update_sign_groups(pid, %{
+        "1111" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert", route_id: "Red"},
+        "2222" => %SignsUi.Config.SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
+        },
+        "3333" => %SignsUi.Config.SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+        },
+        "4444" => %SignsUi.Config.SignGroup{
+          route_id: "Red",
+          alert_id: "active_alert"
+        }
+      })
 
       state = %{
         time_fetcher: fn ->
@@ -225,11 +241,13 @@ defmodule SignsUi.Config.ExpirationTest do
       new_state = SignsUi.Config.State.get_all(:sign_state_test)
 
       assert new_state.sign_groups == %{
-               "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
-               "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
-               "55534" => %SignsUi.Config.SignGroup{
+               "3333" => %SignsUi.Config.SignGroup{
                  route_id: "Red",
                  expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+               },
+               "4444" => %SignsUi.Config.SignGroup{
+                 route_id: "Red",
+                 alert_id: "active_alert"
                }
              }
     end

--- a/test/signs_ui/config/expiration_test.exs
+++ b/test/signs_ui/config/expiration_test.exs
@@ -226,9 +226,10 @@ defmodule SignsUi.Config.ExpirationTest do
 
       assert new_state.sign_groups == %{
                "Red" => %{
-                 "5555" => %SignsUi.Config.SignGroup{},
-                 "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert"},
+                 "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+                 "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
                  "55534" => %SignsUi.Config.SignGroup{
+                   route_id: "Red",
                    expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
                  }
                }

--- a/test/signs_ui/config/s3_test.exs
+++ b/test/signs_ui/config/s3_test.exs
@@ -14,11 +14,11 @@ defmodule SignsUi.Config.S3Test do
         configured_headways: %{},
         chelsea_bridge_announcements: "auto",
         sign_groups: %{
-          "Red" => SignGroup.empty(),
-          "Blue" => SignGroup.empty(),
-          "Orange" => SignGroup.empty(),
-          "Green" => SignGroup.empty(),
-          "Mattapan" => SignGroup.empty()
+          "Red" => %{},
+          "Blue" => %{},
+          "Orange" => %{},
+          "Green" => %{},
+          "Mattapan" => %{}
         }
       }
 

--- a/test/signs_ui/config/s3_test.exs
+++ b/test/signs_ui/config/s3_test.exs
@@ -2,7 +2,6 @@ defmodule SignsUi.Config.S3Test do
   use ExUnit.Case, async: true
   import SignsUi.Config.S3
   alias SignsUi.Config.Sign
-  alias SignsUi.Config.SignGroup
 
   describe "update/1" do
     test "sends_update" do

--- a/test/signs_ui/config/s3_test.exs
+++ b/test/signs_ui/config/s3_test.exs
@@ -2,6 +2,7 @@ defmodule SignsUi.Config.S3Test do
   use ExUnit.Case, async: true
   import SignsUi.Config.S3
   alias SignsUi.Config.Sign
+  alias SignsUi.Config.SignGroup
 
   describe "update/1" do
     test "sends_update" do
@@ -13,11 +14,11 @@ defmodule SignsUi.Config.S3Test do
         configured_headways: %{},
         chelsea_bridge_announcements: "auto",
         sign_groups: %{
-          "Red" => %{},
-          "Blue" => %{},
-          "Orange" => %{},
-          "Green" => %{},
-          "Mattapan" => %{}
+          "Red" => SignGroup.empty(),
+          "Blue" => SignGroup.empty(),
+          "Orange" => SignGroup.empty(),
+          "Green" => SignGroup.empty(),
+          "Mattapan" => SignGroup.empty()
         }
       }
 

--- a/test/signs_ui/config/sign_group_test.exs
+++ b/test/signs_ui/config/sign_group_test.exs
@@ -5,7 +5,7 @@ defmodule SignsUi.Config.SignGroupTest do
   describe "expired/3" do
     test "does not expire a sign group without an alert or expiration time" do
       assert not SignGroup.expired?(
-               %SignGroup{},
+               %SignGroup{route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new(["active_alert"])
              )
@@ -13,7 +13,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
     test "does not expire a sign group with an active alert id" do
       assert not SignGroup.expired?(
-               %SignGroup{alert_id: "active_alert"},
+               %SignGroup{alert_id: "active_alert", route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new(["active_alert"])
              )
@@ -21,7 +21,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
     test "does not expire a sign group with future expiration" do
       assert not SignGroup.expired?(
-               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00]), route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new()
              )
@@ -29,7 +29,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
     test "expires a sign group with an inactive alert id" do
       assert SignGroup.expired?(
-               %SignGroup{alert_id: "active_alert"},
+               %SignGroup{alert_id: "active_alert", route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new()
              )
@@ -37,7 +37,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
     test "expires a sign group with a past expiration" do
       assert SignGroup.expired?(
-               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])},
+               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00]), route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new()
              )
@@ -48,6 +48,7 @@ defmodule SignsUi.Config.SignGroupTest do
     test "converts a valid json map into a valid SignGroup struct" do
       json = %{
         "sign_ids" => ["a_sign_id", "another_sign_id"],
+        "route_id" => "Red",
         "expires" => "2021-05-15T14:00:00Z",
         "line1" => "foo",
         "line2" => "bar",
@@ -56,6 +57,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
       assert SignGroup.from_json(json) == %SignsUi.Config.SignGroup{
                alert_id: "active_alert",
+               route_id: "Red",
                expires: ~U[2021-05-15 14:00:00Z],
                line1: "foo",
                line2: "bar",
@@ -66,6 +68,7 @@ defmodule SignsUi.Config.SignGroupTest do
     test "converts a garbled DateTime to nil and logs the error" do
       json = %{
         "sign_ids" => ["a_sign_id", "another_sign_id"],
+        "route_id" => "Red",
         "expires" => "2021-05-114:00:00Z",
         "line1" => "foo",
         "line2" => "bar",
@@ -74,6 +77,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
       assert SignGroup.from_json(json) == %SignsUi.Config.SignGroup{
                alert_id: "active_alert",
+               route_id: "Red",
                expires: nil,
                line1: "foo",
                line2: "bar",

--- a/test/signs_ui/config/sign_group_test.exs
+++ b/test/signs_ui/config/sign_group_test.exs
@@ -4,7 +4,7 @@ defmodule SignsUi.Config.SignGroupTest do
 
   describe "expired/3" do
     test "does not expire a sign group without an alert or expiration time" do
-      assert not SignGroup.expired?(
+      refute SignGroup.expired?(
                %SignGroup{route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new(["active_alert"])
@@ -12,7 +12,7 @@ defmodule SignsUi.Config.SignGroupTest do
     end
 
     test "does not expire a sign group with an active alert id" do
-      assert not SignGroup.expired?(
+      refute SignGroup.expired?(
                %SignGroup{alert_id: "active_alert", route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new(["active_alert"])
@@ -20,7 +20,7 @@ defmodule SignsUi.Config.SignGroupTest do
     end
 
     test "does not expire a sign group with future expiration" do
-      assert not SignGroup.expired?(
+      refute SignGroup.expired?(
                %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00]), route_id: "Red"},
                DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
                MapSet.new()

--- a/test/signs_ui/config/sign_group_test.exs
+++ b/test/signs_ui/config/sign_group_test.exs
@@ -1,0 +1,46 @@
+defmodule SignsUi.Config.SignGroupTest do
+  use ExUnit.Case
+  alias SignsUi.Config.SignGroup
+
+  describe "expired/3" do
+    test "does not expire a sign group without an alert or expiration time" do
+      assert not SignGroup.expired?(
+               %SignGroup{},
+               DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
+               MapSet.new(["active_alert"])
+             )
+    end
+
+    test "does not expire a sign group with an active alert id" do
+      assert not SignGroup.expired?(
+               %SignGroup{alert_id: "active_alert"},
+               DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
+               MapSet.new(["active_alert"])
+             )
+    end
+
+    test "does not expire a sign group with future expiration" do
+      assert not SignGroup.expired?(
+               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+               DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
+               MapSet.new()
+             )
+    end
+
+    test "expires a sign group with an inactive alert id" do
+      assert SignGroup.expired?(
+               %SignGroup{alert_id: "active_alert"},
+               DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
+               MapSet.new()
+             )
+    end
+
+    test "expires a sign group with a past expiration" do
+      assert SignGroup.expired?(
+               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])},
+               DateTime.new!(~D[2021-05-21], ~T[17:31:00]),
+               MapSet.new()
+             )
+    end
+  end
+end

--- a/test/signs_ui/config/sign_group_test.exs
+++ b/test/signs_ui/config/sign_group_test.exs
@@ -43,4 +43,42 @@ defmodule SignsUi.Config.SignGroupTest do
              )
     end
   end
+
+  describe "from_json/1" do
+    test "converts a valid json map into a valid SignGroup struct" do
+      json = %{
+        "sign_ids" => ["a_sign_id", "another_sign_id"],
+        "expires" => "2021-05-15T14:00:00Z",
+        "line1" => "foo",
+        "line2" => "bar",
+        "alert_id" => "active_alert"
+      }
+
+      assert SignGroup.from_json(json) == %SignsUi.Config.SignGroup{
+               alert_id: "active_alert",
+               expires: ~U[2021-05-15 14:00:00Z],
+               line1: "foo",
+               line2: "bar",
+               sign_ids: ["a_sign_id", "another_sign_id"]
+             }
+    end
+
+    test "converts a garbled DateTime to nil and logs the error" do
+      json = %{
+        "sign_ids" => ["a_sign_id", "another_sign_id"],
+        "expires" => "2021-05-114:00:00Z",
+        "line1" => "foo",
+        "line2" => "bar",
+        "alert_id" => "active_alert"
+      }
+
+      assert SignGroup.from_json(json) == %SignsUi.Config.SignGroup{
+               alert_id: "active_alert",
+               expires: nil,
+               line1: "foo",
+               line2: "bar",
+               sign_ids: ["a_sign_id", "another_sign_id"]
+             }
+    end
+  end
 end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -7,10 +7,13 @@ defmodule SignsUi.Config.SignGroupsTest do
     test "removes sign groups with inactive alerts" do
       sign_groups = %{
         "Red" => %{
-          "5555" => %SignGroup{},
-          "1234" => %SignGroup{alert_id: "active_alert"},
-          "5678" => %SignGroup{alert_id: "inactive_alert"},
-          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])}
+          "5555" => %SignGroup{route_id: "Red"},
+          "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+          "5678" => %SignGroup{alert_id: "inactive_alert", route_id: "Red"},
+          "55534" => %SignGroup{
+            route_id: "Red",
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+          }
         }
       }
 
@@ -23,22 +26,31 @@ defmodule SignsUi.Config.SignGroupsTest do
 
       assert active == %{
                "Red" => %{
-                 "5555" => %SignGroup{},
-                 "1234" => %SignGroup{alert_id: "active_alert"},
-                 "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])}
+                 "5555" => %SignGroup{route_id: "Red"},
+                 "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+                 "55534" => %SignGroup{
+                   route_id: "Red",
+                   expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+                 }
                }
              }
 
-      assert expired == [%SignGroup{alert_id: "inactive_alert"}]
+      assert expired == [%SignGroup{alert_id: "inactive_alert", route_id: "Red"}]
     end
 
     test "removes sign groups that expired in the past" do
       sign_groups = %{
         "Red" => %{
-          "5555" => %SignGroup{},
-          "1234" => %SignGroup{alert_id: "active_alert"},
-          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
-          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
+          "5555" => %SignGroup{route_id: "Red"},
+          "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+          "55534" => %SignGroup{
+            route_id: "Red",
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+          },
+          "34334" => %SignGroup{
+            route_id: "Red",
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
+          }
         }
       }
 
@@ -51,13 +63,18 @@ defmodule SignsUi.Config.SignGroupsTest do
 
       assert active == %{
                "Red" => %{
-                 "5555" => %SignGroup{},
-                 "1234" => %SignGroup{alert_id: "active_alert"},
-                 "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])}
+                 "5555" => %SignGroup{route_id: "Red"},
+                 "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+                 "55534" => %SignGroup{
+                   route_id: "Red",
+                   expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+                 }
                }
              }
 
-      assert expired == [%SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}]
+      assert expired == [
+               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00]), route_id: "Red"}
+             ]
     end
   end
 
@@ -67,6 +84,7 @@ defmodule SignsUi.Config.SignGroupsTest do
         "Red" => %{
           "1234" => %{
             "sign_ids" => [],
+            "route_id" => "Red",
             "expires" => nil,
             "line1" => nil,
             "line2" => nil,
@@ -77,7 +95,7 @@ defmodule SignsUi.Config.SignGroupsTest do
 
       assert SignGroups.from_json(json) == %{
                "Red" => %{
-                 "1234" => %SignsUi.Config.SignGroup{}
+                 "1234" => %SignsUi.Config.SignGroup{route_id: "Red"}
                }
              }
     end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -4,166 +4,60 @@ defmodule SignsUi.Config.SignGroupsTest do
   alias SignsUi.Config.SignGroups
 
   describe "active/3" do
-    test "only returns sign groups that are not expired" do
+    test "removes sign groups with inactive alerts" do
       sign_groups = %{
         "Red" => %{
           "5555" => %SignGroup{},
           "1234" => %SignGroup{alert_id: "active_alert"},
           "5678" => %SignGroup{alert_id: "inactive_alert"},
-          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
-          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
-        },
-        "Blue" => %{
+          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])}
+        }
+      }
+
+      {active, expired} =
+        SignGroups.active(
+          sign_groups,
+          DateTime.new!(~D[2021-05-21], ~T[17:32:30]),
+          MapSet.new(["active_alert"])
+        )
+
+      assert active == %{
+               "Red" => %{
+                 "5555" => %SignGroup{},
+                 "1234" => %SignGroup{alert_id: "active_alert"},
+                 "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])}
+               }
+             }
+
+      assert expired == [%SignGroup{alert_id: "inactive_alert"}]
+    end
+
+    test "removes sign groups that expired in the past" do
+      sign_groups = %{
+        "Red" => %{
           "5555" => %SignGroup{},
           "1234" => %SignGroup{alert_id: "active_alert"},
-          "5678" => %SignGroup{alert_id: "inactive_alert"},
-          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
-          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
-        },
-        "Orange" => %{
-          "5555" => %SignGroup{},
-          "1234" => %SignGroup{alert_id: "active_alert"},
-          "5678" => %SignGroup{alert_id: "inactive_alert"},
-          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
-          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
-        },
-        "Green" => %{
-          "5555" => %SignGroup{},
-          "1234" => %SignGroup{alert_id: "active_alert"},
-          "5678" => %SignGroup{alert_id: "inactive_alert"},
-          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
-          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
-        },
-        "Mattapan" => %{
-          "5555" => %SignGroup{},
-          "1234" => %SignGroup{alert_id: "active_alert"},
-          "5678" => %SignGroup{alert_id: "inactive_alert"},
           "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
           "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
         }
       }
 
-      assert SignGroups.active(
-               sign_groups,
-               DateTime.new!(~D[2021-05-21], ~T[17:32:30]),
-               MapSet.new(["active_alert"])
-             ) == %{
-               "Blue" => %{
-                 "1234" => %SignsUi.Config.SignGroup{
-                   alert_id: "active_alert",
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "55534" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: ~U[2021-05-21 17:35:00Z],
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "5555" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 }
-               },
-               "Green" => %{
-                 "1234" => %SignsUi.Config.SignGroup{
-                   alert_id: "active_alert",
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "55534" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: ~U[2021-05-21 17:35:00Z],
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "5555" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 }
-               },
-               "Mattapan" => %{
-                 "1234" => %SignsUi.Config.SignGroup{
-                   alert_id: "active_alert",
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "55534" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: ~U[2021-05-21 17:35:00Z],
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "5555" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 }
-               },
-               "Orange" => %{
-                 "1234" => %SignsUi.Config.SignGroup{
-                   alert_id: "active_alert",
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "55534" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: ~U[2021-05-21 17:35:00Z],
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "5555" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 }
-               },
+      {active, expired} =
+        SignGroups.active(
+          sign_groups,
+          DateTime.new!(~D[2021-05-21], ~T[17:32:30]),
+          MapSet.new(["active_alert"])
+        )
+
+      assert active == %{
                "Red" => %{
-                 "1234" => %SignsUi.Config.SignGroup{
-                   alert_id: "active_alert",
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "55534" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: ~U[2021-05-21 17:35:00Z],
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 },
-                 "5555" => %SignsUi.Config.SignGroup{
-                   alert_id: nil,
-                   expires: nil,
-                   line1: nil,
-                   line2: nil,
-                   sign_ids: []
-                 }
+                 "5555" => %SignGroup{},
+                 "1234" => %SignGroup{alert_id: "active_alert"},
+                 "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])}
                }
              }
+
+      assert expired == [%SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}]
     end
   end
 end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -103,7 +103,7 @@ defmodule SignsUi.Config.SignGroupsTest do
     test "removes a deleted group" do
       groups = %{"1234" => %SignGroup{route_id: "Red"}, "5678" => %SignGroup{route_id: "Green"}}
 
-      assert SignGroups.update(groups, {"1234", %{}}) == %{
+      assert SignGroups.update({"1234", %{}}, groups) == %{
                "5678" => %SignGroup{route_id: "Green"}
              }
     end
@@ -115,8 +115,8 @@ defmodule SignsUi.Config.SignGroupsTest do
       }
 
       assert SignGroups.update(
-               groups,
-               {"9012", %SignGroup{sign_ids: ["sign_one", "sign_four"], route_id: "Green"}}
+               {"9012", %SignGroup{sign_ids: ["sign_one", "sign_four"], route_id: "Green"}},
+               groups
              ) == %{
                "1234" => %SignGroup{sign_ids: ["sign_two"], route_id: "Red"},
                "5678" => %SignGroup{sign_ids: ["sign_three"], route_id: "Green"},

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -68,4 +68,34 @@ defmodule SignsUi.Config.SignGroupsTest do
              }
     end
   end
+
+  describe "by_route/1" do
+    test "groups sign groups by route" do
+      state = %{
+        "1234" => %SignGroup{route_id: "Red"},
+        "5678" => %SignGroup{route_id: "Red"},
+        "4321" => %SignGroup{route_id: "Green"},
+        "8765" => %SignGroup{route_id: "Green"},
+        "9012" => %SignGroup{route_id: "Orange"},
+        "3456" => %SignGroup{route_id: "Orange"},
+        "7890" => %SignGroup{route_id: "Mattapan"}
+      }
+
+      assert SignGroups.by_route(state) == %{
+               "Red" => %{
+                 "1234" => %SignGroup{route_id: "Red"},
+                 "5678" => %SignGroup{route_id: "Red"}
+               },
+               "Green" => %{
+                 "4321" => %SignGroup{route_id: "Green"},
+                 "8765" => %SignGroup{route_id: "Green"}
+               },
+               "Orange" => %{
+                 "9012" => %SignGroup{route_id: "Orange"},
+                 "3456" => %SignGroup{route_id: "Orange"}
+               },
+               "Mattapan" => %{"7890" => %SignGroup{route_id: "Mattapan"}}
+             }
+    end
+  end
 end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -15,23 +15,14 @@ defmodule SignsUi.Config.SignGroupsTest do
         }
       }
 
-      {active, expired} =
-        SignGroups.active(
+      expired =
+        SignGroups.expired(
           sign_groups,
           DateTime.new!(~D[2021-05-21], ~T[17:32:30]),
           MapSet.new(["active_alert"])
         )
 
-      assert active == %{
-               "5555" => %SignGroup{route_id: "Red"},
-               "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
-               "55534" => %SignGroup{
-                 route_id: "Red",
-                 expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-               }
-             }
-
-      assert expired == [%SignGroup{alert_id: "inactive_alert", route_id: "Red"}]
+      assert expired == %{"5678" => %{}}
     end
 
     test "removes sign groups that expired in the past" do
@@ -48,25 +39,14 @@ defmodule SignsUi.Config.SignGroupsTest do
         }
       }
 
-      {active, expired} =
-        SignGroups.active(
+      expired =
+        SignGroups.expired(
           sign_groups,
           DateTime.new!(~D[2021-05-21], ~T[17:32:30]),
           MapSet.new(["active_alert"])
         )
 
-      assert active == %{
-               "5555" => %SignGroup{route_id: "Red"},
-               "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
-               "55534" => %SignGroup{
-                 route_id: "Red",
-                 expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-               }
-             }
-
-      assert expired == [
-               %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00]), route_id: "Red"}
-             ]
+      assert expired == %{"34334" => %{}}
     end
   end
 

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -60,4 +60,26 @@ defmodule SignsUi.Config.SignGroupsTest do
       assert expired == [%SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}]
     end
   end
+
+  describe "from_json/1" do
+    test "converts groups into structs" do
+      json = %{
+        "Red" => %{
+          "1234" => %{
+            "sign_ids" => [],
+            "expires" => nil,
+            "line1" => nil,
+            "line2" => nil,
+            "alert_id" => nil
+          }
+        }
+      }
+
+      assert SignGroups.from_json(json) == %{
+               "Red" => %{
+                 "1234" => %SignsUi.Config.SignGroup{}
+               }
+             }
+    end
+  end
 end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -1,0 +1,169 @@
+defmodule SignsUi.Config.SignGroupsTest do
+  use ExUnit.Case
+  alias SignsUi.Config.SignGroup
+  alias SignsUi.Config.SignGroups
+
+  describe "active/3" do
+    test "only returns sign groups that are not expired" do
+      sign_groups = %{
+        "Red" => %{
+          "5555" => %SignGroup{},
+          "1234" => %SignGroup{alert_id: "active_alert"},
+          "5678" => %SignGroup{alert_id: "inactive_alert"},
+          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
+        },
+        "Blue" => %{
+          "5555" => %SignGroup{},
+          "1234" => %SignGroup{alert_id: "active_alert"},
+          "5678" => %SignGroup{alert_id: "inactive_alert"},
+          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
+        },
+        "Orange" => %{
+          "5555" => %SignGroup{},
+          "1234" => %SignGroup{alert_id: "active_alert"},
+          "5678" => %SignGroup{alert_id: "inactive_alert"},
+          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
+        },
+        "Green" => %{
+          "5555" => %SignGroup{},
+          "1234" => %SignGroup{alert_id: "active_alert"},
+          "5678" => %SignGroup{alert_id: "inactive_alert"},
+          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
+        },
+        "Mattapan" => %{
+          "5555" => %SignGroup{},
+          "1234" => %SignGroup{alert_id: "active_alert"},
+          "5678" => %SignGroup{alert_id: "inactive_alert"},
+          "55534" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])},
+          "34334" => %SignGroup{expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])}
+        }
+      }
+
+      assert SignGroups.active(
+               sign_groups,
+               DateTime.new!(~D[2021-05-21], ~T[17:32:30]),
+               MapSet.new(["active_alert"])
+             ) == %{
+               "Blue" => %{
+                 "1234" => %SignsUi.Config.SignGroup{
+                   alert_id: "active_alert",
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "55534" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: ~U[2021-05-21 17:35:00Z],
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "5555" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 }
+               },
+               "Green" => %{
+                 "1234" => %SignsUi.Config.SignGroup{
+                   alert_id: "active_alert",
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "55534" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: ~U[2021-05-21 17:35:00Z],
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "5555" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 }
+               },
+               "Mattapan" => %{
+                 "1234" => %SignsUi.Config.SignGroup{
+                   alert_id: "active_alert",
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "55534" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: ~U[2021-05-21 17:35:00Z],
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "5555" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 }
+               },
+               "Orange" => %{
+                 "1234" => %SignsUi.Config.SignGroup{
+                   alert_id: "active_alert",
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "55534" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: ~U[2021-05-21 17:35:00Z],
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "5555" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 }
+               },
+               "Red" => %{
+                 "1234" => %SignsUi.Config.SignGroup{
+                   alert_id: "active_alert",
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "55534" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: ~U[2021-05-21 17:35:00Z],
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 },
+                 "5555" => %SignsUi.Config.SignGroup{
+                   alert_id: nil,
+                   expires: nil,
+                   line1: nil,
+                   line2: nil,
+                   sign_ids: []
+                 }
+               }
+             }
+    end
+  end
+end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -6,14 +6,12 @@ defmodule SignsUi.Config.SignGroupsTest do
   describe "active/3" do
     test "removes sign groups with inactive alerts" do
       sign_groups = %{
-        "Red" => %{
-          "5555" => %SignGroup{route_id: "Red"},
-          "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
-          "5678" => %SignGroup{alert_id: "inactive_alert", route_id: "Red"},
-          "55534" => %SignGroup{
-            route_id: "Red",
-            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-          }
+        "5555" => %SignGroup{route_id: "Red"},
+        "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+        "5678" => %SignGroup{alert_id: "inactive_alert", route_id: "Red"},
+        "55534" => %SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
         }
       }
 
@@ -25,13 +23,11 @@ defmodule SignsUi.Config.SignGroupsTest do
         )
 
       assert active == %{
-               "Red" => %{
-                 "5555" => %SignGroup{route_id: "Red"},
-                 "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
-                 "55534" => %SignGroup{
-                   route_id: "Red",
-                   expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-                 }
+               "5555" => %SignGroup{route_id: "Red"},
+               "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+               "55534" => %SignGroup{
+                 route_id: "Red",
+                 expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
                }
              }
 
@@ -40,17 +36,15 @@ defmodule SignsUi.Config.SignGroupsTest do
 
     test "removes sign groups that expired in the past" do
       sign_groups = %{
-        "Red" => %{
-          "5555" => %SignGroup{route_id: "Red"},
-          "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
-          "55534" => %SignGroup{
-            route_id: "Red",
-            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-          },
-          "34334" => %SignGroup{
-            route_id: "Red",
-            expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
-          }
+        "5555" => %SignGroup{route_id: "Red"},
+        "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+        "55534" => %SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+        },
+        "34334" => %SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:30:00])
         }
       }
 
@@ -62,13 +56,11 @@ defmodule SignsUi.Config.SignGroupsTest do
         )
 
       assert active == %{
-               "Red" => %{
-                 "5555" => %SignGroup{route_id: "Red"},
-                 "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
-                 "55534" => %SignGroup{
-                   route_id: "Red",
-                   expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-                 }
+               "5555" => %SignGroup{route_id: "Red"},
+               "1234" => %SignGroup{alert_id: "active_alert", route_id: "Red"},
+               "55534" => %SignGroup{
+                 route_id: "Red",
+                 expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
                }
              }
 
@@ -81,22 +73,18 @@ defmodule SignsUi.Config.SignGroupsTest do
   describe "from_json/1" do
     test "converts groups into structs" do
       json = %{
-        "Red" => %{
-          "1234" => %{
-            "sign_ids" => [],
-            "route_id" => "Red",
-            "expires" => nil,
-            "line1" => nil,
-            "line2" => nil,
-            "alert_id" => nil
-          }
+        "1234" => %{
+          "sign_ids" => [],
+          "route_id" => "Red",
+          "expires" => nil,
+          "line1" => nil,
+          "line2" => nil,
+          "alert_id" => nil
         }
       }
 
       assert SignGroups.from_json(json) == %{
-               "Red" => %{
-                 "1234" => %SignsUi.Config.SignGroup{route_id: "Red"}
-               }
+               "1234" => %SignsUi.Config.SignGroup{route_id: "Red"}
              }
     end
   end

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -98,4 +98,30 @@ defmodule SignsUi.Config.SignGroupsTest do
              }
     end
   end
+
+  describe "update/2" do
+    test "removes a deleted group" do
+      groups = %{"1234" => %SignGroup{route_id: "Red"}, "5678" => %SignGroup{route_id: "Green"}}
+
+      assert SignGroups.update(groups, {"1234", %{}}) == %{
+               "5678" => %SignGroup{route_id: "Green"}
+             }
+    end
+
+    test "adds a new group and removes its sign ids from existing groups" do
+      groups = %{
+        "1234" => %SignGroup{sign_ids: ["sign_one", "sign_two"], route_id: "Red"},
+        "5678" => %SignGroup{sign_ids: ["sign_three", "sign_four"], route_id: "Green"}
+      }
+
+      assert SignGroups.update(
+               groups,
+               {"9012", %SignGroup{sign_ids: ["sign_one", "sign_four"], route_id: "Green"}}
+             ) == %{
+               "1234" => %SignGroup{sign_ids: ["sign_two"], route_id: "Red"},
+               "5678" => %SignGroup{sign_ids: ["sign_three"], route_id: "Green"},
+               "9012" => %SignGroup{sign_ids: ["sign_one", "sign_four"], route_id: "Green"}
+             }
+    end
+  end
 end

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -185,22 +185,22 @@ defmodule SignsUi.Config.StateTest do
 
       @endpoint.subscribe("sign_groups:all")
 
-      changes = %{
-        "Red" => %{
-          "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
-          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
-          "55534" => %SignsUi.Config.SignGroup{
-            route_id: "Red",
-            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
-          }
+      expired = %{"1222" => %{}, "34334" => %{}}
+
+      {:ok, new_state} = update_sign_groups(pid, expired)
+
+      updated_state = %{
+        "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+        "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
+        "55534" => %SignsUi.Config.SignGroup{
+          route_id: "Red",
+          expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
         }
       }
 
-      {:ok, new_state} = update_sign_groups(pid, changes)
+      assert new_state.sign_groups == updated_state
 
-      assert new_state.sign_groups == changes
-
-      assert_broadcast("new_sign_groups_state", ^changes)
+      assert_broadcast("new_sign_groups_state", ^updated_state)
     end
   end
 end

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -187,9 +187,10 @@ defmodule SignsUi.Config.StateTest do
 
       changes = %{
         "Red" => %{
-          "5555" => %SignsUi.Config.SignGroup{},
-          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert"},
+          "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
           "55534" => %SignsUi.Config.SignGroup{
+            route_id: "Red",
             expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
           }
         }

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -198,9 +198,20 @@ defmodule SignsUi.Config.StateTest do
         }
       }
 
+      display_state = %{
+        "Red" => %{
+          "5555" => %SignsUi.Config.SignGroup{route_id: "Red"},
+          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert", route_id: "Red"},
+          "55534" => %SignsUi.Config.SignGroup{
+            route_id: "Red",
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+          }
+        }
+      }
+
       assert new_state.sign_groups == updated_state
 
-      assert_broadcast("new_sign_groups_state", ^updated_state)
+      assert_broadcast("new_sign_groups_state", ^display_state)
     end
   end
 end

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -178,4 +178,28 @@ defmodule SignsUi.Config.StateTest do
       })
     end
   end
+
+  describe "update_sign_groups/2" do
+    test "broadcasts updated sign groups" do
+      {:ok, pid} = GenServer.start_link(SignsUi.Config.State, [], [])
+
+      @endpoint.subscribe("sign_groups:all")
+
+      changes = %{
+        "Red" => %{
+          "5555" => %SignsUi.Config.SignGroup{},
+          "1234" => %SignsUi.Config.SignGroup{alert_id: "active_alert"},
+          "55534" => %SignsUi.Config.SignGroup{
+            expires: DateTime.new!(~D[2021-05-21], ~T[17:35:00])
+          }
+        }
+      }
+
+      {:ok, new_state} = update_sign_groups(pid, changes)
+
+      assert new_state.sign_groups == changes
+
+      assert_broadcast("new_sign_groups_state", ^changes)
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Sign groups expire](https://app.asana.com/0/584764604969369/1200222628914559/f)

I added code to expire sign groups, including a new SignGroup struct and SignGroups module. The functions that handle expiring sign groups live in those modules, including `SignGroups.active/3` and `SignGroup.expired?/3`. I also corrected and unified some usages of typespecs in `SignsUi.Config`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
