### PR TITLE
Sign groups bridge of front and back ends

### DIFF
--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -197,8 +197,7 @@ class ViewerApp extends React.Component<
 
     if (channel) {
       channel.push('changeSignGroups', {
-        route: line,
-        data: { [timestamp]: signGroup },
+        data: { [timestamp]: { ...signGroup, ...{ route_id: line } } },
       });
     } else {
       Sentry.captureMessage('signGroupsChannel not present');

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -163,7 +163,7 @@ defmodule SignsUi.Config.State do
     {:ok, _} = save_state(new_state)
 
     SignsUiWeb.Endpoint.broadcast!(
-      "sign_groups:all",
+      "signGroups:all",
       "new_sign_groups_state",
       SignGroups.by_route(new_groups)
     )

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -168,7 +168,7 @@ defmodule SignsUi.Config.StateTest do
     test "broadcasts updated sign groups after expiration" do
       {:ok, pid} = GenServer.start_link(SignsUi.Config.State, [], [])
 
-      @endpoint.subscribe("sign_groups:all")
+      @endpoint.subscribe("signGroups:all")
 
       initial_state = %{
         "1111" => %SignsUi.Config.SignGroup{alert_id: "inactive_alert", route_id: "Red"},
@@ -208,7 +208,7 @@ defmodule SignsUi.Config.StateTest do
     test "handles sequential updates" do
       {:ok, pid} = GenServer.start_link(SignsUi.Config.State, [], [])
 
-      @endpoint.subscribe("sign_groups:all")
+      @endpoint.subscribe("signGroups:all")
 
       initial_state = %{
         "1111" => %SignsUi.Config.SignGroup{

--- a/test/signs_ui_web/channels/chelsea_bridge_announcements_channel_test.exs
+++ b/test/signs_ui_web/channels/chelsea_bridge_announcements_channel_test.exs
@@ -1,6 +1,7 @@
 defmodule SignsUiWeb.ChelseaBridgeAnnouncementsChannelTest do
   use SignsUiWeb.ChannelCase
   import ExUnit.CaptureLog
+  alias Test.Support.Helpers
 
   setup do
     socket =
@@ -18,16 +19,7 @@ defmodule SignsUiWeb.ChelseaBridgeAnnouncementsChannelTest do
     test "allows changing chelsea bridge announcements when socket is authenticated", %{
       socket: socket
     } do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-admin"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-admin"])
 
       log =
         capture_log([level: :info], fn ->
@@ -46,16 +38,7 @@ defmodule SignsUiWeb.ChelseaBridgeAnnouncementsChannelTest do
          %{
            socket: socket
          } do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-read-only"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-read-only"])
 
       log =
         capture_log([level: :info], fn ->

--- a/test/signs_ui_web/channels/headways_channel_test.exs
+++ b/test/signs_ui_web/channels/headways_channel_test.exs
@@ -1,6 +1,7 @@
 defmodule SignsUiWeb.HeadwaysChannelTest do
   use SignsUiWeb.ChannelCase
   import ExUnit.CaptureLog
+  alias Test.Support.Helpers
 
   setup do
     socket = subscribe_and_join!(socket(), SignsUiWeb.HeadwaysChannel, "headways:all", %{})
@@ -9,16 +10,7 @@ defmodule SignsUiWeb.HeadwaysChannelTest do
 
   describe "handle_in/3" do
     test "allows changing multi-sign headways when socket is authenticated", %{socket: socket} do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-admin"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-admin"])
 
       log =
         capture_log([level: :info], fn ->
@@ -33,16 +25,7 @@ defmodule SignsUiWeb.HeadwaysChannelTest do
          %{
            socket: socket
          } do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-read-only"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-read-only"])
 
       log =
         capture_log([level: :info], fn ->

--- a/test/signs_ui_web/channels/sign_groups_channel_test.exs
+++ b/test/signs_ui_web/channels/sign_groups_channel_test.exs
@@ -1,6 +1,7 @@
 defmodule SignsUiWeb.SignGroupsChannelTest do
   use SignsUiWeb.ChannelCase
   import ExUnit.CaptureLog
+  alias Test.Support.Helpers
 
   setup do
     socket = subscribe_and_join!(socket(), SignsUiWeb.SignGroupsChannel, "signGroups:all", %{})
@@ -8,8 +9,26 @@ defmodule SignsUiWeb.SignGroupsChannelTest do
   end
 
   describe "handle_in/3" do
-    test "logs changeSignGroups events to console", %{socket: socket} do
-      changes = %{"route" => "Red", "data" => %{}}
+    test "allows changing sign groups when admin", %{socket: socket} do
+      @endpoint.subscribe("signGroups:all")
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-admin"])
+
+      changes = %{
+        "data" => %{
+          "1623264463487" => %{
+            "alert_id" => "",
+            "expires" => "2021-06-22T18:30:00.000Z",
+            "line1" => "line1",
+            "line2" => "line2",
+            "route_id" => "Orange",
+            "sign_ids" => [
+              "oak_grove_mezzanine_southbound",
+              "oak_grove_platform",
+              "wellington_southbound"
+            ]
+          }
+        }
+      }
 
       log =
         capture_log([level: :info], fn ->
@@ -17,9 +36,23 @@ defmodule SignsUiWeb.SignGroupsChannelTest do
                    SignsUiWeb.SignGroupsChannel.handle_in("changeSignGroups", changes, socket)
         end)
 
-      assert log =~ "changeSignGroups: %{"
-      assert log =~ ~s/"route" => "Red"/
-      assert log =~ ~s/"data" => %{}/
+      assert log =~ "changeSignGroups"
+      assert log =~ "foo@mbta.com"
+
+      assert_broadcast(
+        "new_sign_groups_state",
+        %{"Orange" => %{"1623264463487" => %SignsUi.Config.SignGroup{}}},
+        300
+      )
+    end
+
+    test "rejects changing sign groups when not admin", %{socket: socket} do
+      @endpoint.subscribe("signGroups:all")
+
+      {:stop, :normal, _socket} =
+        SignsUiWeb.SignGroupsChannel.handle_in("changeSignGroups", %{"data" => %{}}, socket)
+
+      assert_push("auth_expired", %{})
     end
   end
 end

--- a/test/signs_ui_web/channels/signs_channel_test.exs
+++ b/test/signs_ui_web/channels/signs_channel_test.exs
@@ -1,6 +1,7 @@
 defmodule SignsUiWeb.SignsChannelTest do
   use SignsUiWeb.ChannelCase
   import ExUnit.CaptureLog
+  alias Test.Support.Helpers
 
   setup do
     socket = subscribe_and_join!(socket(), SignsUiWeb.SignsChannel, "signs:all", %{})
@@ -9,16 +10,7 @@ defmodule SignsUiWeb.SignsChannelTest do
 
   describe "handle_in" do
     test "allows changing signs when socket is authenticated", %{socket: socket} do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-admin"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-admin"])
 
       log =
         capture_log([level: :info], fn ->
@@ -32,16 +24,7 @@ defmodule SignsUiWeb.SignsChannelTest do
     test "rejects changing signs when socket is authenticated with read-only view", %{
       socket: socket
     } do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-read-only"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-read-only"])
 
       log =
         capture_log([level: :info], fn ->
@@ -69,16 +52,7 @@ defmodule SignsUiWeb.SignsChannelTest do
 
   describe "handle_out" do
     test "allows sending sign updates when socket is authenticated", %{socket: socket} do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-admin"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-admin"])
 
       assert {:noreply, _socket} = SignsUiWeb.SignsChannel.handle_out("sign_update", %{}, socket)
     end
@@ -86,16 +60,7 @@ defmodule SignsUiWeb.SignsChannelTest do
     test "allows sending sign updates when socket is authenticated with read-only view", %{
       socket: socket
     } do
-      current_time = System.system_time(:second)
-      expiration_time = current_time + 500
-
-      {:ok, token, claims} =
-        SignsUiWeb.AuthManager.encode_and_sign("foo@mbta.com", %{
-          "exp" => expiration_time,
-          "groups" => ["signs-ui-read-only"]
-        })
-
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "foo@mbta.com", token, claims)
+      socket = Helpers.sign_in_with_groups(socket, "foo@mbta.com", ["signs-ui-read-only"])
 
       assert {:noreply, _socket} = SignsUiWeb.SignsChannel.handle_out("sign_update", %{}, socket)
     end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -21,4 +21,18 @@ defmodule Test.Support.Helpers do
       end)
     end
   end
+
+  @spec sign_in_with_groups(Phoenix.Socket.t(), String.t(), [String.t()]) :: Phoenix.Socket.t()
+  def sign_in_with_groups(socket, username, groups) do
+    current_time = System.system_time(:second)
+    expiration_time = current_time + 500
+
+    {:ok, token, claims} =
+      SignsUiWeb.AuthManager.encode_and_sign(username, %{
+        "exp" => expiration_time,
+        "groups" => groups
+      })
+
+    Guardian.Phoenix.Socket.assign_rtc(socket, username, token, claims)
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Fill in sign_groups channel handler stub](https://app.asana.com/0/584764604969369/1200222628914563)

The first commit is a small refactor, pulling some duplicated "sign in" logic out of our tests into a helper function.

The second commit is what actually bridges the frontend and backend, via the channel handler. In implementing this, I realized that since we changed the form of the backend state, we might as well change the form of the frontend request to match, to take advantage of the parsing functions we have. I also fixed up some inconsistencies with the channel being called `sign_groups:all` vs `signGroups:all`.

Related to the second commit, I think a couple good learnings:
* As we've discussed, grooming tickets in terms of features which use the frontend and backend are less brittle. In this case our interface changed due to discoveries working on the backend side of things, meaning this ticket's spec was off. If I had made it more end-to-end, this wouldn't have been a problem.
* Integration tests! Valuable for catching things like joining the wrong channel.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
