### PR TITLE
feat: enable editing existing sign groups

### DIFF
--- a/assets/css/configured_headways_form.css
+++ b/assets/css/configured_headways_form.css
@@ -1,3 +1,8 @@
+.configured-headways-form {
+  /* enables position: absolute for --edit_button */
+  position: relative;
+}
+
 .configured-headways-form input[type='number'] {
   width: 3rem;
 }

--- a/assets/css/sign_groups.css
+++ b/assets/css/sign_groups.css
@@ -109,8 +109,11 @@
   padding-left: 1rem;
 }
 
-.sign_groups--apply-container {
+.sign_groups--buttons-container {
   display: flex;
   justify-content: flex-end;
-  padding-right: 1rem;
+}
+
+.sign_groups--buttons-container * {
+  margin-left: 1rem;
 }

--- a/assets/js/AlertPicker.tsx
+++ b/assets/js/AlertPicker.tsx
@@ -111,7 +111,7 @@ function AlertPicker({
         aria-label="Alert ID picker"
         disabled={disabled}
         type="text"
-        value={alertId || ''}
+        value={alertId}
         onClick={() => {
           setIsOpen(true);
         }}

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -41,6 +41,7 @@
       },
       "devDependencies": {
         "@testing-library/dom": "^7.30.4",
+        "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.0.4",
         "@testing-library/user-event": "^13.1.8",
         "babel-jest": "^26.1.0",
@@ -1385,6 +1386,95 @@
         "node": ">=8"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
+      "integrity": "sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@testing-library/react": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
@@ -1594,6 +1684,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+    },
+    "node_modules/@types/testing-library__jest-dom": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.0.tgz",
+      "integrity": "sha512-l2P2GO+hFF4Liye+fAajT1qBqvZOiL79YMpEvgGs1xTK7hECxBI8Wz4J7ntACJNiJ9r0vXQqYovroXRLPDja6A==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -3431,6 +3530,17 @@
         "node": "*"
       }
     },
+    "node_modules/css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      }
+    },
     "node_modules/css-loader": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.3.0.tgz",
@@ -3528,6 +3638,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
+    "node_modules/css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css/node_modules/source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "dev": true,
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/cssesc": {
@@ -3796,9 +3931,9 @@
       }
     },
     "node_modules/dom-accessibility-api": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
-      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
+      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
       "dev": true
     },
     "node_modules/dom-align": {
@@ -8842,6 +8977,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mini-css-extract-plugin": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.5.0.tgz",
@@ -10644,6 +10788,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -12123,6 +12280,18 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -15372,6 +15541,74 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
+      "integrity": "sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
@@ -15567,6 +15804,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.0.tgz",
+      "integrity": "sha512-l2P2GO+hFF4Liye+fAajT1qBqvZOiL79YMpEvgGs1xTK7hECxBI8Wz4J7ntACJNiJ9r0vXQqYovroXRLPDja6A==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -17021,6 +17267,35 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
+      }
+    },
     "css-loader": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.3.0.tgz",
@@ -17082,6 +17357,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
       "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {
@@ -17285,9 +17566,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
-      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
+      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
       "dev": true
     },
     "dom-align": {
@@ -21065,6 +21346,12 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "mini-css-extract-plugin": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.5.0.tgz",
@@ -22456,6 +22743,16 @@
         "picomatch": "^2.2.1"
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -23619,6 +23916,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "@testing-library/dom": "^7.30.4",
+    "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.0.4",
     "@testing-library/user-event": "^13.1.8",
     "babel-jest": "^26.1.0",
@@ -69,7 +70,7 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "./scripts/jestSetup.js"
+      "./scripts/jest-setup.ts"
     ],
     "testURL": "http://localhost/",
     "preset": "ts-jest",

--- a/assets/scripts/jest-setup.ts
+++ b/assets/scripts/jest-setup.ts
@@ -1,5 +1,7 @@
 require('regenerator-runtime/runtime');
+
 const Enzyme = require('enzyme');
 const EnzymeAdapter = require('enzyme-adapter-react-16');
-
 Enzyme.configure({ adapter: new EnzymeAdapter() });
+
+import '@testing-library/jest-dom';

--- a/assets/test/SignGroups.test.tsx
+++ b/assets/test/SignGroups.test.tsx
@@ -1,20 +1,29 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SignGroups from '../js/SignGroups';
 import { SignGroup } from '../js/types';
 
-function openForm() {
-  userEvent.click(screen.getByText('Create'));
+function openNewGroupForm() {
+  userEvent.click(screen.getByRole('button', { name: 'Create' }));
 }
 
-function chooseZones(zones: string[]) {
-  zones.forEach((z) => userEvent.click(screen.getByText(z)));
+function openEditGroupForm(timestamp: string) {
+  const groupContext = within(screen.getByText(timestamp, { exact: false }));
+  userEvent.click(groupContext.getByRole('button', { name: 'Edit' }));
+}
+
+function toggleZones(zones: string[]) {
+  zones.forEach((z) => userEvent.click(screen.getByTestId(z)));
 }
 
 function setMessage(line1: string, line2: string) {
-  userEvent.type(screen.getByAltText('Line one custom text input'), line1);
-  userEvent.type(screen.getByAltText('Line two custom text input'), line2);
+  const line1Input = screen.getByAltText('Line one custom text input');
+  const line2Input = screen.getByAltText('Line two custom text input');
+  userEvent.clear(line1Input);
+  userEvent.clear(line2Input);
+  userEvent.type(line1Input, line1);
+  userEvent.type(line2Input, line2);
 }
 
 function chooseAlert(alertId: string) {
@@ -22,17 +31,26 @@ function chooseAlert(alertId: string) {
   userEvent.click(screen.getByRole('button', { name: alertId }));
 }
 
-function applyForm() {
-  userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+function newGroupSubmitButton() {
+  return screen.getByRole('button', { name: 'Create group' });
 }
 
-test('can create a sign group', () => {
-  let signGroupSubmissions: Array<{
-    line: string;
-    timestamp: number;
-    signGroup: SignGroup;
-  }> = [];
+function editGroupSubmitButton() {
+  return screen.getByRole('button', { name: 'Apply changes' });
+}
 
+function cancelFormButton() {
+  return screen.getByRole('button', { name: 'Cancel' });
+}
+
+type SignGroupUpdate = {
+  line: string;
+  timestamp: number;
+  signGroup: SignGroup;
+};
+
+test('can create a sign group', () => {
+  let signGroupSubmissions: Array<SignGroupUpdate> = [];
   const line = 'Red';
   const currentTime = 1622149913;
 
@@ -48,32 +66,121 @@ test('can create a sign group', () => {
         },
       },
       signGroups: {},
-      setSignGroup: (line: string, timestamp: number, signGroup: SignGroup) => {
+      setSignGroup: (line, timestamp, signGroup) => {
         signGroupSubmissions.push({ line, timestamp, signGroup });
       },
       readOnly: false,
     }),
   );
 
-  openForm();
-  chooseZones(['Arrival Platform', 'Braintree Platform NB']);
+  openNewGroupForm();
+  toggleZones(['central_northbound', 'central_southbound']);
   setMessage('Line 1 text', 'Line 2 text');
   chooseAlert('alert1');
-  applyForm();
+  userEvent.click(newGroupSubmitButton());
 
   expect(signGroupSubmissions).toEqual([
     {
       line,
       timestamp: currentTime,
       signGroup: {
-        sign_ids: [
-          'south_station_silver_line_arrival_platform',
-          'jfk_umass_braintree_platform_northbound',
-        ],
+        sign_ids: ['central_northbound', 'central_southbound'],
         line1: 'Line 1 text',
         line2: 'Line 2 text',
         expires: null,
         alert_id: 'alert1',
+      },
+    },
+  ]);
+});
+
+test('can cancel creating a sign group', () => {
+  let signGroupSubmissions: Array<SignGroupUpdate> = [];
+
+  render(
+    React.createElement(SignGroups, {
+      line: 'Red',
+      currentTime: 1622149913,
+      alerts: {},
+      signGroups: {},
+      setSignGroup: (line, timestamp, signGroup) => {
+        signGroupSubmissions.push({ line, timestamp, signGroup });
+      },
+      readOnly: false,
+    }),
+  );
+
+  openNewGroupForm();
+  toggleZones(['central_northbound', 'central_southbound']);
+  setMessage('Line 1 text', 'Line 2 text');
+  userEvent.click(cancelFormButton());
+  openNewGroupForm();
+
+  expect(signGroupSubmissions).toEqual([]);
+  expect(screen.getByAltText('Line one custom text input')).toHaveValue('');
+});
+
+test('requires selecting at least one sign', () => {
+  render(
+    React.createElement(SignGroups, {
+      line: 'Red',
+      currentTime: 1622149913,
+      alerts: {},
+      signGroups: {},
+      setSignGroup: (line, timestamp, signGroup) => {},
+      readOnly: false,
+    }),
+  );
+
+  openNewGroupForm();
+  toggleZones(['central_northbound']);
+  toggleZones(['central_northbound']);
+  setMessage('Line 1 text', 'Line 2 text');
+
+  expect(newGroupSubmitButton()).toBeDisabled();
+});
+
+test('can edit an existing sign group', () => {
+  let signGroupSubmissions: Array<SignGroupUpdate> = [];
+  const line = 'Blue';
+  const timestamp = 1622149900;
+
+  render(
+    React.createElement(SignGroups, {
+      line,
+      currentTime: 1622149913,
+      alerts: {},
+      signGroups: {
+        [timestamp]: {
+          sign_ids: ['airport_westbound', 'airport_eastbound'],
+          line1: 'custom',
+          line2: 'text',
+          expires: null,
+          alert_id: null,
+        },
+      },
+      setSignGroup: (line, timestamp, signGroup) => {
+        signGroupSubmissions.push({ line, timestamp, signGroup });
+      },
+      readOnly: false,
+    }),
+  );
+
+  openEditGroupForm(timestamp.toString());
+  toggleZones(['airport_eastbound', 'maverick_westbound']);
+  setMessage('other', 'text');
+  userEvent.click(editGroupSubmitButton());
+
+  expect(signGroupSubmissions).toEqual([
+    {
+      line,
+      timestamp: timestamp,
+      signGroup: {
+        sign_ids: ['airport_westbound', 'maverick_westbound'],
+        line1: 'other',
+        line2: 'text',
+        expires: null,
+        alert_id: null,
       },
     },
   ]);

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -56,7 +56,7 @@
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     },
     "include": [
-        "js", "test"
+        "js", "test", "scripts"
     ],
     "exclude": [
         "node_modules"

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -2,6 +2,7 @@ defmodule SignsUiWeb.MessagesController do
   require Logger
   use SignsUiWeb, :controller
 
+  alias SignsUi.Config.SignGroups
   alias SignsUi.Messages.SignContent
   alias SignsUi.Signs.State
 
@@ -31,7 +32,7 @@ defmodule SignsUiWeb.MessagesController do
       end)
 
     chelsea_bridge_announcements = Map.get(config, :chelsea_bridge_announcements, "off")
-    sign_groups = Map.fetch!(config, :sign_groups)
+    sign_groups = config |> Map.fetch!(:sign_groups) |> SignGroups.by_route()
     sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito")
 
     render(conn, "index.html",


### PR DESCRIPTION
**Asana Ticket:** [🔀 Ability to edit sign group](https://app.asana.com/0/584764604969369/1200222628914565)

The barebones list of sign groups now has edit buttons for each:

![Screen Shot 2021-06-30 at 3 59 50 PM](https://user-images.githubusercontent.com/394835/124023861-77af7a80-d9bc-11eb-8aae-59600052e345.png)

Clicking this enables editing the sign group:

![Screen Shot 2021-06-30 at 4 00 05 PM](https://user-images.githubusercontent.com/394835/124023907-87c75a00-d9bc-11eb-8ed1-58b7a7458d42.png)

The "Cancel" button is also present in the new-group form, and in both places it discards any changes made in the form.

The submit button is disabled if either no changes have been made yet, or no signs are selected. It does stay enabled if you change the form but then change it back to how it was originally — as per the Asana task saying to do whatever is simplest, this was simplest.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
