### PR TITLE
feat: Put bulk editing tools in accordion

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -4,6 +4,7 @@
 @import 'configured_headways_form.css';
 @import 'custom_text_input.css';
 @import 'phoenix.css';
+@import 'rc_collapse.css';
 @import 'rc_tabs.css';
 @import 'set_expiration.css';
 @import 'sign_groups.css';

--- a/assets/css/rc_collapse.css
+++ b/assets/css/rc_collapse.css
@@ -1,0 +1,52 @@
+.rc-collapse {
+  border: 1px solid rgb(151, 151, 151);
+  border-radius: 0px;
+  margin-bottom: 2rem;
+}
+
+.rc-collapse-header {
+  background-color: white;
+  color: rgb(59, 59, 59);
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 10px 16px;
+  text-transform: uppercase;
+}
+
+.rc-collapse-header .arrow {
+  display: inline-block;
+  content: '\20';
+  width: 0;
+  height: 0;
+  font-size: 0;
+  line-height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 8px solid #666;
+  vertical-align: middle;
+  margin-right: 8px;
+  top: -2px;
+  position: relative;
+}
+
+.rc-collapse-header[aria-expanded='true'] {
+  border-bottom: 1px solid rgb(151, 151, 151);
+}
+
+.rc-collapse-header[aria-expanded='true'] .arrow {
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 8px solid #666;
+  margin-right: 4px;
+  left: -2px;
+  top: 2px;
+}
+
+.rc-collapse-content {
+  padding: 0;
+}
+
+.rc-collapse-content-box {
+  padding: 0;
+  margin: 0;
+}

--- a/assets/css/rc_tabs.css
+++ b/assets/css/rc_tabs.css
@@ -1,13 +1,8 @@
-.rc-tabs {
-  margin-bottom: 1rem;
-}
-
 .rc-tabs-nav {
   line-height: 1.2;
 }
 
 .rc-tabs-nav-list {
-  border: 1px solid #ddd;
   display: flex;
 }
 

--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Collapse, { Panel } from 'rc-collapse';
 import Tabs, { TabPane } from 'rc-tabs';
 import ConfiguredHeadwaysForm from './ConfiguredHeadwaysForm';
 import Station from './Station';
@@ -131,30 +132,34 @@ function Line({
   return (
     <div>
       <h1>{name(line)}</h1>
-      <Tabs defaultActiveKey="0" tabBarStyle={{}}>
-        {featureIsEnabled('sign_groups') && (
-          <TabPane tab="Sign Groups">
-            <SignGroups
-              line={line}
-              currentTime={currentTime}
-              alerts={alerts}
-              signGroups={signGroups[line] || {}}
-              setSignGroup={setSignGroup}
-              readOnly={readOnly}
-            />
-          </TabPane>
-        )}
-        {branches.length > 0 && (
-          <TabPane tab="Set Headways" key="1">
-            <ConfiguredHeadwaysForm
-              branches={branches}
-              configuredHeadways={configuredHeadways}
-              setConfiguredHeadways={setConfiguredHeadways}
-              readOnly={readOnly}
-            />
-          </TabPane>
-        )}
-      </Tabs>
+      <Collapse destroyInactivePanel={true}>
+        <Panel header="Bulk Editing">
+          <Tabs defaultActiveKey="0" tabBarStyle={{}}>
+            {featureIsEnabled('sign_groups') && (
+              <TabPane tab="Sign Groups">
+                <SignGroups
+                  line={line}
+                  currentTime={currentTime}
+                  alerts={alerts}
+                  signGroups={signGroups[line] || {}}
+                  setSignGroup={setSignGroup}
+                  readOnly={readOnly}
+                />
+              </TabPane>
+            )}
+            {branches.length > 0 && (
+              <TabPane tab="Set Headways" key="1">
+                <ConfiguredHeadwaysForm
+                  branches={branches}
+                  configuredHeadways={configuredHeadways}
+                  setConfiguredHeadways={setConfiguredHeadways}
+                  readOnly={readOnly}
+                />
+              </TabPane>
+            )}
+          </Tabs>
+        </Panel>
+      </Collapse>
 
       {line === 'Silver' && (
         <label className="mt-1 mb-4">

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -28,6 +28,7 @@
         "mini-css-extract-plugin": "^1.2.0",
         "phoenix": "^1.5.6",
         "phoenix_html": "^2.10.4",
+        "rc-collapse": "^3.1.1",
         "react": "^16.4.1",
         "react-datepicker": "^3.3.0",
         "react-dom": "^16.4.1",
@@ -10419,6 +10420,22 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/rc-collapse": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.1.1.tgz",
+      "integrity": "sha512-/oetKApTHzGGeR8Q8vD168EXkCs2MpEIrURGyy2D+LrrJd29LY/huuIMvOiJoSV6W3bcGhJqIdgHtg1Dxn1smA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.3.4",
+        "rc-util": "^5.2.1",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/rc-dropdown": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.2.0.tgz",
@@ -10459,7 +10476,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.3.tgz",
       "integrity": "sha512-GZLLFXHl/VqTfI7bSZNNZozcblNmDka1AAoQig7EZ6s0rWg5y0RlgrcHWO+W+nrOVbYfJDxoaQUoP2fEmvCWmA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -10547,7 +10563,6 @@
       "version": "5.12.2",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.12.2.tgz",
       "integrity": "sha512-kzqG2lHY4oZsoj5Svov12K+9wi0xQHvGzfbLlsF1PDEH1aTbgdNTwlE7mejc3MGEr+7bNHa4+T5ZemCS8vQ1Gw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "react-is": "^16.12.0",
@@ -11568,8 +11583,7 @@
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -22461,6 +22475,18 @@
         "resize-observer-polyfill": "^1.5.1"
       }
     },
+    "rc-collapse": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.1.1.tgz",
+      "integrity": "sha512-/oetKApTHzGGeR8Q8vD168EXkCs2MpEIrURGyy2D+LrrJd29LY/huuIMvOiJoSV6W3bcGhJqIdgHtg1Dxn1smA==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.3.4",
+        "rc-util": "^5.2.1",
+        "shallowequal": "^1.1.0"
+      }
+    },
     "rc-dropdown": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.2.0.tgz",
@@ -22493,7 +22519,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.3.tgz",
       "integrity": "sha512-GZLLFXHl/VqTfI7bSZNNZozcblNmDka1AAoQig7EZ6s0rWg5y0RlgrcHWO+W+nrOVbYfJDxoaQUoP2fEmvCWmA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -22555,7 +22580,6 @@
       "version": "5.12.2",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.12.2.tgz",
       "integrity": "sha512-kzqG2lHY4oZsoj5Svov12K+9wi0xQHvGzfbLlsF1PDEH1aTbgdNTwlE7mejc3MGEr+7bNHa4+T5ZemCS8vQ1Gw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "react-is": "^16.12.0",
@@ -23340,8 +23364,7 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -57,6 +57,7 @@
     "mini-css-extract-plugin": "^1.2.0",
     "phoenix": "^1.5.6",
     "phoenix_html": "^2.10.4",
+    "rc-collapse": "^3.1.1",
     "react": "^16.4.1",
     "react-datepicker": "^3.3.0",
     "react-dom": "^16.4.1",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Bulk editing accordion](https://app.asana.com/0/584764604969369/1200255474259892)

Adds a new `rc-collapse` library and wraps our Headways / Sign Groups in it. Maybe easier to review [without whitespace changes](https://github.com/mbta/signs_ui/pull/547/files?w=1).

There were a few react accordion/collapsible libraries to choose from, but this one seemed to be most popular (from npm download stats). It was also among the smallest in size, and we already use its sibling library `rc-tabs`. I couldn't get the little collapse arrow to style exactly as in the mocks, so I'll check that with Kristin.

It's not wrapped in an experiment, so it will just go out to prod when merged and deployed, but I think that's fine. I believe having to scroll past the large "Set Headways" form every time was already an issue raised by the PIOs, so I think they'll like this, even with just the one tab inside.

I pondered adding tests, but ultimately the code change here was very little, and it seemed more like it would be testing the `rc-collapse` functionality, which is presumably already tested.

<img width="1141" alt="Screen Shot 2021-07-02 at 2 19 52 PM" src="https://user-images.githubusercontent.com/384428/124320035-c8e87700-db40-11eb-92f9-a35b39471dc7.png">

<img width="1150" alt="Screen Shot 2021-07-02 at 2 20 10 PM" src="https://user-images.githubusercontent.com/384428/124320046-cdad2b00-db40-11eb-8c62-60fa56257f7b.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
