### PR TITLE
Display list of sign groups

### DIFF
--- a/assets/css/sign_groups.css
+++ b/assets/css/sign_groups.css
@@ -117,3 +117,49 @@
 .sign_groups--buttons-container * {
   margin-left: 1rem;
 }
+
+.sign_groups--groups-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  height: 344px;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.sign_groups--group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-basis: 80%;
+}
+
+.sign_groups--group-list-container {
+  max-height: 100%;
+  overflow-y: scroll;
+  padding-right: 5rem;
+}
+
+.sign_groups--group-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  background-color: rgb(206, 206, 206);
+  padding: 0.5rem;
+}
+
+.sign_groups--group-expiration {
+  font-weight: bold;
+  font-style: italic;
+}
+
+.sign_groups--group-buttons {
+  display: flex;
+  margin-inline-start: auto;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sign_groups--group-edit-button {
+  align-self: flex-end;
+}

--- a/assets/js/SignGroupItem.tsx
+++ b/assets/js/SignGroupItem.tsx
@@ -1,0 +1,53 @@
+import dateFormat from 'dateformat';
+import React from 'react';
+import SignText from './SignText';
+import { SignGroup } from './types';
+
+interface SignGroupProps {
+  timestamp: string;
+  currentTime: number;
+  group: SignGroup;
+  readOnly: boolean;
+  onEdit: (timestamp: string) => void;
+}
+
+export default function SignGroupItem({
+  timestamp,
+  currentTime,
+  group,
+  readOnly,
+  onEdit,
+}: SignGroupProps) {
+  return (
+    <div className="sign_groups--group-item">
+      <SignText time={currentTime} line1={group.line1} line2={group.line2} />
+      <div className="sign_group--expiration-container">
+        Scheduled return to auto:
+        {group.expires ? (
+          <div className="sign_groups--group-expiration">
+            at {dateFormat(new Date(group.expires), 'mm/dd/yyyy hh:MM TT')}
+          </div>
+        ) : group.alert_id ? (
+          <div className="sign_groups--group-expiration">
+            when alert {group.alert_id} closes
+          </div>
+        ) : (
+          <div className="sign_groups--group-expiration">manually</div>
+        )}
+      </div>
+      <div className="sign_groups--group-buttons">
+        <button
+          disabled={readOnly}
+          onClick={() => onEdit(timestamp)}
+          type="button"
+          className="btn btn-secondary sign_groups--group-edit-button"
+        >
+          Edit
+        </button>
+        <button type="button" className="btn btn-primary">
+          Return to "Auto"
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/assets/js/SignGroupItem.tsx
+++ b/assets/js/SignGroupItem.tsx
@@ -19,7 +19,7 @@ export default function SignGroupItem({
   onEdit,
 }: SignGroupProps) {
   return (
-    <div className="sign_groups--group-item">
+    <div className="sign_groups--group-item" data-testid={timestamp}>
       <SignText time={currentTime} line1={group.line1} line2={group.line2} />
       <div className="sign_group--expiration-container">
         Scheduled return to auto:

--- a/assets/js/SignGroups.tsx
+++ b/assets/js/SignGroups.tsx
@@ -12,6 +12,7 @@ import {
   SignGroup,
 } from './types';
 import { defaultZoneLabel } from './helpers';
+import SignGroupItem from './SignGroupItem';
 
 interface ZoneSelectorProps {
   config: StationConfig;
@@ -293,6 +294,7 @@ function SignGroupsForm({
 interface SignGroupsListProps {
   signGroups: RouteSignGroups;
   readOnly: boolean;
+  currentTime: number;
   onCreate: () => void;
   onEdit: (timestamp: string) => void;
 }
@@ -300,26 +302,37 @@ interface SignGroupsListProps {
 function SignGroupsList({
   signGroups,
   readOnly,
+  currentTime,
   onCreate,
   onEdit,
 }: SignGroupsListProps): JSX.Element | null {
+  const groupCount = Object.keys(signGroups).length;
+
   return (
-    <div>
-      {Object.keys(signGroups).map((timestamp) => (
-        <p key={timestamp}>
-          <button
-            disabled={readOnly}
-            onClick={() => onEdit(timestamp)}
-            type="button"
-          >
-            Edit
-          </button>
-          {timestamp}: {JSON.stringify(signGroups[timestamp])}
-        </p>
-      ))}
-      <button disabled={readOnly} onClick={onCreate} type="button">
+    <div className="sign_groups--groups-container">
+      <button
+        className="btn btn-primary"
+        disabled={readOnly}
+        onClick={onCreate}
+        type="button"
+      >
         Create
       </button>
+      <div className="sign_groups--group-list-container">
+        {groupCount > 0 && <h6>Active Groups</h6>}
+        <div className="sign_groups--group-list">
+          {Object.keys(signGroups).map((timestamp) => (
+            <SignGroupItem
+              key={timestamp}
+              timestamp={timestamp}
+              currentTime={currentTime}
+              group={signGroups[timestamp]}
+              readOnly={readOnly}
+              onEdit={onEdit}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -352,10 +365,10 @@ function SignGroups({
   const [formSignGroup, setFormSignGroup] = React.useState(newSignGroup);
   const [isFormOpen, setIsFormOpen] = React.useState(false);
 
-  const openEditForm = React.useCallback(
-    (timestamp: string) => {
-      setFormKey(timestamp);
-      setFormSignGroup(signGroups[timestamp]);
+  const openForm = React.useCallback(
+    (formKey: string | null) => {
+      setFormKey(formKey);
+      setFormSignGroup(formKey ? signGroups[formKey] : newSignGroup);
       setIsFormOpen(true);
     },
     [signGroups],
@@ -386,9 +399,10 @@ function SignGroups({
   return (
     <SignGroupsList
       signGroups={signGroups}
+      currentTime={currentTime}
       readOnly={readOnly}
-      onCreate={() => setIsFormOpen(true)}
-      onEdit={openEditForm}
+      onCreate={() => openForm(null)}
+      onEdit={openForm}
     />
   );
 }

--- a/assets/test/SignGroups.test.tsx
+++ b/assets/test/SignGroups.test.tsx
@@ -9,7 +9,7 @@ function openNewGroupForm() {
 }
 
 function openEditGroupForm(timestamp: string) {
-  const groupContext = within(screen.getByText(timestamp, { exact: false }));
+  const groupContext = within(screen.getByTestId(timestamp, { exact: false }));
   userEvent.click(groupContext.getByRole('button', { name: 'Edit' }));
 }
 

--- a/lib/signs_ui/config/sign_groups.ex
+++ b/lib/signs_ui/config/sign_groups.ex
@@ -22,11 +22,23 @@ defmodule SignsUi.Config.SignGroups do
     end
   end
 
+  @doc """
+  Converts sign group data from the frontend, like this:
+
+  iex> from_json(%{"12345" => %{"route_id" => "Red"}})
+  %{"12345" => %SignsUi.Config.SignGroup{route_id: "Red"}}
+  """
   @spec from_json(t()) :: t()
   def from_json(sign_groups) do
     Map.new(sign_groups, fn {time, group} -> {time, SignGroup.from_json(group)} end)
   end
 
+  @doc """
+  Organizes sign group data by the route it's relevant to, like this:
+
+  iex> by_route(%{"12345" => %SignsUi.Config.SignGroup{route_id: "Red"}})
+  %{"Red" => %{"12345" => %SignsUi.Config.SignGroup{route_id: "Red"}}}
+  """
   @spec by_route(t()) :: by_route()
   def by_route(sign_groups) do
     Enum.reduce(sign_groups, %{}, fn {time, group}, acc ->
@@ -34,6 +46,10 @@ defmodule SignsUi.Config.SignGroups do
     end)
   end
 
+  @doc """
+  Updates existing sign group state with new groups and deletions, ensuring that
+  signs are only in one group at a time.
+  """
   @spec update({unix_time(), SignGroup.t() | %{}}, t()) :: t()
   def update({created_at, map}, sign_groups) when map == %{} do
     Map.delete(sign_groups, created_at)

--- a/test/signs_ui/config/sign_groups_test.exs
+++ b/test/signs_ui/config/sign_groups_test.exs
@@ -1,5 +1,6 @@
 defmodule SignsUi.Config.SignGroupsTest do
   use ExUnit.Case
+  doctest SignsUi.Config.SignGroups, import: true
   alias SignsUi.Config.SignGroup
   alias SignsUi.Config.SignGroups
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Display list of sign groups](https://app.asana.com/0/584764604969369/1200392286075647/f)

Added a new list item element styled with flexbox and fleshed out the styling of other elements shown in the mockup. The new sign group items also have a dummy "Return to 'Auto'" button styled and ready to be wired up or replaced with another component. Also clarified some docs and added some doctests for functions on the Elixir side that confused me (despite the fact that I wrote them). Here's a screenshot: 
<img width="1174" alt="Screen Shot 2021-07-07 at 11 01 27 PM" src="https://user-images.githubusercontent.com/9062973/124855664-449a5780-df77-11eb-8fd5-4e64a29c7432.png">



#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
