### PR TITLE
fix: Updating SignGroups propagates to the sign configs

### DIFF
--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -626,5 +626,4 @@ test('allows removing an individual sign from a group', () => {
     expires: null,
     alert_id: null,
   });
-  // TODO: assert sign was returned to auto, once it does that
 });

--- a/lib/signs_ui/config/sign_group_to_sign_configs.ex
+++ b/lib/signs_ui/config/sign_group_to_sign_configs.ex
@@ -1,0 +1,116 @@
+defmodule SignsUi.Config.SignGroupToSignConfigs do
+  @moduledoc """
+  A compatibility layer that supports the concept of Sign Groups while leaving clients like Realtime
+  Signs unchanged. When Sign Groups are changed, those changes are propagated to the underlying Sign
+  configs. There are three kinds of changes:
+
+  * New Sign Group - all the signs in this group have their custom text, mode and expiration options
+    set to the same values as the group value.
+  * Sign Group Deleted - all the signs in the group are reset back to Auto
+  * Sign Group Updated - Same as New Sign Group, plus any signs that were removed are reset back to
+    Auto.
+  """
+
+  alias SignsUi.Config.Sign
+  alias SignsUi.Config.SignGroup
+  alias SignsUi.Config.SignGroups
+  alias SignsUi.Config.State
+
+  @doc """
+  Transforms the Sign Group changes into a map of Sign Config updates.
+  """
+  @spec apply(SignGroups.t(), State.t()) :: %{Sign.id() => Sign.t()}
+  def apply(sign_group_changes, config_state) do
+    Enum.reduce(sign_group_changes, %{}, fn {changed_sign_group_id, changed_sign_group}, acc ->
+      config_state.sign_groups
+      |> Map.get(changed_sign_group_id)
+      |> process_sign_group(normalize(changed_sign_group))
+      |> Map.merge(acc)
+    end)
+  end
+
+  @spec process_sign_group(SignGroup.t() | nil, SignGroup.t() | nil) :: %{Sign.id() => Sign.t()}
+  defp process_sign_group(old_sign_group, new_sign_group)
+
+  # Group is being deleted
+  defp process_sign_group(%SignGroup{} = old_group, nil) do
+    set_signs_to_auto(old_group.sign_ids)
+  end
+
+  # Group is being added
+  defp process_sign_group(nil, %SignGroup{} = new_sign_group) do
+    set_signs_to_static_text(
+      new_sign_group.sign_ids,
+      new_sign_group.line1,
+      new_sign_group.line2,
+      new_sign_group.expires,
+      new_sign_group.alert_id
+    )
+  end
+
+  # Group is being updated
+  defp process_sign_group(%SignGroup{} = old_group, %SignGroup{} = new_group) do
+    additions =
+      set_signs_to_static_text(
+        new_group.sign_ids,
+        new_group.line1,
+        new_group.line2,
+        new_group.expires,
+        new_group.alert_id
+      )
+
+    removed_signs =
+      MapSet.difference(
+        MapSet.new(old_group.sign_ids),
+        MapSet.new(new_group.sign_ids)
+      )
+
+    removals = set_signs_to_auto(removed_signs)
+
+    Map.merge(additions, removals)
+  end
+
+  # Shouldn't occur, but for completeness
+  defp process_sign_group(nil, nil) do
+    %{}
+  end
+
+  @spec set_signs_to_auto(Enumerable.t()) :: %{Sign.id() => Sign.t()}
+  defp set_signs_to_auto(sign_ids) do
+    Map.new(sign_ids, fn sign_id ->
+      {sign_id, %Sign{id: sign_id, config: %{mode: :auto}}}
+    end)
+  end
+
+  @spec set_signs_to_static_text(
+          Enumerable.t(),
+          String.t(),
+          String.t(),
+          Sign.expires_on() | nil,
+          String.t() | nil
+        ) ::
+          %{
+            Sign.id() => Sign.t()
+          }
+  defp set_signs_to_static_text(sign_ids, line1, line2, expires, alert_id) do
+    Map.new(sign_ids, fn sign_id ->
+      {
+        sign_id,
+        %Sign{
+          id: sign_id,
+          config: %{
+            mode: :static_text,
+            line1: line1,
+            line2: line2,
+            expires: expires,
+            alert_id: alert_id
+          }
+        }
+      }
+    end)
+  end
+
+  @spec normalize(SignGroup.t() | map()) :: SignGroup.t() | nil
+  defp normalize(%SignGroup{} = sign_group), do: sign_group
+  defp normalize(sg) when sg == %{}, do: nil
+end

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -102,7 +102,9 @@ defmodule SignsUi.Config.State do
   end
 
   def handle_call({:update_sign_groups, changes}, _from, old_state) do
-    new_state = save_sign_group_changes(changes, old_state)
+    sign_config_changes = SignsUi.Config.SignGroupToSignConfigs.apply(changes, old_state)
+    new_sign_group_state = save_sign_group_changes(changes, old_state)
+    new_state = save_sign_config_changes(sign_config_changes, new_sign_group_state)
     {:reply, {:ok, new_state}, new_state}
   end
 

--- a/test/signs_ui/config/sign_group_to_sign_configs_test.exs
+++ b/test/signs_ui/config/sign_group_to_sign_configs_test.exs
@@ -1,0 +1,169 @@
+defmodule SignsUi.Config.SignGroupToSignConfigsTest do
+  use ExUnit.Case, async: true
+
+  alias SignsUi.Config.Sign
+  alias SignsUi.Config.SignGroup
+  alias SignsUi.Config.SignGroupToSignConfigs
+
+  @state %{
+    signs: %{},
+    configured_headways: %{},
+    chelsea_bridge_announcements: "off",
+    sign_groups: %{}
+  }
+
+  describe "apply/2" do
+    test "Adding a sign group applies the changes to its signs" do
+      sign_group_changes = %{
+        "new_sign_group" => %SignGroup{
+          sign_ids: ["sign1", "sign2"],
+          route_id: "Red",
+          line1: "line1",
+          line2: "line2",
+          expires: nil,
+          alert_id: "alert_id"
+        }
+      }
+
+      assert %{
+               "sign1" => %Sign{
+                 id: "sign1",
+                 config: %{
+                   mode: :static_text,
+                   line1: "line1",
+                   line2: "line2",
+                   expires: nil,
+                   alert_id: "alert_id"
+                 }
+               },
+               "sign2" => %Sign{
+                 id: "sign2",
+                 config: %{
+                   mode: :static_text,
+                   line1: "line1",
+                   line2: "line2",
+                   expires: nil,
+                   alert_id: "alert_id"
+                 }
+               }
+             } = SignGroupToSignConfigs.apply(sign_group_changes, @state)
+    end
+
+    test "Removing a sign group sets its signs to Auto" do
+      state =
+        @state
+        |> put_in([:signs], %{
+          "sign1" => %Sign{
+            id: "sign1",
+            config: %{
+              mode: :static_text,
+              line1: "line1",
+              line2: "line2",
+              expires: nil,
+              alert_id: "alert_id"
+            }
+          },
+          "sign2" => %Sign{
+            id: "sign2",
+            config: %{
+              mode: :static_text,
+              line1: "line1",
+              line2: "line2",
+              expires: nil,
+              alert_id: "alert_id"
+            }
+          }
+        })
+        |> put_in([:sign_groups], %{
+          "sign_group" => %SignGroup{
+            sign_ids: ["sign1", "sign2"],
+            route_id: "Red",
+            line1: "line1",
+            line2: "line2",
+            expires: nil,
+            alert_id: "alert_id"
+          }
+        })
+
+      sign_group_changes = %{"sign_group" => %{}}
+
+      assert %{
+               "sign1" => %Sign{id: "sign1", config: %{mode: :auto}},
+               "sign2" => %Sign{id: "sign2", config: %{mode: :auto}}
+             } = SignGroupToSignConfigs.apply(sign_group_changes, state)
+    end
+
+    test "Updating a sign group sets removed signs to Auto" do
+      state =
+        @state
+        |> put_in([:signs], %{
+          "sign1" => %Sign{
+            id: "sign1",
+            config: %{
+              mode: :static_text,
+              line1: "line1",
+              line2: "line2",
+              expires: nil,
+              alert_id: "alert_id"
+            }
+          },
+          "sign2" => %Sign{
+            id: "sign2",
+            config: %{
+              mode: :static_text,
+              line1: "line1",
+              line2: "line2",
+              expires: nil,
+              alert_id: "alert_id"
+            }
+          },
+          "sign3" => %Sign{id: "sign3", config: %{mode: :auto}}
+        })
+        |> put_in([:sign_groups], %{
+          "sign_group" => %SignGroup{
+            sign_ids: ["sign1", "sign2"],
+            route_id: "Red",
+            line1: "line1",
+            line2: "line2",
+            expires: nil,
+            alert_id: "alert_id"
+          }
+        })
+
+      sign_group_changes = %{
+        "sign_group" => %SignGroup{
+          sign_ids: ["sign1", "sign3"],
+          route_id: "Red",
+          line1: "new line1",
+          line2: "new line2",
+          expires: ~U[2021-07-13 12:00:00.000Z],
+          alert_id: nil
+        }
+      }
+
+      assert %{
+               "sign1" => %Sign{
+                 id: "sign1",
+                 config: %{
+                   mode: :static_text,
+                   line1: "new line1",
+                   line2: "new line2",
+                   expires: ~U[2021-07-13 12:00:00.000Z],
+                   alert_id: nil
+                 }
+               },
+               "sign3" => %Sign{
+                 id: "sign3",
+                 config: %{
+                   mode: :static_text,
+                   line1: "new line1",
+                   line2: "new line2",
+                   expires: ~U[2021-07-13 12:00:00.000Z],
+                   alert_id: nil
+                 }
+               },
+               "sign2" => %Sign{id: "sign2", config: %{mode: :auto}}
+             } = SignGroupToSignConfigs.apply(sign_group_changes, state)
+    end
+  end
+end

--- a/test/signs_ui/config/state_test.exs
+++ b/test/signs_ui/config/state_test.exs
@@ -263,5 +263,28 @@ defmodule SignsUi.Config.StateTest do
 
       assert_broadcast("new_sign_groups_state", ^display_state)
     end
+
+    test "updates sign configs, too" do
+      {:ok, pid} = GenServer.start_link(SignsUi.Config.State, [], [])
+      @endpoint.subscribe("signGroups:all")
+      @endpoint.subscribe("signs:all")
+
+      updates = %{
+        "new_sign_group" => %SignsUi.Config.SignGroup{
+          sign_ids: ["sign_one"],
+          route_id: "Red",
+          line1: "line1",
+          line2: "line2",
+          alert_id: "alert"
+        }
+      }
+
+      {:ok, new_state} = update_sign_groups(pid, updates)
+
+      assert %{"new_sign_group" => %{}} = new_state.sign_groups
+      assert %{"sign_one" => %{}} = new_state.signs
+      assert_broadcast("new_sign_groups_state", %{"Red" => %{"new_sign_group" => %{}}})
+      assert_broadcast("new_sign_configs_state", %{"sign_one" => %{}})
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Saving sign groups updates the underlying signs' data.](https://app.asana.com/0/584764604969369/1200580099553918)

This adds a step in the `Config.State` handling of sign groups to reflect those changes across the individual signs as well.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
