### PR TITLE
All to auto/headway/off prompts if there are sign groups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Elixir CI
+name: Static Checks CI
 
 on: [pull_request]
 
@@ -30,18 +30,27 @@ jobs:
           echo "$ASDF_DIR/bin" >> $GITHUB_PATH
           echo "$ASDF_DIR/shims" >> $GITHUB_PATH
           $ASDF_DIR/bin/asdf reshim
-      - name: Restore dependencies cache
-        id: deps-cache
+      - name: <elixir> Restore dependencies cache
+        id: elixir-cache
         uses: actions/cache@v2
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-
-      - name: Install dependencies
+      - name: <elixir> Install dependencies (if needed)
+        if: steps.elixir-cache.outputs.cache-hit != 'true'
         run: |
-          mix local.rebar --foce
+          mix local.rebar --force
           mix local.hex --force
           mix deps.get
+      - name: <node> Restore dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: "assets/node_modules"
+          key: ${{ runner.os }}-nodejs-${{ hashFiles('assets/package-lock.json') }}
+        id: node-cache
+      - name: <node> Install dependencies (if needed)
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm install --prefix assets
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
       - name: Check formatting
@@ -52,6 +61,10 @@ jobs:
         run: mix sobelow mix sobelow --skip --exit
       - name: Run tests
         run: mix test --cover
+      - name: JS checks
+        run: npm run check --prefix assets
+      - name: JS tests
+        run: npm run test --prefix assets
       - name: Save PR information
         run: |
           echo "${{ github.event.pull_request.number }}" > cover/PR_NUMBER

--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -12,7 +12,6 @@ import {
   RouteSignGroups,
   SignConfigs,
   SignContent,
-  SignGroup,
   StationConfig,
 } from './types';
 
@@ -88,7 +87,7 @@ interface LineProps {
   chelseaBridgeAnnouncements: 'auto' | 'off';
   setChelseaBridgeAnnouncements: (x: 'auto' | 'off') => void;
   signGroups: RouteSignGroups;
-  setSignGroup: (line: string, key: string, signGroup: SignGroup) => void;
+  setSignGroups: (line: string, signGroups: RouteSignGroups) => void;
 }
 
 function Line({
@@ -105,7 +104,7 @@ function Line({
   setChelseaBridgeAnnouncements,
   stationConfigs,
   signGroups,
-  setSignGroup,
+  setSignGroups,
 }: LineProps): JSX.Element {
   const branches = branchConfig[line] || [];
 
@@ -129,12 +128,14 @@ function Line({
       const groupKey = signsToGroups[realtimeId];
       const { sign_ids: signIds, ...signGroup } = signGroups[groupKey];
 
-      setSignGroup(line, groupKey, {
-        ...signGroup,
-        sign_ids: signIds.filter((id) => id !== realtimeId),
+      setSignGroups(line, {
+        [groupKey]: {
+          ...signGroup,
+          sign_ids: signIds.filter((id) => id !== realtimeId),
+        },
       });
     },
-    [line, signGroups, signsToGroups, setSignGroup],
+    [line, signGroups, signsToGroups, setSignGroups],
   );
 
   const batchModes =
@@ -172,7 +173,7 @@ function Line({
                   currentTime={currentTime}
                   alerts={alerts}
                   signGroups={signGroups}
-                  setSignGroup={setSignGroup}
+                  setSignGroups={setSignGroups}
                   readOnly={readOnly}
                 />
               </TabPane>

--- a/assets/js/ModalPrompt.tsx
+++ b/assets/js/ModalPrompt.tsx
@@ -15,21 +15,34 @@ function ModalPrompt({
   contents,
   elementId,
 }: ModalPromptProps): JSX.Element {
-  const obscuredElement = elementId
-    ? document.getElementById(elementId) || document.body
-    : document.body;
+  const obscuredElement = elementId && document.getElementById(elementId);
+  let top;
+  let left;
+  let width;
+  let height;
 
-  const box = obscuredElement.getBoundingClientRect();
+  if (obscuredElement) {
+    const box = obscuredElement.getBoundingClientRect();
+    top = box.top;
+    left = box.left;
+    width = box.width;
+    height = box.height;
+  } else {
+    top = window.scrollY;
+    left = window.scrollX;
+    width = window.innerWidth;
+    height = window.innerHeight;
+  }
 
   return (
     <div
       className="modal_prompt--backdrop"
       style={{
         position: 'absolute',
-        top: `${box.top}px`,
-        left: `${box.left}px`,
-        width: `${box.width}px`,
-        height: `${box.height}px`,
+        top: `${top}px`,
+        left: `${left}px`,
+        width: `${width}px`,
+        height: `${height}px`,
       }}
       data-testid="modal-prompt"
     >

--- a/assets/js/SignGroupExpirationDetails.tsx
+++ b/assets/js/SignGroupExpirationDetails.tsx
@@ -6,7 +6,7 @@ export default function SignGroupExpirationDetails({
   group,
 }: {
   group: SignGroup;
-}) {
+}): JSX.Element {
   const expirationText = React.useMemo(() => {
     let text;
     if (group.expires) {

--- a/assets/js/SignGroupItem.tsx
+++ b/assets/js/SignGroupItem.tsx
@@ -17,7 +17,7 @@ export default function SignGroupItem({
   group,
   readOnly,
   onEdit,
-}: SignGroupProps) {
+}: SignGroupProps): JSX.Element {
   return (
     <div className="sign_groups--group-item" data-testid={groupKey}>
       <SignText time={currentTime} line1={group.line1} line2={group.line2} />
@@ -32,7 +32,7 @@ export default function SignGroupItem({
           Edit
         </button>
         <button type="button" className="btn btn-primary">
-          Return to "Auto"
+          Return to &ldquo;Auto&rdquo;
         </button>
       </div>
     </div>

--- a/assets/js/SignGroups.tsx
+++ b/assets/js/SignGroups.tsx
@@ -400,7 +400,7 @@ interface SignGroupsProps {
   currentTime: number;
   alerts: RouteAlerts;
   signGroups: RouteSignGroups;
-  setSignGroup: (line: string, key: string, signGroup: SignGroup) => void;
+  setSignGroups: (line: string, signGroups: RouteSignGroups) => void;
   readOnly: boolean;
 }
 
@@ -409,7 +409,7 @@ function SignGroups({
   currentTime,
   alerts,
   signGroups,
-  setSignGroup,
+  setSignGroups,
   readOnly,
 }: SignGroupsProps): JSX.Element | null {
   const newSignGroup: SignGroup = {
@@ -436,9 +436,9 @@ function SignGroups({
     (groupKey: string | null, signGroup: SignGroup) => {
       setIsFormOpen(false);
       const key = groupKey || currentTime.toString();
-      setSignGroup(line, key, signGroup);
+      setSignGroups(line, { [key]: signGroup });
     },
-    [line, currentTime, setSignGroup, setIsFormOpen],
+    [line, currentTime, setSignGroups, setIsFormOpen],
   );
 
   if (isFormOpen) {

--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -152,6 +152,10 @@ class SignPanel extends React.Component<
     this.setState({ staticLine2: newText, customChanges: true });
   }
 
+  setConfirmingUngroup(confirming: boolean): void {
+    this.setState({ confirmingUngroup: confirming });
+  }
+
   performUngroup(): void {
     const { ungroupSign } = this.props;
 
@@ -159,10 +163,6 @@ class SignPanel extends React.Component<
       this.setState({ confirmingUngroup: false });
       ungroupSign();
     }
-  }
-
-  setConfirmingUngroup(confirming: boolean): void {
-    this.setState({ confirmingUngroup: confirming });
   }
 
   saveStaticText(): void {

--- a/assets/js/Viewer.tsx
+++ b/assets/js/Viewer.tsx
@@ -4,9 +4,9 @@ import {
   Alerts,
   SignContent,
   ConfiguredHeadways,
+  RouteSignGroups,
   SignConfigs,
   SignGroupMap,
-  SignGroup,
 } from './types';
 import { alertsForLine } from './helpers';
 
@@ -23,7 +23,7 @@ interface ViewerProps {
   chelseaBridgeAnnouncements: 'auto' | 'off';
   setChelseaBridgeAnnouncements: (x: 'auto' | 'off') => void;
   signGroups: SignGroupMap;
-  setSignGroup: (line: string, key: string, signGroup: SignGroup) => void;
+  setSignGroups: (line: string, signGroups: RouteSignGroups) => void;
 }
 
 function Viewer({
@@ -39,7 +39,7 @@ function Viewer({
   setChelseaBridgeAnnouncements,
   chelseaBridgeAnnouncements,
   signGroups,
-  setSignGroup,
+  setSignGroups,
 }: ViewerProps): JSX.Element {
   const routeSignGroups = React.useMemo(
     () => signGroups[line] || {},
@@ -60,7 +60,7 @@ function Viewer({
         chelseaBridgeAnnouncements={chelseaBridgeAnnouncements}
         setChelseaBridgeAnnouncements={setChelseaBridgeAnnouncements}
         signGroups={routeSignGroups}
-        setSignGroup={setSignGroup}
+        setSignGroups={setSignGroups}
         readOnly={readOnly}
       />
     </div>

--- a/assets/js/Viewer.tsx
+++ b/assets/js/Viewer.tsx
@@ -4,7 +4,7 @@ import {
   Alerts,
   SignContent,
   ConfiguredHeadways,
-  RouteSignGroups,
+  RouteSignGroupsWithDeletions,
   SignConfigs,
   SignGroupMap,
 } from './types';
@@ -23,7 +23,10 @@ interface ViewerProps {
   chelseaBridgeAnnouncements: 'auto' | 'off';
   setChelseaBridgeAnnouncements: (x: 'auto' | 'off') => void;
   signGroups: SignGroupMap;
-  setSignGroups: (line: string, signGroups: RouteSignGroups) => void;
+  setSignGroups: (
+    line: string,
+    signGroups: RouteSignGroupsWithDeletions,
+  ) => void;
 }
 
 function Viewer({

--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -10,7 +10,7 @@ import {
   Alerts,
   SignGroup,
   SignGroupMap,
-  RouteSignGroups,
+  RouteSignGroupsWithDeletions,
 } from './types';
 
 /* eslint-disable camelcase */
@@ -20,6 +20,8 @@ declare global {
     userToken: string;
   }
 }
+
+type SignGroupApi = (SignGroup & { route_id: string }) | Record<string, never>;
 
 interface ViewerAppProps {
   initialAlerts: Alerts;
@@ -194,14 +196,18 @@ class ViewerApp extends React.Component<
     }
   }
 
-  setSignGroups(line: string, signGroups: RouteSignGroups): void {
+  setSignGroups(line: string, signGroups: RouteSignGroupsWithDeletions): void {
     const { signGroupsChannel: channel } = this.state;
 
     if (channel) {
-      const data: { [key: string]: SignGroup & { route_id: string } } = {};
+      const data: { [key: string]: SignGroupApi } = {};
 
       Object.entries(signGroups).forEach(([key, signGroup]) => {
-        data[key] = { ...signGroup, ...{ route_id: line } };
+        if (Object.keys(signGroup).length > 0) {
+          data[key] = { ...(signGroup as SignGroup), ...{ route_id: line } };
+        } else {
+          data[key] = {};
+        }
       });
 
       channel.push('changeSignGroups', { data });

--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -10,6 +10,7 @@ import {
   Alerts,
   SignGroup,
   SignGroupMap,
+  RouteSignGroups,
 } from './types';
 
 /* eslint-disable camelcase */
@@ -60,7 +61,7 @@ class ViewerApp extends React.Component<
     this.setConfiguredHeadways = this.setConfiguredHeadways.bind(this);
     this.setChelseaBridgeAnnouncements =
       this.setChelseaBridgeAnnouncements.bind(this);
-    this.setSignGroup = this.setSignGroup.bind(this);
+    this.setSignGroups = this.setSignGroups.bind(this);
     this.changeLine = this.changeLine.bind(this);
     this.updateTime = this.updateTime.bind(this);
     this.state = {
@@ -193,13 +194,17 @@ class ViewerApp extends React.Component<
     }
   }
 
-  setSignGroup(line: string, key: string, signGroup: SignGroup): void {
+  setSignGroups(line: string, signGroups: RouteSignGroups): void {
     const { signGroupsChannel: channel } = this.state;
 
     if (channel) {
-      channel.push('changeSignGroups', {
-        data: { [key]: { ...signGroup, ...{ route_id: line } } },
+      const data: { [key: string]: SignGroup & { route_id: string } } = {};
+
+      Object.entries(signGroups).forEach(([key, signGroup]) => {
+        data[key] = { ...signGroup, ...{ route_id: line } };
       });
+
+      channel.push('changeSignGroups', { data });
     } else {
       Sentry.captureMessage('signGroupsChannel not present');
     }
@@ -298,7 +303,7 @@ class ViewerApp extends React.Component<
             configuredHeadways={configuredHeadways}
             setConfiguredHeadways={this.setConfiguredHeadways}
             signGroups={signGroups}
-            setSignGroup={this.setSignGroup}
+            setSignGroups={this.setSignGroups}
             currentTime={currentTime}
             line={line}
             chelseaBridgeAnnouncements={chelseaBridgeAnnouncements}

--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -12,6 +12,8 @@ import {
   SignGroupMap,
 } from './types';
 
+/* eslint-disable camelcase */
+
 declare global {
   interface Window {
     userToken: string;

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -96,6 +96,12 @@ type RouteSignGroups = {
   [key: string]: SignGroup;
 };
 
+// {groupKey: {}} means "delete groupKey sign group"
+// {} is represented in TS as Record<string, never>
+type RouteSignGroupsWithDeletions = {
+  [key: string]: SignGroup | Record<string, never>;
+};
+
 type SignGroupMap = {
   [routeId: string]: RouteSignGroups;
 };
@@ -114,5 +120,6 @@ export {
   ZoneConfig,
   SignGroupMap,
   RouteSignGroups,
+  RouteSignGroupsWithDeletions,
   SignGroup,
 };

--- a/assets/package.json
+++ b/assets/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint js/** --fix --ext .js,.jsx,.ts,.tsx",
     "lint:check": "eslint js/** --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc --noEmit",
-    "check": "npm run typecheck && npm run lint && npm run format:check",
+    "check": "npm run typecheck && npm run lint:check && npm run format:check",
     "format": "prettier --write \"{.,**}/*.{js,json,ts,tsx,css,scss}\"",
     "format:check": "prettier --check \"{.,**}/*.{js,json,ts,tsx,css,scss}\"",
     "start": "npm run watch",

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -40,7 +40,7 @@ test('Shows all signs for a line', () => {
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -78,7 +78,7 @@ test('Shows batch mode buttons when not read-only', () => {
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -118,7 +118,7 @@ test.each([['Silver'], ['Busway']])(
           chelseaBridgeAnnouncements: 'off',
           setChelseaBridgeAnnouncements: () => {},
           signGroups: {},
-          setSignGroup: () => {},
+          setSignGroups: () => {},
         },
         null,
       ),
@@ -161,7 +161,7 @@ test('Shows "Mixed" batch mode buttons when multiple modes are chosen', () => {
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -204,7 +204,7 @@ test('Does not show "Mixed" batch mode buttons when one mode is chosen', () => {
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -244,7 +244,7 @@ test("Doesn't show batch mode buttons when read-only", () => {
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -283,7 +283,7 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -320,7 +320,7 @@ test('Doesn\t show ConfiguredHeadwaysForm if current line has no branches config
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -357,7 +357,7 @@ test('Shows ConfiguredHeadwaysForm if current line has branches configured', () 
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -456,7 +456,7 @@ test('Sign config is not affected by batch updates if sign does not support mode
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements: () => {},
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -510,7 +510,7 @@ test('can toggle chelsea bridge announcements on and off on Silver Line page', (
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements,
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -544,7 +544,7 @@ test('does not show chelsea bridge announcements toggle on non-Silver Line pages
         chelseaBridgeAnnouncements: 'off',
         setChelseaBridgeAnnouncements,
         signGroups: {},
-        setSignGroup: () => {},
+        setSignGroups: () => {},
       },
       null,
     ),
@@ -569,7 +569,7 @@ test('does not show chelsea bridge toggle if in read-only mode', () => {
       chelseaBridgeAnnouncements: 'auto',
       setChelseaBridgeAnnouncements: () => {},
       signGroups: {},
-      setSignGroup: () => {},
+      setSignGroups: () => {},
     }),
   );
 
@@ -580,7 +580,7 @@ test('does not show chelsea bridge toggle if in read-only mode', () => {
 
 test('allows removing an individual sign from a group', () => {
   const line = 'Red';
-  const setSignGroup = jest.fn();
+  const setSignGroups = jest.fn();
   const groupKey = '1625778000';
 
   render(
@@ -607,7 +607,7 @@ test('allows removing an individual sign from a group', () => {
             alert_id: null,
           },
         },
-        setSignGroup,
+        setSignGroups,
       },
       null,
     ),
@@ -619,11 +619,13 @@ test('allows removing an individual sign from a group', () => {
   userEvent.click(centralNB.getByRole('button', { name: /Yes/ }));
 
   expect(centralNB.queryByRole('button', { name: /Yes/ })).toBeNull();
-  expect(setSignGroup).toHaveBeenCalledWith(line, groupKey, {
-    sign_ids: ['central_southbound'],
-    line1: 'custom',
-    line2: 'text',
-    expires: null,
-    alert_id: null,
+  expect(setSignGroups).toHaveBeenCalledWith(line, {
+    [groupKey]: {
+      sign_ids: ['central_southbound'],
+      line1: 'custom',
+      line2: 'text',
+      expires: null,
+      alert_id: null,
+    },
   });
 });


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 "All to ____" works with sign groups](https://app.asana.com/0/584764604969369/1200222628914571)

Commit-by-commit:

1. I realized that the CI checks from the GitHub action migration didn't run our frontend scripts! So this updates that, and then fixes a couple issues that had snuck in.
2. Tweak to the `ModalPrompt` widget to handle not covering a specific parent element. The mocks for my feature had it covering what looked like more or less the whole page, but the previous implementation centered the dialog box over the opaque layer, which put it too far down the page. So this tweak lets you use a ModalPrompt without specifying an element, in which case it will just take over the current viewport dimensions, so the dialog box is properly centered in the window.
3. A refactor from `setSignGroup` to `setSignGroups`, so that we can edit multiple sign groups at once. This will be useful for my main feature which is...
4. Updating the "All to Auto/Headway/Off" buttons to trigger the ModalPrompt if any sign groups exist, and then deleting all the sign groups (i.e. sending `{groupKey1: {}, groupKey2: {}, ...}` to the backend).

<img width="1266" alt="Screen Shot 2021-07-21 at 4 38 05 PM" src="https://user-images.githubusercontent.com/384428/126563606-049a9104-1718-49ee-ba76-87c8ef5acb3f.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
