### PR TITLE
feat: better selections for "Return to Auto"

### DIFF
--- a/assets/css/set_expiration.css
+++ b/assets/css/set_expiration.css
@@ -1,3 +1,7 @@
+.set_expiration > * {
+  display: block;
+}
+
 .set_expiration--label-disabled {
   color: rgba(0, 0, 0, 0.6);
 }

--- a/assets/css/sign_groups.css
+++ b/assets/css/sign_groups.css
@@ -79,39 +79,43 @@
 }
 
 .sign_groups--container-right {
+  display: grid;
+  grid:
+    'a a' min-content
+    'b c' 1fr
+    / 1fr min-content;
   flex: 1 1 auto;
   padding-left: 1rem;
+  padding-bottom: 1rem;
   overflow-x: scroll;
 }
 
 .sign_groups--custom_message-container {
+  grid-area: a;
   justify-content: space-around;
-  background-color: white;
-  display: flex;
   margin-bottom: 1rem;
+}
+
+.sign_groups--custom_message-input {
+  display: flex;
+  background-color: white;
   padding: 1rem;
 }
 
-.sign_groups--schedule-container {
-  background-color: white;
-  display: flex;
-  margin-bottom: 1rem;
+.sign_groups--container-message-expiration {
+  grid-area: b;
+  /* padding: 1rem; */
+}
+.sign-groups--container-expiration-picker {
   padding: 1rem;
-}
-
-.sign_groups--schedule-date {
-  flex: 0 0 50%;
-}
-
-.sign_groups--schedule-alert {
-  flex: 0 0 50%;
-  border-left: 1px solid #f0f0f0;
-  padding-left: 1rem;
+  background-color: white;
 }
 
 .sign_groups--buttons-container {
+  grid-area: c;
   display: flex;
   justify-content: flex-end;
+  align-self: flex-end;
 }
 
 .sign_groups--buttons-container * {

--- a/assets/js/AlertPicker.tsx
+++ b/assets/js/AlertPicker.tsx
@@ -74,6 +74,7 @@ interface AlertPickerProps {
   alertId: string;
   alerts: RouteAlerts;
   onChange: (alertId: string) => void;
+  startOpen?: boolean;
   disabled: boolean;
 }
 
@@ -81,24 +82,22 @@ function AlertPicker({
   alertId,
   alerts,
   onChange,
+  startOpen = false,
   disabled,
 }: AlertPickerProps): JSX.Element | null {
-  const [isOpen, setIsOpen] = React.useState(false);
-
   // if alerts change out from under us, AlertPickerPopup should re-render,
   // since it relies on the presence of alerts.
   const popupKey = JSON.stringify(Object.keys(alerts).sort());
+  const [open, setOpen] = React.useState(startOpen);
 
-  const isNoAlerts = Object.keys(alerts).length === 0;
-
-  if (isOpen) {
+  if (open) {
     return (
       <AlertPickerPopup
         key={popupKey}
-        setIsOpen={setIsOpen}
+        setIsOpen={setOpen}
         alerts={alerts}
         onChange={(newAlertId) => {
-          setIsOpen(false);
+          setOpen(false);
           onChange(newAlertId);
         }}
       />
@@ -113,11 +112,11 @@ function AlertPicker({
         type="text"
         value={alertId}
         onClick={() => {
-          setIsOpen(true);
+          setOpen(true);
         }}
         readOnly
       />
-      {isNoAlerts ? (
+      {Object.keys(alerts).length === 0 ? (
         <div className="alert_picker--no_alerts">
           There are currently no active alerts for this line.
         </div>

--- a/assets/js/SignGroups.tsx
+++ b/assets/js/SignGroups.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import ReactDatePicker from 'react-datepicker';
 import { stationConfig, arincToRealtimeId } from './mbta';
 import SignText from './SignText';
 import SignTextInput from './SignTextInput';
-import AlertPicker from './AlertPicker';
 import ModalPrompt from './ModalPrompt';
 import {
   RouteAlerts,
@@ -15,6 +13,7 @@ import {
 } from './types';
 import { defaultZoneLabel } from './helpers';
 import SignGroupItem from './SignGroupItem';
+import SetExpiration from './SetExpiration';
 
 function changeGroupSignText([station, zone]: [string, Zone], line: string) {
   const stationConfigs = stationConfig[line]?.stations || [];
@@ -168,7 +167,7 @@ function SignGroupsForm({
   );
 
   const stations = stationConfig[line]?.stations ?? [];
-  const submitText = signGroupKey === null ? 'Create group' : 'Apply changes';
+  const submitText = signGroupKey === null ? 'Create' : 'Apply';
   const canSubmit =
     signGroup !== initialSignGroup && signGroup.sign_ids.length > 0;
 
@@ -274,9 +273,9 @@ function SignGroupsForm({
           </div>
         </div>
         <div className="sign_groups--container-right">
-          <div>
+          <div className="sign_groups--custom_message-container">
             Set Custom Message
-            <div className="sign_groups--custom_message-container">
+            <div className="sign_groups--custom_message-input">
               <div>
                 <SignTextInput
                   signID="sign_group"
@@ -299,38 +298,20 @@ function SignGroupsForm({
               </div>
             </div>
           </div>
-          <div>
-            Schedule return to &quot;Auto&quot;
-            <div className="sign_groups--schedule-container">
-              <div className="sign_groups--schedule-date">
-                Date and time
-                <div>
-                  <ReactDatePicker
-                    selected={expires}
-                    onChange={onDatePickerChange}
-                    showTimeSelect
-                    timeFormat="HH:mm"
-                    timeIntervals={15}
-                    dateFormat="MMM d @ h:mm aa"
-                    disabled={signGroup.alert_id !== null}
-                  />
-                </div>
-              </div>
-              <div className="sign_groups--schedule-alert">
-                Upon alert closing
-                <div>
-                  <AlertPicker
-                    alertId={signGroup.alert_id || ''}
-                    onChange={(id) =>
-                      setSignGroup({ ...signGroup, alert_id: id })
-                    }
-                    alerts={alerts}
-                    disabled={
-                      expires !== null || Object.keys(alerts).length === 0
-                    }
-                  />
-                </div>
-              </div>
+          <div className="sign_groups--container-message-expiration">
+            Message Expiration
+            <div className="sign-groups--container-expiration-picker">
+              <SetExpiration
+                alerts={alerts}
+                expires={expires}
+                alertId={signGroup.alert_id}
+                onDateChange={onDatePickerChange}
+                onAlertChange={(id) =>
+                  setSignGroup({ ...signGroup, alert_id: id })
+                }
+                readOnly={false}
+                showAlertSelector
+              />
             </div>
           </div>
           <div className="sign_groups--buttons-container">

--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -98,6 +98,49 @@ function lineDisplayText(
   return '';
 }
 
+function stringify(expires: Date | null) {
+  if (expires) {
+    return expires.toISOString();
+  }
+
+  return null;
+}
+
+function updateConfig(
+  setConfigsFn: (x: SignConfigs) => void,
+  realtimeId: string,
+  signConfig: SignConfig,
+  expires: Date | [Date, Date] | null,
+  alertId: string | null,
+) {
+  if (Array.isArray(expires)) {
+    return;
+  }
+  const expirationConfig = stringify(expires);
+
+  const newConfig = {
+    ...signConfig,
+    expires: expirationConfig,
+    alert_id: alertId,
+  };
+
+  setConfigsFn({
+    [realtimeId]: newConfig,
+  });
+}
+
+function parseDate(str: string | null | undefined): Date | null {
+  if (str) {
+    const date = new Date(str);
+
+    if (date.toString() !== 'Invalid Date') {
+      return date;
+    }
+  }
+
+  return null;
+}
+
 interface SignPanelProps {
   alerts: RouteAlerts;
   signId: string;
@@ -303,9 +346,20 @@ class SignPanel extends React.Component<
             <div className="viewer--schedule-expires">
               <SetExpiration
                 alerts={alerts}
-                realtimeId={realtimeId}
-                signConfig={signConfig}
-                setConfigs={setConfigs}
+                expires={parseDate(signConfig.expires)}
+                alertId={signConfig.alert_id}
+                onDateChange={(dt) => {
+                  updateConfig(setConfigs, realtimeId, signConfig, dt, null);
+                }}
+                onAlertChange={(alertId) =>
+                  updateConfig(
+                    setConfigs,
+                    realtimeId,
+                    signConfig,
+                    null,
+                    alertId,
+                  )
+                }
                 readOnly={readOnly}
                 showAlertSelector={shouldShowAlertSelector(line)}
               />

--- a/assets/test/SetExpiration.test.ts
+++ b/assets/test/SetExpiration.test.ts
@@ -2,86 +2,115 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 
 import SetExpiration from '../js/SetExpiration';
-import { SignConfigs } from '../js/types';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 test('Can set the expiration time', () => {
-  const requests: SignConfigs[] = [];
+  const dates: (Date | null)[] = [];
   const readOnly = false;
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
       alerts: {},
-      realtimeId: 'rtID',
-      signConfig: {
-        id: '1',
-        mode: 'static_text',
-        line1: 'line1',
-        line2: 'line2',
-        expires: null,
-      },
-      setConfigs: (arg) => {
-        requests.push(arg);
-      },
+      expires: null,
+      alertId: null,
+      onDateChange: (d) => dates.push(d),
+      onAlertChange: () => true,
       readOnly,
       showAlertSelector: true,
     }),
   );
 
+  wrapper.find('input[type="checkbox"]').simulate('click');
+  wrapper.find('.set_expiration--datetime').simulate('change');
   wrapper.find('.react-datepicker-wrapper input').simulate('focus');
   wrapper.find('.react-datepicker__day--015').simulate('click');
-  expect(requests.length).toBe(1);
-  const newConf = requests[0].rtID;
-  expect(new Date(newConf.expires!)).toBeInstanceOf(Date);
+  expect(dates.length).toBe(1);
+  expect(dates[0]?.getDate()).toBe(15);
 });
 
 test('Can clear the expiration time', () => {
-  const requests: SignConfigs[] = [];
+  const dates: (Date | null)[] = [];
   const readOnly = false;
 
-  const wrapper = mount(
+  render(
     React.createElement(SetExpiration, {
-      alerts: {},
-      realtimeId: 'rtID',
-      signConfig: {
-        id: '1',
-        mode: 'static_text',
-        line1: 'line1',
-        line2: 'line2',
-        expires: new Date().toISOString(),
+      alerts: {
+        Red: {
+          id: 'bar',
+          created_at: null,
+          service_effect: 'nothing',
+        },
       },
-      setConfigs: (arg) => {
-        requests.push(arg);
-      },
+      expires: null,
+      alertId: null,
+      onDateChange: (d) => dates.push(d),
+      onAlertChange: () => true,
       readOnly,
       showAlertSelector: true,
     }),
   );
 
-  wrapper.find('.set_expiration--cancel').simulate('click');
-  expect(requests.length).toBe(1);
-  const newConf = requests[0].rtID;
-  expect(newConf.expires).toBe(null);
+  userEvent.click(
+    screen.getByRole('checkbox', { name: 'Schedule return to "Auto"' }),
+  );
+  userEvent.click(screen.getByRole('radio', { name: 'Date and time' }));
+  userEvent.click(
+    screen.getByRole('radio', { name: 'At the end of an alert effect period' }),
+  );
+
+  expect(dates.length).toBe(1);
+  expect(dates[0]).toBe(null);
+});
+
+test('Deselecting return to auto clears the expiration ', () => {
+  const dates: (Date | null)[] = [];
+  const alerts: (string | null)[] = [];
+  const readOnly = false;
+
+  render(
+    React.createElement(SetExpiration, {
+      alerts: {
+        Red: {
+          id: 'bar',
+          created_at: null,
+          service_effect: 'nothing',
+        },
+      },
+      expires: null,
+      alertId: null,
+      onDateChange: (d) => dates.push(d),
+      onAlertChange: (a) => alerts.push(a),
+      readOnly,
+      showAlertSelector: true,
+    }),
+  );
+
+  userEvent.click(
+    screen.getByRole('checkbox', { name: 'Schedule return to "Auto"' }),
+  );
+  userEvent.click(
+    screen.getByRole('checkbox', { name: 'Schedule return to "Auto"' }),
+  );
+
+  expect(dates.length).toBe(1);
+  expect(alerts.length).toBe(1);
+  expect(dates[0]).toBe(null);
+  expect(alerts[0]).toBe(null);
 });
 
 test('Shows widget when no expiration set if not in read-only mode', () => {
-  const setConfigs = () => true;
-
   const readOnly = false;
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
       alerts: {},
-      realtimeId: 'rtID',
-      signConfig: {
-        id: '1',
-        mode: 'static_text',
-        line1: 'line1',
-        line2: 'line2',
-        expires: null,
-      },
-      setConfigs,
+      expires: null,
+      alertId: null,
+      onDateChange: () => true,
+      onAlertChange: () => true,
       readOnly,
       showAlertSelector: true,
     }),
@@ -91,22 +120,15 @@ test('Shows widget when no expiration set if not in read-only mode', () => {
 });
 
 test('Suppresses widget when no expiration set if in read-only mode', () => {
-  const setConfigs = () => true;
-
   const readOnly = true;
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
       alerts: {},
-      realtimeId: 'rtID',
-      signConfig: {
-        id: '1',
-        mode: 'static_text',
-        line1: 'line1',
-        line2: 'line2',
-        expires: '',
-      },
-      setConfigs,
+      expires: null,
+      alertId: null,
+      onDateChange: () => true,
+      onAlertChange: () => true,
       readOnly,
       showAlertSelector: true,
     }),
@@ -116,22 +138,15 @@ test('Suppresses widget when no expiration set if in read-only mode', () => {
 });
 
 test("Shows 'Scheduled' when expiration is set if in read-only mode", () => {
-  const setConfigs = () => true;
-
   const readOnly = true;
 
   const wrapper = mount(
     React.createElement(SetExpiration, {
       alerts: {},
-      realtimeId: 'rtID',
-      signConfig: {
-        id: '1',
-        mode: 'static_text',
-        line1: 'line1',
-        line2: 'line2',
-        expires: new Date().toISOString(),
-      },
-      setConfigs,
+      expires: new Date(),
+      alertId: null,
+      onDateChange: () => true,
+      onAlertChange: () => true,
       readOnly,
       showAlertSelector: true,
     }),

--- a/assets/test/SignGroups.test.tsx
+++ b/assets/test/SignGroups.test.tsx
@@ -27,16 +27,21 @@ function setMessage(line1: string, line2: string) {
 }
 
 function chooseAlert(alertId: string) {
-  userEvent.click(screen.getByRole('textbox', { name: /alert id picker/i }));
+  userEvent.click(
+    screen.getByRole('checkbox', { name: 'Schedule return to "Auto"' }),
+  );
+  userEvent.click(
+    screen.getByRole('radio', { name: 'At the end of an alert effect period' }),
+  );
   userEvent.click(screen.getByRole('button', { name: alertId }));
 }
 
 function newGroupSubmitButton() {
-  return screen.getByRole('button', { name: 'Create group' });
+  return screen.getByRole('button', { name: 'Create' });
 }
 
 function editGroupSubmitButton() {
-  return screen.getByRole('button', { name: 'Apply changes' });
+  return screen.getByRole('button', { name: 'Apply' });
 }
 
 function cancelFormButton() {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Better selections for "schedule return to auto" module ](https://app.asana.com/0/584764604969369/1200421875163998/f)

Made `SetExpiration` into a reusable component that fires callbacks when selecting date and alert expiration types, and clears them when returning to auto is disabled.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
