### PR TITLE
feat: Return to Auto button in sign group list works

### DIFF
--- a/assets/js/SignGroupItem.tsx
+++ b/assets/js/SignGroupItem.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import SignText from './SignText';
 import SignGroupExpirationDetails from './SignGroupExpirationDetails';
-import { SignGroup } from './types';
+import { RouteSignGroupsWithDeletions, SignGroup } from './types';
 
 interface SignGroupProps {
   currentTime: number;
   groupKey: string;
   group: SignGroup;
+  line: string;
+  setSignGroups: (
+    line: string,
+    signGroups: RouteSignGroupsWithDeletions,
+  ) => void;
   readOnly: boolean;
   onEdit: (key: string) => void;
 }
@@ -15,6 +20,8 @@ export default function SignGroupItem({
   groupKey,
   currentTime,
   group,
+  line,
+  setSignGroups,
   readOnly,
   onEdit,
 }: SignGroupProps): JSX.Element {
@@ -31,7 +38,11 @@ export default function SignGroupItem({
         >
           Edit
         </button>
-        <button type="button" className="btn btn-primary">
+        <button
+          onClick={() => setSignGroups(line, { [groupKey]: {} })}
+          type="button"
+          className="btn btn-primary"
+        >
           Return to &ldquo;Auto&rdquo;
         </button>
       </div>

--- a/assets/js/SignGroups.tsx
+++ b/assets/js/SignGroups.tsx
@@ -10,6 +10,7 @@ import {
   StationConfig,
   Zone,
   RouteSignGroups,
+  RouteSignGroupsWithDeletions,
   SignGroup,
 } from './types';
 import { defaultZoneLabel } from './helpers';
@@ -355,6 +356,11 @@ interface SignGroupsListProps {
   currentTime: number;
   onCreate: () => void;
   onEdit: (groupKey: string) => void;
+  line: string;
+  setSignGroups: (
+    line: string,
+    signGroups: RouteSignGroupsWithDeletions,
+  ) => void;
 }
 
 function SignGroupsList({
@@ -363,6 +369,8 @@ function SignGroupsList({
   currentTime,
   onCreate,
   onEdit,
+  line,
+  setSignGroups,
 }: SignGroupsListProps): JSX.Element | null {
   const groupCount = Object.keys(signGroups).length;
 
@@ -385,6 +393,8 @@ function SignGroupsList({
               currentTime={currentTime}
               groupKey={groupKey}
               group={signGroups[groupKey]}
+              line={line}
+              setSignGroups={setSignGroups}
               readOnly={readOnly}
               onEdit={onEdit}
             />
@@ -400,7 +410,10 @@ interface SignGroupsProps {
   currentTime: number;
   alerts: RouteAlerts;
   signGroups: RouteSignGroups;
-  setSignGroups: (line: string, signGroups: RouteSignGroups) => void;
+  setSignGroups: (
+    line: string,
+    signGroups: RouteSignGroupsWithDeletions,
+  ) => void;
   readOnly: boolean;
 }
 
@@ -462,6 +475,8 @@ function SignGroups({
       readOnly={readOnly}
       onCreate={() => openForm(null)}
       onEdit={openForm}
+      line={line}
+      setSignGroups={setSignGroups}
     />
   );
 }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 Return to "Auto" button on group](https://app.asana.com/0/584764604969369/1200222628914567)

The button was already there, this just updates the callback to use the `setSignGroups` function which already exists and can be used to delete a sign group (by sending `{}`). The ticket mentions a Return to Auto button inside the form as well, but Jessie/Kristin gave the go ahead to skip that for now, since it seems unlikely a PIO would use it compared to the button in the sign group list, and since there's other ongoing work inside the form there which it might conflict with.

<img width="666" alt="Screen Shot 2021-07-28 at 1 37 09 PM" src="https://user-images.githubusercontent.com/384428/127377670-6395d770-6d9c-4612-aede-c0826f2da3e0.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
