### PR TITLE
feat: Apply button on individual signs matches groups

### DIFF
--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -329,16 +329,6 @@ class SignPanel extends React.Component<
                 onValidLine1Change={this.handleInputLine1}
                 onValidLine2Change={this.handleInputLine2}
               />
-              <div>
-                <input
-                  className="viewer--apply-button"
-                  disabled={!customChanges}
-                  type="submit"
-                  value="Apply"
-                  onClick={this.saveStaticText}
-                />
-                {customChanges ? '*' : ''}
-              </div>
             </div>
           )}
 
@@ -365,6 +355,16 @@ class SignPanel extends React.Component<
               />
             </div>
           )}
+          <div>
+                <input
+                  className="viewer--apply-button"
+                  disabled={!customChanges}
+                  type="submit"
+                  value="Apply"
+                  onClick={this.saveStaticText}
+                />
+                {customChanges ? '*' : ''}
+                </div>
 
           {signGroup && (
             <div className="viewer--sign-group">

--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -356,15 +356,15 @@ class SignPanel extends React.Component<
             </div>
           )}
           <div>
-                <input
-                  className="viewer--apply-button"
-                  disabled={!customChanges}
-                  type="submit"
-                  value="Apply"
-                  onClick={this.saveStaticText}
-                />
-                {customChanges ? '*' : ''}
-                </div>
+            <input
+              className="viewer--apply-button"
+              disabled={!customChanges}
+              type="submit"
+              value="Apply"
+              onClick={this.saveStaticText}
+            />
+            {customChanges ? '*' : ''}
+          </div>
 
           {signGroup && (
             <div className="viewer--sign-group">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 "apply" for both custom text modules functions similarly](https://app.asana.com/0/584764604969369/1200421875164011/f)

Apply button moved under date picker widget. Changes to sign takes effect after button is clicked. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
