### PR TITLE
Reworking "Apply" in SignPanel

### DIFF
--- a/assets/js/SignTextInput.tsx
+++ b/assets/js/SignTextInput.tsx
@@ -45,6 +45,7 @@ function SignTextInput({
       <div>
         <input
           id={`${signID}-line1-input`}
+          data-testid={`${signID}-line1-input`}
           className="custom_text_input--line-input"
           type="text"
           maxLength={18}
@@ -57,6 +58,7 @@ function SignTextInput({
       <div>
         <input
           id={`${signID}-line2-input`}
+          data-testid={`${signID}-line2-input`}
           className="custom_text_input--line-input"
           type="text"
           maxLength={24}

--- a/assets/js/Station.tsx
+++ b/assets/js/Station.tsx
@@ -68,6 +68,13 @@ function makeSign(
     const signGroup = signGroupKey ? signGroups[signGroupKey] : undefined;
     const ungroupMe = signGroupKey ? () => ungroupSign(realtimeId) : undefined;
 
+    const setConfig = React.useCallback(
+      (conf: SignConfig) => {
+        setConfigs({ [realtimeId]: conf });
+      },
+      [setConfigs, realtimeId],
+    );
+
     return (
       <SignPanel
         alerts={alerts}
@@ -78,7 +85,7 @@ function makeSign(
         signContent={signContent}
         currentTime={currentTime}
         signConfig={signConfig}
-        setConfigs={setConfigs}
+        setConfig={setConfig}
         realtimeId={realtimeId}
         signGroup={signGroup}
         ungroupSign={ungroupMe}

--- a/assets/test/SignPanel.test.ts
+++ b/assets/test/SignPanel.test.ts
@@ -9,6 +9,7 @@ import {
   SignConfig,
   SignGroup,
   SingleSignContent,
+  SignConfigs,
 } from '../js/types';
 
 function customSignContent(): SingleSignContent {
@@ -50,7 +51,7 @@ function customModeSignProps(): SignPanelProps {
     currentTime: now + 2000,
     line: 'Red',
     signConfig: { mode: 'static_text' },
-    setConfigs: () => true,
+    setConfig: () => true,
     realtimeId: 'id',
     readOnly: false,
     modes: {
@@ -100,7 +101,7 @@ test('does not show messages that have expired', () => {
   const line = 'Red';
   const signConfig: SignConfig = { mode: 'auto' };
   const signContent = signContentWithExpirations(fresh, expired);
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = false;
   const modes = {
@@ -120,7 +121,7 @@ test('does not show messages that have expired', () => {
         currentTime,
         line,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
         modes,
@@ -146,7 +147,7 @@ test('does not show select in read-only mode', () => {
     fresh,
     fresh,
   );
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = true;
   const modes = {
@@ -167,7 +168,7 @@ test('does not show select in read-only mode', () => {
         currentTime,
         line,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
       },
@@ -189,7 +190,7 @@ test('shows the mode the sign is in in read-only mode', () => {
     fresh,
     fresh,
   );
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = true;
   const modes = {
@@ -210,7 +211,7 @@ test('shows the mode the sign is in in read-only mode', () => {
         currentTime,
         line,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
       },
@@ -229,7 +230,7 @@ test('does show select when not in read-only mode', () => {
   const line = 'Red';
   const signConfig: SignConfig = { mode: 'auto' };
   const signContent = signContentWithExpirations(fresh, fresh);
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = false;
   const modes = {
@@ -250,7 +251,7 @@ test('does show select when not in read-only mode', () => {
         line,
         modes,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
       },
@@ -316,7 +317,7 @@ test.each([
     const line = 'Red';
     const signConfig: SignConfig = { mode: 'auto' };
     const signContent = signContentWithExpirations(fresh, fresh);
-    const setConfigs = () => true;
+    const setConfig = () => true;
     const realtimeId = 'id';
     const readOnly = false;
     const modes: ZoneConfig['modes'] = {
@@ -337,7 +338,7 @@ test.each([
           currentTime,
           line,
           signConfig,
-          setConfigs,
+          setConfig,
           realtimeId,
           readOnly,
           modes,
@@ -362,7 +363,7 @@ test('shows the return to auto time field if sign can be set to auto', () => {
   const line = 'Red';
   const signConfig: SignConfig = { mode: 'static_text' };
   const signContent = signContentWithExpirations(fresh, fresh);
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = false;
   const modes = {
@@ -383,7 +384,7 @@ test('shows the return to auto time field if sign can be set to auto', () => {
         line,
         modes,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
       },
@@ -402,7 +403,7 @@ test('does not show the return to auto time field if sign can be set to auto', (
   const line = 'Red';
   const signConfig: SignConfig = { mode: 'off' };
   const signContent = signContentWithExpirations(fresh, fresh);
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = false;
   const modes = {
@@ -423,7 +424,7 @@ test('does not show the return to auto time field if sign can be set to auto', (
         line,
         modes,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
       },
@@ -442,7 +443,7 @@ test('shows clock even when no other content is present', () => {
   const line = 'Red';
   const signConfig: SignConfig = { mode: 'auto' };
   const signContent = signContentWithExpirations(expired, expired);
-  const setConfigs = () => true;
+  const setConfig = () => true;
   const realtimeId = 'id';
   const readOnly = false;
   const modes = {
@@ -462,7 +463,7 @@ test('shows clock even when no other content is present', () => {
         currentTime,
         line,
         signConfig,
-        setConfigs,
+        setConfig,
         realtimeId,
         readOnly,
         modes,
@@ -542,4 +543,59 @@ test('allows backing out of the ungrouping prompt', () => {
   expect(ungroupFn).not.toHaveBeenCalled();
   expect(screen.getByRole('button', { name: 'Ungroup' })).not.toBeDisabled();
   expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+});
+
+test('does not save changes to backend until Apply is pressed', () => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+
+  const setConfigHistory: SignConfig[] = [];
+
+  render(
+    React.createElement(SignPanel, {
+      alerts: {
+        alert1: {
+          id: 'alert1',
+          service_effect: "there's a problem",
+          created_at: null,
+        },
+      },
+      signId: 'signId',
+      modes: { auto: true, custom: true, headway: true, off: true },
+      signContent: signContentWithExpirations(fresh, fresh),
+      currentTime,
+      line: 'Red',
+      setConfig: (signConfig: SignConfig) => {
+        setConfigHistory.push(signConfig);
+      },
+      signConfig: { mode: 'auto' },
+      realtimeId: 'arincId',
+      readOnly: false,
+    }),
+  );
+
+  userEvent.selectOptions(screen.getByTestId('arincId'), 'Custom');
+  userEvent.type(screen.getByTestId('arincId-line1-input'), 'line1');
+  userEvent.type(screen.getByTestId('arincId-line2-input'), 'line2');
+  userEvent.click(screen.getByLabelText('Schedule return to "Auto"'));
+  userEvent.click(screen.getByLabelText('Date and time'));
+  userEvent.click(
+    screen.getByLabelText('At the end of an alert effect period'),
+  );
+  userEvent.click(screen.getByRole('button', { name: 'alert1' }));
+
+  expect(setConfigHistory).toEqual([]);
+
+  userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+  expect(setConfigHistory).toEqual([
+    {
+      mode: 'static_text',
+      line1: 'line1',
+      line2: 'line2',
+      expires: null,
+      alert_id: 'alert1',
+    },
+  ]);
 });


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔀 "apply" for both custom text modules functions similarly](https://app.asana.com/0/584764604969369/1200421875164011)

The first commit is a refactor of `SignPanel` to the functional component react style that we use now.

The second changes the component to not immediately save in all the cases that it used to. Formerly, the UX was a bit confusing: Changing to "Custom" immediately saved a new configuration with empty lines, having the effect of blanking the sign. Then subsequent changes to the line inputs didn't take effect until the "Apply" button was pressed. However, the expiration values (datetime or alert ID) were saved immediately upon choosing them. Now, changing to "Custom" exposes the form but does not save, and similarly adding an expiration criterion does not save. Only once "Apply" is pressed does it save everything. Note that per the ticket specification, changing to a mode other than Custom still *does* apply immediately.

To change the behavior in the desired way, I added more state to the component, and updated the things that previously saved to the backend, to simply update the internal state instead. And then "Apply" would send the new state to the backend. Since we're now keeping the whole sign config in the state, I removed the individual `staticLine1` and `staticLine2` fields, and replaced them with a `signConfig` object, which gets initialized by the current value in its props.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
