### PR TITLE
fix: Shorten JFK/UMass sign names to fix wrapping

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -1075,7 +1075,7 @@ const stationConfig: {
         name: 'JFK/UMass',
         zones: {
           n: {
-            label: 'Braintree Platform NB',
+            label: 'Braintree NB',
             modes: {
               auto: true,
               custom: true,
@@ -1084,7 +1084,7 @@ const stationConfig: {
             },
           },
           s: {
-            label: 'Braintree Platform SB',
+            label: 'Braintree SB',
             modes: {
               auto: true,
               custom: true,
@@ -1093,7 +1093,7 @@ const stationConfig: {
             },
           },
           e: {
-            label: 'Ashmont Platform NB',
+            label: 'Ashmont NB',
             modes: {
               auto: true,
               custom: true,
@@ -1102,7 +1102,7 @@ const stationConfig: {
             },
           },
           w: {
-            label: 'Ashmont Platform SB',
+            label: 'Ashmont SB',
             modes: {
               auto: true,
               custom: true,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛👁 JFK/UMass signs info correctly aligned](https://app.asana.com/0/584764604969369/1200871142354109)

Changed the sign names to what was in the ticket, and now it fits:

<img width="1095" alt="Screen Shot 2021-09-17 at 2 34 28 PM" src="https://user-images.githubusercontent.com/384428/133844215-7c6f6474-d5ee-4aea-9fa5-87d9f5fefa5b.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
