### PR TITLE
fix: Allow SL signs with no 'auto' mode to still Apply custom text

### DIFF
--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -258,25 +258,27 @@ function SignPanel({
           </div>
         )}
 
-        {signConfig.mode !== 'auto' && modes.auto && !signGroup && (
+        {signConfig.mode !== 'auto' && !signGroup && (
           <div>
-            <div className="viewer--schedule-expires">
-              <SetExpiration
-                alerts={alerts}
-                expires={parseDate(signConfig.expires)}
-                alertId={signConfig.alert_id}
-                onDateChange={(dt) => {
-                  setSignConfig({ ...signConfig, expires: stringify(dt) });
-                  setHasCustomChanges(true);
-                }}
-                onAlertChange={(alertId) => {
-                  setSignConfig({ ...signConfig, alert_id: alertId });
-                  setHasCustomChanges(true);
-                }}
-                readOnly={readOnly}
-                showAlertSelector={shouldShowAlertSelector(line)}
-              />
-            </div>
+            {modes.auto && (
+              <div className="viewer--schedule-expires">
+                <SetExpiration
+                  alerts={alerts}
+                  expires={parseDate(signConfig.expires)}
+                  alertId={signConfig.alert_id}
+                  onDateChange={(dt) => {
+                    setSignConfig({ ...signConfig, expires: stringify(dt) });
+                    setHasCustomChanges(true);
+                  }}
+                  onAlertChange={(alertId) => {
+                    setSignConfig({ ...signConfig, alert_id: alertId });
+                    setHasCustomChanges(true);
+                  }}
+                  readOnly={readOnly}
+                  showAlertSelector={shouldShowAlertSelector(line)}
+                />
+              </div>
+            )}
             <div>
               <input
                 className="viewer--apply-button"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Signs-UI bug, can't use custom text if auto not supported](https://app.asana.com/0/584764604969369/1201298286453765).

Fixes an issue a PIO [reported conversation in Slack](https://mbta.slack.com/archives/GKQ8R5HAN/p1635862067010000) that the SL signs which don't have "Auto" as an option (because predictions are bad there), don't have the ability to apply Custom Text anymore either, because the Apply button doesn't appear.

I think this came about when we refactored the signs to have an "Apply" button that updates all the content of the sign, rather than just the custom text. But it only gets displayed in tandem with the "Set Expiration" field.

Since we don't want the PIOs to use "Set Expiration" if the signs can't go back to Auto, this PR updates the "Set Expiration" part to stay hidden if the sign doesn't support Auto, but moves the Apply button outside of that condition.

This branch is deploying to Dev right now.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
