### PR TITLE
Add Braintree busway sign

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2922,6 +2922,26 @@ const stationConfig: {
           },
         },
       },
+      {
+        id: 'SBRA',
+        name: 'Braintree',
+        zonePositions: {
+          left: [],
+          center: ['n'],
+          right: [],
+        },
+        zones: {
+          n: {
+            label: 'Busway',
+            modes: {
+              auto: true,
+              custom: true,
+              headway: false,
+              off: true,
+           }
+          }
+        }
+      },
     ],
   },
 };
@@ -3190,6 +3210,7 @@ const arincToRealtimeIdMap: { [key: string]: string } = {
   'SDAV-m': 'bus.Davis',
   'SFOR-n': 'bus.Forest_Hills_upper_fence',
   'SFOR-s': 'bus.Forest_Hills_upper_island',
+  'SBRA-n': 'bus.Braintree'
 };
 
 function arincToRealtimeId(stationZone: string, line: string): string {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Reconfigure Braintree Busway Sign](https://app.asana.com/0/1180642489429371/1180642489429379/f)

This PR adds the config for the signs at the Braintree Busway. The sign has been offline for some time, but we are having ARINC bring it back on. Because the Center and Mezzanine zones are already being used for Subway predictions, ARINC is mapping the signs to the North zone which is why they are configured as `SBRA-n` in Signs UI.
