### PR TITLE
Enable glx signs for more modes

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -1994,26 +1994,26 @@ const stationConfig: {
           e: {
             label: 'Track 1',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
             },
           },
           w: {
             label: 'Track 2',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
             },
           },
           m: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
             },
           },
@@ -2026,26 +2026,26 @@ const stationConfig: {
           e: {
             label: 'Union Sq',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
             },
           },
           w: {
             label: 'Copley & West',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
             },
           },
           m: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
             },
           },

--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -1994,7 +1994,7 @@ const stationConfig: {
           e: {
             label: 'Track 1',
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,
@@ -2003,7 +2003,7 @@ const stationConfig: {
           w: {
             label: 'Track 2',
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,
@@ -2011,7 +2011,7 @@ const stationConfig: {
           },
           m: {
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,
@@ -2026,7 +2026,7 @@ const stationConfig: {
           e: {
             label: 'Union Sq',
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,
@@ -2035,7 +2035,7 @@ const stationConfig: {
           w: {
             label: 'Copley & West',
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,
@@ -2043,7 +2043,7 @@ const stationConfig: {
           },
           m: {
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Follow up on "Updates to signs-ui"](https://app.asana.com/0/1201753694073608/1201681770685701/f)

This PR enables headway mode as an option for the new GLX sign zones. For clarity, this PR doesn't include auto mode (used for predictions) since we will not be able to provide predictions until after opening day as some unknown time. We should keep that mode disabled to prevent accidental setting of those signs to auto mode.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
