### PR TITLE
Adjust station code

### DIFF
--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -302,6 +302,7 @@ class ViewerApp extends React.Component<
         </div>
         {line && (
           <Viewer
+            key={line}
             alerts={alerts}
             signs={signs}
             signConfigs={signConfigs}

--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2923,7 +2923,7 @@ const stationConfig: {
         },
       },
       {
-        id: 'SBRA',
+        id: 'RBRA',
         name: 'Braintree',
         zonePositions: {
           left: [],
@@ -3210,7 +3210,7 @@ const arincToRealtimeIdMap: { [key: string]: string } = {
   'SDAV-m': 'bus.Davis',
   'SFOR-n': 'bus.Forest_Hills_upper_fence',
   'SFOR-s': 'bus.Forest_Hills_upper_island',
-  'SBRA-n': 'bus.Braintree',
+  'RBRA-n': 'bus.Braintree',
 };
 
 function arincToRealtimeId(stationZone: string, line: string): string {


### PR DESCRIPTION
#### Summary of changes
Station code for the busway should actually be `RBRA-n` and not `SBRA-n`. 

Additionally, changing the Station Id to `RBRA` revealed a bug when React was trying to re-render the Station components when switching tabs. To remediate this, a key was added to force a remount of the Viewer component each time we switch tabs. This bug is also happening for `SFOR` because that Station Id exists both in the Busway tab as well as the Orange tab.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
