### PR TITLE
Disable auto mode for GSCI EB and MZ zones 

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2057,7 +2057,7 @@ const stationConfig: {
         zones: {
           e: {
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,
@@ -2073,7 +2073,7 @@ const stationConfig: {
           },
           m: {
             modes: {
-              auto: true,
+              auto: false,
               custom: true,
               headway: true,
               off: true,


### PR DESCRIPTION
#### Summary of changes
Disabling these zones to improve user/rider experience since predictions are not able to be given for these zones until further notice. These signs will remain in headway mode (or custom text if needed) for the time being.
