### PR TITLE
Set Lechmere busway sign to have auto mode enabled

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2817,7 +2817,7 @@ const stationConfig: {
           m: {
             label: 'Busway',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               headway: false,
               off: true,


### PR DESCRIPTION
#### Summary of changes
This PR simply sets this sign to have auto mode enabled.

Context: These signs actually don't exist in real life. But there are bus predictions being provided technically, so for now we are at least enabling this in dev for the time being to monitor predictions through Signs UI.