### PR TITLE
Add back secret_key_base

### DIFF
--- a/.github/workflows/dev-ecs.yml
+++ b/.github/workflows/dev-ecs.yml
@@ -24,10 +24,13 @@ jobs:
         uses: mbta/actions/commit-metadata@v1
       - uses: mbta/actions/build-push-ecr@v1
         id: build-push
+        env:
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-args: "--build-arg SECRET_KEY_BASE"
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/prod-ecs.yml
+++ b/.github/workflows/prod-ecs.yml
@@ -22,10 +22,13 @@ jobs:
         uses: mbta/actions/commit-metadata@v1
       - uses: mbta/actions/build-push-ecr@v1
         id: build-push
+        env:
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-args: "--build-arg SECRET_KEY_BASE"
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
We should leave this in for the time being until `SECRET_KEY_BASE` is accessible through Secrets Manager.