### PR TITLE
Remove SECRET_KEY_BASE from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@
 FROM hexpm/elixir:1.11.4-erlang-23.3.1-debian-buster-20210326 as elixir-builder
 ENV LANG="C.UTF-8" MIX_ENV="prod"
 
-ARG SECRET_KEY_BASE
-ENV SECRET_KEY_BASE=${SECRET_KEY_BASE}
-RUN if test -z $SECRET_KEY_BASE; then (>&2 echo "No SECRET_KEY_BASE"); exit 1; fi
-
 WORKDIR /root
 ADD . .
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,7 +16,6 @@ import Config
 config :signs_ui, SignsUiWeb.Endpoint,
   load_from_system_env: true,
   url: [host: "example.com", port: 443, scheme: "https"],
-  secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE"),
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :signs_ui, :redirect_http?, true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,1 +1,4 @@
 import Config
+
+config :signs_ui, SignsUiWeb.Endpoint,
+  secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,4 +1,6 @@
 import Config
 
-config :signs_ui, SignsUiWeb.Endpoint,
-  secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE")
+if config_env() == :prod do
+  config :signs_ui, SignsUiWeb.Endpoint,
+    secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE")
+end


### PR DESCRIPTION
This PR removes `SECRET_KEY_BASE` from the dockerfile since it's added through the container definition in Terraform and is therefore not needed here. This should also help ensure that we will be okay to remove `SECRET_KEY_BASE` from GitHub environments.

The PR also moves the `SECRET_KEY_BASE` config value to the runtime config. General best-practice at the CTD is to pull in secrets to the application environment at runtime. Although for this specific secret we add it as an env variable through the Terraform container definition, sometimes we make calls to AWS Secrets manager in `runtime.ex` and pull in secrets that way.