### PR TITLE
Move screenplay URLs to prod.exs

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,12 +7,12 @@ import Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :signs_ui, SignsUiWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: 5000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
   watchers: [npm: ["run", "watch", cd: Path.expand("../assets", __DIR__)]],
-  screenplay_base_url: "https://screenplay-dev.mbtace.com/"
+  screenplay_base_url: "localhost:4000/"
 
 # ## SSL Support
 #

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,4 @@
 import Config
-use Logger
 
 # For production, we often load configuration from external
 # sources, such as your system environment. For this reason,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,5 @@
 import Config
+use Logger
 
 # For production, we often load configuration from external
 # sources, such as your system environment. For this reason,
@@ -16,8 +17,7 @@ import Config
 config :signs_ui, SignsUiWeb.Endpoint,
   load_from_system_env: true,
   url: [host: "example.com", port: 443, scheme: "https"],
-  cache_static_manifest: "priv/static/cache_manifest.json",
-  screenplay_base_url: "https://screenplay.mbta.com/"
+  cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :signs_ui, :redirect_http?, true
 
@@ -35,6 +35,16 @@ config :ueberauth, Ueberauth.Strategy.Cognito,
   client_secret: {System, :get_env, ["COGNITO_CLIENT_SECRET"]},
   user_pool_id: {System, :get_env, ["COGNITO_USER_POOL_ID"]},
   aws_region: {System, :get_env, ["COGNITO_AWS_REGION"]}
+
+if System.get_env("ENVIRONMENT_NAME") == "dev" do
+  config :signs_ui, SignsUiWeb.Endpoint,
+    screenplay_base_url: "localhost:4000/ https://screenplay-dev.mbtace.com/"
+end
+
+if System.get_env("ENVIRONMENT_NAME") == "prod" do
+  config :signs_ui, SignsUiWeb.Endpoint,
+    screenplay_base_url: "https://screenplay.mbta.com/"
+end
 
 # ## SSL Support
 #


### PR DESCRIPTION
The initial configuration didn't work when Signs UI was deployed to dev in ECS since the `MIX_ENV` used is still prod and so `dev.exs` isn't actually evaluated in dev ECS.

Moved the config to `prod.exs` instead and used the system env variables to branch depending on which ECS environment we're deployed to.

Also including localhost as an accepted frame ancestor so that local instances are able to embed Signs UI Dev renderings. Otherwise while doing local development, one would have to start up signs UI locally alongside Screenplay in order for the renderings to be viewable.