### PR TITLE
Add frame ancestors to content-security-policy at controller

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -35,15 +35,6 @@ config :ueberauth, Ueberauth.Strategy.Cognito,
   user_pool_id: {System, :get_env, ["COGNITO_USER_POOL_ID"]},
   aws_region: {System, :get_env, ["COGNITO_AWS_REGION"]}
 
-if System.get_env("ENVIRONMENT_NAME") == "prod" do
-  config :signs_ui, SignsUiWeb.Endpoint,
-    screenplay_base_url: "https://screenplay.mbta.com/"
-else
-  config :signs_ui, SignsUiWeb.Endpoint,
-    screenplay_base_url: "localhost:4000/ https://screenplay-dev.mbtace.com/"
-end
-
-
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -35,15 +35,14 @@ config :ueberauth, Ueberauth.Strategy.Cognito,
   user_pool_id: {System, :get_env, ["COGNITO_USER_POOL_ID"]},
   aws_region: {System, :get_env, ["COGNITO_AWS_REGION"]}
 
-if System.get_env("ENVIRONMENT_NAME") == "dev" do
+if System.get_env("ENVIRONMENT_NAME") == "prod" do
+  config :signs_ui, SignsUiWeb.Endpoint,
+    screenplay_base_url: "https://screenplay.mbta.com/"
+else
   config :signs_ui, SignsUiWeb.Endpoint,
     screenplay_base_url: "localhost:4000/ https://screenplay-dev.mbtace.com/"
 end
 
-if System.get_env("ENVIRONMENT_NAME") == "prod" do
-  config :signs_ui, SignsUiWeb.Endpoint,
-    screenplay_base_url: "https://screenplay.mbta.com/"
-end
 
 # ## SSL Support
 #

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,10 +6,10 @@ if config_env() == :prod do
 end
 
 
-if System.get_env("ENVIRONMENT_NAME") == "prod" do
-  config :signs_ui, SignsUiWeb.Endpoint,
-    screenplay_base_url: "https://screenplay.mbta.com/"
-else
-  config :signs_ui, SignsUiWeb.Endpoint,
-    screenplay_base_url: "localhost:4000/ https://screenplay-dev.mbtace.com/"
-end
+screenplay_base_url =
+  if System.get_env("ENVIRONMENT_NAME") == "prod",
+    do: "https://screenplay.mbta.com/",
+    else: "localhost:4000/ https://screenplay-dev.mbtace.com/"
+
+config :signs_ui, SignsUiWeb.Endpoint,
+    screenplay_base_url: screenplay_base_url

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,3 +4,12 @@ if config_env() == :prod do
   config :signs_ui, SignsUiWeb.Endpoint,
     secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE")
 end
+
+
+if System.get_env("ENVIRONMENT_NAME") == "prod" do
+  config :signs_ui, SignsUiWeb.Endpoint,
+    screenplay_base_url: "https://screenplay.mbta.com/"
+else
+  config :signs_ui, SignsUiWeb.Endpoint,
+    screenplay_base_url: "localhost:4000/ https://screenplay-dev.mbtace.com/"
+end

--- a/lib/signs_ui_web/controllers/single_sign_controller.ex
+++ b/lib/signs_ui_web/controllers/single_sign_controller.ex
@@ -8,8 +8,19 @@ defmodule SignsUiWeb.SingleSignController do
     sign_id = station_code <> "-" <> zone
     sign = State.get_single_sign(sign_id)
 
+    [policy] = get_resp_header(conn, "content-security-policy")
+
     conn
     |> put_layout("single_sign.html")
+    |> put_resp_header(
+      "content-security-policy",
+      policy <>
+        " frame-ancestors #{
+          :signs_ui
+          |> Application.get_env(SignsUiWeb.Endpoint)
+          |> Keyword.get(:screenplay_base_url)
+        };"
+    )
     |> render("single_sign.html", sign: sign)
   end
 end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -9,11 +9,7 @@ defmodule SignsUiWeb.Router do
 
     plug(:put_secure_browser_headers, %{
       "content-security-policy" =>
-        "default-src 'self'; connect-src 'self' https://*.ingest.sentry.io; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-ancestors #{
-          :signs_ui
-          |> Application.get_env(SignsUiWeb.Endpoint)
-          |> Keyword.get(:screenplay_base_url)
-        };"
+        "default-src 'self'; connect-src 'self' https://*.ingest.sentry.io; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';"
     })
   end
 


### PR DESCRIPTION
Third times the charm. 

Basically, the prior attempts at a solution didn't work because we were depending on runtime values at compile time. This should work since we check for the `ENVIRONMENT_NAME` in `runtime.exs` and we append to the response header just before the controller returns a response.
