### PR TITLE
Allow parentheses

### DIFF
--- a/assets/js/SignTextInput.tsx
+++ b/assets/js/SignTextInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 function isValidText(text: string) {
-  return !/[^a-zA-Z0-9,/!@' +]/.test(text);
+  return !/[^a-zA-Z0-9,/!@()' +]/.test(text);
 }
 
 interface SignTextInputProps {
@@ -39,7 +39,7 @@ function SignTextInput({
     <div>
       {showTipText && (
         <small className="custom_text_input--error-text">
-          You may use letters, numbers, and: /,!@&quot;
+          You may use letters, numbers, and: /,!@()&quot;
         </small>
       )}
       <div>

--- a/lib/signs_ui/messages/sign_content.ex
+++ b/lib/signs_ui/messages/sign_content.ex
@@ -26,7 +26,7 @@ defmodule SignsUi.Messages.SignContent do
   page_text =
     ignore(string("-"))
     |> ignore(string("\""))
-    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+], min: 0)
+    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+, ?(, ?)], min: 0)
     |> ignore(string("\""))
     |> optional(
       ignore(string("."))


### PR DESCRIPTION
This change allows Signs UI to parse parentheses and allow them in custom text messages as well. The need for this came out of the JFK/UMass improvements that will use parentheses for communicating what platform the next northbound train will arrive at.

Dan Salomon reported that parentheses can work on countdown clocks in [this thread](https://mbta.slack.com/archives/G01HD71N1GD/p1652378170981619?thread_ts=1652376450.649179&cid=G01HD71N1GD) and I also tested this in the real world at the Silver Line Courthouse station mezzanine as pictured below
![Screenshot_20220812-112330_2](https://user-images.githubusercontent.com/16074540/184388059-7a879085-385a-4d4e-a47c-c4f3434e64d0.png)

