### PR TITLE
Remove outdated logic for RL predictions for SL transfers

### DIFF
--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -57,7 +57,7 @@ function setAllStationsMode(
 
   stations.forEach((station: StationConfig) => {
     ['n', 's', 'e', 'w', 'm', 'c'].forEach((zone) => {
-      const realtimeId = arincToRealtimeId(`${station.id}-${zone}`, line);
+      const realtimeId = arincToRealtimeId(`${station.id}-${zone}`);
       const zoneConfig = station.zones[zone];
       if (zoneConfig !== undefined) {
         const { modes } = zoneConfig;
@@ -151,7 +151,7 @@ function Line({
     const isMixed = stations.some((station) =>
       Object.keys(station.zones).some((zone) => {
         if (station.zones[zone]) {
-          const realtimeId = arincToRealtimeId(`${station.id}-${zone}`, line);
+          const realtimeId = arincToRealtimeId(`${station.id}-${zone}`);
           const mode = signConfigs[realtimeId] && signConfigs[realtimeId].mode;
           if (mode) {
             uniqueModes[mode] = mode;

--- a/assets/js/SignGroups.tsx
+++ b/assets/js/SignGroups.tsx
@@ -65,7 +65,7 @@ function ZoneSelector({
   }
 
   const zoneLabel = zoneConfig.label || defaultZoneLabel(zone);
-  const signId = arincToRealtimeId(`${config.id}-${zone}`, line);
+  const signId = arincToRealtimeId(`${config.id}-${zone}`);
   const isSelected = selectedSigns.has(signId);
 
   return (
@@ -142,7 +142,7 @@ function SignGroupsForm({
   const onSignChange = React.useCallback(
     ([stationId, zone]: [string, Zone], isChecked: boolean) => {
       const newSignIds = new Set(signIds);
-      const signId = arincToRealtimeId(`${stationId}-${zone}`, line);
+      const signId = arincToRealtimeId(`${stationId}-${zone}`);
       if (isChecked) {
         if (signIdsInOtherGroups.has(signId)) {
           setArincSignChangingGroup([stationId, zone]);
@@ -180,7 +180,7 @@ function SignGroupsForm({
           elementId="tab-panel-container"
           onAccept={() => {
             const [station, zone] = arincSignChangingGroup;
-            const signId = arincToRealtimeId(`${station}-${zone}`, line);
+            const signId = arincToRealtimeId(`${station}-${zone}`);
             const newSignIds = new Set(signIds).add(signId);
             setSignGroup({ ...signGroup, sign_ids: Array.from(newSignIds) });
             setArincSignChangingGroup(null);

--- a/assets/js/Station.tsx
+++ b/assets/js/Station.tsx
@@ -61,7 +61,7 @@ function makeSign(
   if (zone && zoneConfig) {
     const key = `${config.id}-${zone}`;
     const signContent = signs[key] || { sign_id: key, lines: {} };
-    const realtimeId = arincToRealtimeId(key, line);
+    const realtimeId = arincToRealtimeId(key);
     const signConfig = signConfigs[realtimeId] || { mode: 'off' };
     const signGroupKey = signsToGroups[realtimeId];
     const signGroup = signGroupKey ? signGroups[signGroupKey] : undefined;

--- a/assets/js/helpers.ts
+++ b/assets/js/helpers.ts
@@ -104,14 +104,7 @@ function defaultZoneLabel(z: Zone): string {
   }
 }
 
-function arincToRealtimeId(stationZone: string, line: string): string {
-  if (stationZone === 'RSOU-m' && line === 'Red') {
-    return 'red_south_station_mezzanine';
-  }
-  if (stationZone === 'RSOU-m' && line === 'Silver') {
-    return 'south_station_mezzanine';
-  }
-
+function arincToRealtimeId(stationZone: string): string {
   return window.arincToRealtimeIdMap[stationZone];
 }
 

--- a/priv/arinc_to_realtime.json
+++ b/priv/arinc_to_realtime.json
@@ -140,6 +140,7 @@
   "RDTC-s": "red_downtown_crossing_southbound",
   "RSOU-n": "red_south_station_northbound",
   "RSOU-s": "red_south_station_southbound",
+  "RSOU-m": "red_south_station_mezzanine",
   "SSOU-w": "south_station_silver_line_arrival_platform",
   "RBRO-m": "broadway_mezzanine",
   "RBRO-n": "broadway_northbound",


### PR DESCRIPTION
#### Summary of changes
This PR is a minor tweak of #831. The `red_south_station_mezzanine` id is used for the actual South Station Red Line Mezzanine sign, which always shows Red Line predictions. The `south_station_mezzanine` id was _intended_ for a sign at the Silver Line platform that shows Red Line predictions for riders that are transferring from Silver to Red. It turns out that there is already an Id called `south_station_silver_line_arrival_platform` for this same use-case so the id `south_station_mezzanine` is actually not being used and is defunct. Therefore, we can safely remove the dedicated logic in the helper function.

I also considered removing the helper function entirely, but I think keeping the function there is a little more readable.
