### PR TITLE
Add component for Bowdoin drop-off zone

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -1693,6 +1693,15 @@ const stationConfig: {
               off: true,
             },
           },
+          w: {
+            label: 'Drop-off',
+            modes: {
+              auto: true,
+              custom: true,
+              headway: true,
+              off: true,
+            },
+          },
         },
       },
     ],

--- a/priv/arinc_to_realtime.json
+++ b/priv/arinc_to_realtime.json
@@ -54,6 +54,7 @@
   "BGOV-w": "government_center_westbound",
   "BBOW-e": "bowdoin_eastbound",
   "BBOW-m": "bowdoin_mezzanine",
+  "BBOW-w": "bowdoin_drop_off",
   "OOAK-m": "oak_grove_mezzanine_southbound",
   "OOAK-e": "oak_grove_east_busway",
   "OOAK-s": "oak_grove_platform",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add Bowdoin zone "W" to match what's installed](https://app.asana.com/0/1201786812162837/1203208997479587/f)

This PR adds a Signs UI component for the BBOW-w sign zone (Bowdoin Westbound). Since Bowdoin is a terminal, in reality this platform is used as a drop-off only zone where trains stop and let passengers out before looping around.

By adding this zone to Signs UI, but labeled as "Drop-off", we allow more flexibility for this sign. As of now, it's always blank and we don't have any manual control to display content even if we wanted to. Signs UI will let us either display eastbound predictions, custom text from PIOs, or even just keep the sign in the off state which wouldn't change anything from the status quo.

![Screen Shot 2022-10-20 at 12 31 48 PM](https://user-images.githubusercontent.com/16074540/197006402-969b58ab-bb02-462e-ab42-f8c73c96a2e3.png)

