### PR TITLE
experiment: app logout at end of flow

### DIFF
--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -52,8 +52,8 @@ defmodule SignsUiWeb.AuthController do
     end
   end
 
-  @spec logout(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def logout(conn, params) do
+  @spec initiate_logout(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def initiate_logout(conn, params) do
     refresh_token_store = Application.get_env(:signs_ui, :refresh_token_store)
 
     conn
@@ -66,6 +66,13 @@ defmodule SignsUiWeb.AuthController do
     conn
     |> Guardian.Plug.sign_out(SignsUiWeb.AuthManager)
     |> redirect(external: redirect_url)
+  end
+
+  @spec logout(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def logout(conn, _params) do
+    conn
+    |> Guardian.Plug.sign_out(SignsUiWeb.AuthManager)
+    |> redirect(to: SignsUiWeb.Router.Helpers.page_path(conn, :index))
   end
 
   @spec error?([Ueberauth.Failure.t(), ...], String.t()) :: boolean
@@ -96,7 +103,7 @@ defmodule SignsUiWeb.AuthController do
           |> Application.get_env(Ueberauth.Strategy.Cognito)
           |> Keyword.get(:client_id)
           |> config_value,
-        "logout_uri" => SignsUiWeb.Router.Helpers.page_url(conn, :index)
+        "logout_uri" => SignsUiWeb.Router.Helpers.auth_url(conn, :logout, "cognito")
       })
 
     "https://#{auth_domain}/logout?" <> redirect_params

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -34,7 +34,7 @@ defmodule SignsUiWeb.MessagesController do
 
     chelsea_bridge_announcements = Map.get(config, :chelsea_bridge_announcements, "off")
     sign_groups = config |> Map.fetch!(:sign_groups) |> SignGroups.by_route()
-    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito")
+    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :initiate_logout, "cognito")
 
     render(conn, "index.html",
       alerts: alerts,

--- a/lib/signs_ui_web/controllers/unauthorized_controller.ex
+++ b/lib/signs_ui_web/controllers/unauthorized_controller.ex
@@ -3,7 +3,7 @@ defmodule SignsUiWeb.UnauthorizedController do
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
-    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito")
+    sign_out_path = SignsUiWeb.Router.Helpers.auth_path(conn, :initiate_logout, "cognito")
 
     conn
     |> put_status(403)

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -41,6 +41,7 @@ defmodule SignsUiWeb.Router do
 
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
+    get("/:provider/initiate_logout", AuthController, :initiate_logout)
     get("/:provider/logout", AuthController, :logout)
   end
 

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -94,18 +94,16 @@ defmodule SignsUiWeb.AuthControllerTest do
     end
   end
 
-  describe "logout" do
+  describe "initiate_logout" do
     @tag :authenticated
     test "clears refresh token, logs user out, and redirects to Cognito logout", %{conn: conn} do
       reassign_env(:refresh_token_store, SignsUiWeb.AuthControllerTest.FakeRefreshTokenStore)
 
       log =
         capture_log([level: :info], fn ->
-          conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito"))
+          conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :initiate_logout, "cognito"))
 
           response = response(conn, 302)
-
-          assert is_nil(Guardian.Plug.current_claims(conn))
 
           assert response =~ "https://test_auth_domain/logout?client_id=test_client_secret"
         end)
@@ -129,11 +127,23 @@ defmodule SignsUiWeb.AuthControllerTest do
 
       Application.put_env(:ueberauth, Ueberauth.Strategy.Cognito, new_config)
 
-      conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito"))
+      conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :initiate_logout, "cognito"))
 
       response = response(conn, 302)
 
       assert response =~ "https://test_auth_domain/logout?client_id=test_client_secret_2"
+    end
+  end
+
+  describe "logout" do
+    test "logs user out and redirects to homepage", %{conn: conn} do
+      conn = get(conn, SignsUiWeb.Router.Helpers.auth_path(conn, :logout, "cognito"))
+
+      response = response(conn, 302)
+
+      assert is_nil(Guardian.Plug.current_claims(conn))
+
+      assert redirected_to(conn) == SignsUiWeb.Router.Helpers.page_path(conn, :index)
     end
   end
 

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -52,7 +52,10 @@ defmodule SignsUiWeb.MessagesControllerTest do
 
       response = html_response(conn, 200)
 
-      assert response =~ "signOutPath = \"/auth/cognito/logout\""
+      assert response =~
+               "signOutPath = \"#{
+                 SignsUiWeb.Router.Helpers.auth_path(conn, :initiate_logout, "cognito")
+               }\""
     end
   end
 

--- a/test/signs_ui_web/controllers/unauthorized_controller_test.exs
+++ b/test/signs_ui_web/controllers/unauthorized_controller_test.exs
@@ -8,7 +8,7 @@ defmodule SignsUiWeb.UnauthorizedControllerTest do
       html = html_response(conn, 403)
 
       assert html =~ "not authorized"
-      assert html =~ "/logout"
+      assert html =~ SignsUiWeb.Router.Helpers.auth_path(conn, :initiate_logout, "cognito")
     end
   end
 end


### PR DESCRIPTION
This is an experiment with reworking how the logout flow works. Creating a draft PR solely to run CI before deploying to dev.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
