### PR TITLE
experiment: use redirect_uri instead of logout_uri

### DIFF
--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -96,8 +96,7 @@ defmodule SignsUiWeb.AuthController do
           |> Application.get_env(Ueberauth.Strategy.Cognito)
           |> Keyword.get(:client_id)
           |> config_value,
-        # temporarily hardcoded for testing - Cognito docs say to use the allowed callback URI
-        "redirect_uri" => "https://signs-dev.mbtace.com/auth/cognito/callback"
+        "logout_uri" => "https://www.mbta.com/"
       })
 
     "https://#{auth_domain}/logout?" <> redirect_params

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -82,7 +82,7 @@ defmodule SignsUiWeb.AuthController do
   end
 
   @spec logout_redirect_url_for_provider(Plug.Conn.t(), String.t()) :: String.t()
-  defp logout_redirect_url_for_provider(conn, "cognito") do
+  defp logout_redirect_url_for_provider(_conn, "cognito") do
     auth_domain =
       :ueberauth
       |> Application.get_env(Ueberauth.Strategy.Cognito)
@@ -96,7 +96,8 @@ defmodule SignsUiWeb.AuthController do
           |> Application.get_env(Ueberauth.Strategy.Cognito)
           |> Keyword.get(:client_id)
           |> config_value,
-        "logout_uri" => SignsUiWeb.Router.Helpers.page_url(conn, :index)
+        # temporarily hardcoded for testing - Cognito docs say to use the allowed callback URI
+        "redirect_uri" => "https://signs-dev.mbtace.com/auth/cognito/callback"
       })
 
     "https://#{auth_domain}/logout?" <> redirect_params


### PR DESCRIPTION
This is my second experiment, again opening a PR for CI. I think between these two separate branches I'll be good for everything I want to try out.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
