### PR TITLE
Add Ashmont drop-off (SB) zone to the UI

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -1234,6 +1234,15 @@ const stationConfig: {
               off: true,
             },
           },
+          s: {
+            label: 'Drop-off',
+            modes: {
+              auto: true,
+              custom: true,
+              headway: true,
+              off: true,
+            },
+          },
         },
       },
       {

--- a/priv/arinc_to_realtime.json
+++ b/priv/arinc_to_realtime.json
@@ -160,6 +160,7 @@
   "RSHA-s": "shawmut_southbound",
   "RASH-m": "ashmont_mezzanine",
   "RASH-n": "red_ashmont_northbound",
+  "RASH-s": "red_ashmont_southbound",
   "RNQU-m": "north_quincy_mezzanine",
   "RNQU-n": "north_quincy_northbound",
   "RNQU-s": "north_quincy_southbound",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Blank countdown clocks on Ashmont drop-off platform display next 2 Mattapan Line departures](https://app.asana.com/0/1201786812162837/1203414051619270/f)

This PR will add a UI component for the Ashmont SB zone which is currently not being utilized, apart from PSAs that show on those signs.

This change will be followed up with a change to realtime-signs that will start sending predictions to this sign.

![Screen Shot 2022-11-29 at 11 12 26 AM](https://user-images.githubusercontent.com/16074540/204582652-e5d84757-af9b-497a-86d7-60d29cddc6b2.png)
