### PR TITLE
Update Lechmere EB label

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: dev
     env:
       ECS_CLUSTER: signs-ui

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: prod
     env:
       ECS_CLUSTER: signs-ui

--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   report-coverage:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - run: mkdir -p ${{ runner.temp }}/cover

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2202,7 +2202,6 @@ const stationConfig: {
         name: 'Lechmere',
         zones: {
           e: {
-            label: 'Union Sq',
             modes: {
               auto: true,
               custom: true,


### PR DESCRIPTION
Small tweak to change Lechmere outbound label to say EB. We'll use EB to be consistent with the rest of the GL trunk.

Before: 
![Screenshot 2022-12-15 at 12 05 35 PM](https://user-images.githubusercontent.com/16074540/207923178-5beba8fc-4cdd-4159-8ec5-ce455db0bacb.png)

After:
![Screenshot 2022-12-15 at 12 05 11 PM](https://user-images.githubusercontent.com/16074540/207923317-fb393aef-8d7e-44f2-8e05-0da17f9fcba6.png)

