### PR TITLE
remove improper hook call

### DIFF
--- a/assets/js/Station.tsx
+++ b/assets/js/Station.tsx
@@ -67,12 +67,9 @@ function makeSign(
     const signGroup = signGroupKey ? signGroups[signGroupKey] : undefined;
     const ungroupMe = signGroupKey ? () => ungroupSign(realtimeId) : undefined;
 
-    const setConfig = React.useCallback(
-      (conf: SignConfig) => {
-        setConfigs({ [realtimeId]: conf });
-      },
-      [setConfigs, realtimeId],
-    );
+    const setConfig = (conf: SignConfig) => {
+      setConfigs({ [realtimeId]: conf });
+    };
 
     return (
       <SignPanel


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Chore: Update error-prone call to hook in Station component](https://app.asana.com/0/1201753694073608/1201950647334669/f)

This fixes a situation where a hook was being called inside a conditional, which is not valid and can cause bugs. Since downstream components aren't memoized, this `useCallback` wasn't providing any optimizations, so removing it was the simplest option.