### PR TITLE
fix crash in AlertPicker

### DIFF
--- a/assets/js/AlertPicker.tsx
+++ b/assets/js/AlertPicker.tsx
@@ -17,7 +17,7 @@ function AlertPickerPopup({
   const [hoveredAlertId, setHoveredAlertId] = React.useState<string>(
     alertIds[0],
   );
-  const hoveredAlert = alerts[hoveredAlertId];
+  const hoveredAlert = hoveredAlertId && alerts[hoveredAlertId];
 
   const ref = React.useRef<HTMLDivElement | null>(null);
 

--- a/assets/js/AlertPicker.tsx
+++ b/assets/js/AlertPicker.tsx
@@ -17,6 +17,7 @@ function AlertPickerPopup({
   const [hoveredAlertId, setHoveredAlertId] = React.useState<string>(
     alertIds[0],
   );
+  const hoveredAlert = alerts[hoveredAlertId];
 
   const ref = React.useRef<HTMLDivElement | null>(null);
 
@@ -55,13 +56,13 @@ function AlertPickerPopup({
         ))}
       </div>
       <div className="alert_picker--content">
-        {hoveredAlertId === null ? (
+        {!hoveredAlert ? (
           'No alert selected'
         ) : (
           <>
-            <div>{alerts[hoveredAlertId].service_effect}</div>
+            <div>{hoveredAlert.service_effect}</div>
             <div className="alert_picker--created_at">
-              Created {formatTime(alerts[hoveredAlertId].created_at)}
+              Created {formatTime(hoveredAlert.created_at)}
             </div>
           </>
         )}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Crash when alert picker dropdown is open while an alert is closed](https://app.asana.com/0/1201753694073608/1203852555384568/f)

This fixes a crash when the last alert for a line is removed while the `AlertPicker` is open. The `key` for `AlertPickerPopup` changes every time the list of alerts changes, causing the popup to re-mount and reinitialize the selected alert id to the first in the list. When the new list is empty, the selected id becomes undefined, which later causes the crash. This changes the guard clause to ensure we actually have an alert before accessing it.