### PR TITLE
improve timings of paging messages

### DIFF
--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -87,7 +87,11 @@ function lineDisplayText(
     lineContent !== undefined &&
     isNotExpired(lineContent.expiration, currentTime)
   ) {
-    return choosePage(lineContent.text, (currentTime - initialTime) / 1000);
+    // ARINC signs start paging on the second page, so we rearrange the content to emulate that behavior
+    return choosePage(
+      [...lineContent.text.slice(1), ...lineContent.text.slice(0, 1)],
+      Math.round((currentTime - initialTime) / 1000),
+    );
   }
   return '';
 }

--- a/assets/js/helpers.ts
+++ b/assets/js/helpers.ts
@@ -12,7 +12,7 @@ function choosePage(
   let excessTime = elapsedSeconds % repeatTime;
 
   for (let i = 0; i < pages.length; i += 1) {
-    if (excessTime <= pages[i].duration) {
+    if (excessTime < pages[i].duration) {
       return pages[i].content;
     }
     excessTime -= pages[i].duration;


### PR DESCRIPTION
#### Summary of changes

This makes two improvements to the display of paging messages:

Because timeout callbacks are always approximate, the interval between `currentTime` updates is usually slightly above or below 1 second. We effectively truncate the time in `choosePage`, causing random 1 sec variations in paging duration. By rounding first, we can eliminate that variation. Also fixes an off-by-one error.

ARINC signs have the quirk of starting paging on page 2 of a message. We compensate for this in realtime-signs by shifting the pages so the desired one is shown first. This change emulates the sign behavior by shifting the other way, so the net result is the correct ordering.