### PR TITLE
remove @types/yup

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -17,7 +17,6 @@
         "@types/react": "^16.9.56",
         "@types/react-datepicker": "^3.1.1",
         "@types/react-dom": "^16.9.9",
-        "@types/yup": "^0.29.9",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.52.0",
         "copy-webpack-plugin": "^11.0.0",
@@ -2010,11 +2009,6 @@
       "version": "20.2.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
-    },
-    "node_modules/@types/yup": {
-      "version": "0.29.11",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.29.11.tgz",
-      "integrity": "sha512-9cwk3c87qQKZrT251EDoibiYRILjCmxBvvcb4meofCmx1vdnNcR9gyildy5vOHASpOKMsn42CugxUvcwK5eu1g=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.51.0",
@@ -12551,11 +12545,6 @@
       "version": "20.2.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
-    },
-    "@types/yup": {
-      "version": "0.29.11",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.29.11.tgz",
-      "integrity": "sha512-9cwk3c87qQKZrT251EDoibiYRILjCmxBvvcb4meofCmx1vdnNcR9gyildy5vOHASpOKMsn42CugxUvcwK5eu1g=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.51.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -46,7 +46,6 @@
     "@types/react": "^16.9.56",
     "@types/react-datepicker": "^3.1.1",
     "@types/react-dom": "^16.9.9",
-    "@types/yup": "^0.29.9",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.52.0",
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
#### Summary of changes

Removes the types package, which is no longer needed since `yup` started shipping its own types a while back.