### PR TITLE
Remove hidden switch text and add handler for Chelsea Bridge Channel

### DIFF
--- a/assets/css/toggle_switch.css
+++ b/assets/css/toggle_switch.css
@@ -1,5 +1,6 @@
 .toggle_switch--container {
   margin-left: 8px;
+  top: 7px;
   position: relative;
   display: inline-block;
 }

--- a/assets/js/Line.tsx
+++ b/assets/js/Line.tsx
@@ -280,7 +280,7 @@ function Line({
                   );
                 }}
               />
-              <span className="toggle_switch--label">Switch</span>
+              <span className="toggle_switch--label" />
             </div>
           )}
         </label>

--- a/assets/js/ViewerApp.tsx
+++ b/assets/js/ViewerApp.tsx
@@ -133,6 +133,16 @@ class ViewerApp extends React.Component<
       this.setState({ signGroups: signGroupState });
     });
 
+    chelseaBridgeAnnouncementsChannel.on(
+      'new_chelsea_bridge_announcements_state',
+      (chelseaBridgeAnnouncementState) => {
+        this.setState({
+          chelseaBridgeAnnouncements:
+            chelseaBridgeAnnouncementState.chelsea_bridge_announcements,
+        });
+      },
+    );
+
     signsChannel.on('auth_expired', () => {
       window.location.reload();
     });


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞: "Switch" label hidden on Silver Line page next to Chelsea Bridge toggle](https://app.asana.com/0/1201753694073608/1204060644183788/f)

This PR removes some text that was hidden next to the Chelsea Bridge Toggle. The span still needs to be there because I believe the toggle's animation is sort of anchored on it. I didn't read too in depth, but it seems a bit like the original author of the code may have followed this tutorial or something similar: https://www.sitepoint.com/react-toggle-switch-reusable-component/

While testing the change, I realized that the frontend lacked a handler for the Chelsea Bridge Announcements phoenix channel. This means that realtime updates weren't happening on other open browsers when a user toggles the chelsea bridge announcements on. Instead, they would have to refresh the page to pick up the change to the UI. This behavior can be seen/tested currently in dev. Since the issue seemed closely enough related to the original bug for this task, I went ahead and bundled it in the PR.
