### PR TITLE
default to auto when no config

### DIFF
--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -220,7 +220,9 @@ function SignPanel({
                 value={signConfig.mode}
                 onChange={handleModeSelect}
               >
-                {modes.auto && <option value="auto">Auto</option>}
+                {(modes.auto || signConfig.mode === 'auto') && (
+                  <option value="auto">Auto</option>
+                )}
                 {modes.headway && <option value="headway">Headways</option>}
                 {modes.custom && <option value="static_text">Custom</option>}
                 {modes.off && <option value="off">Off</option>}

--- a/assets/js/Station.tsx
+++ b/assets/js/Station.tsx
@@ -10,7 +10,7 @@ import {
   StationConfig,
   Zone,
 } from './types';
-import { defaultZoneLabel, arincToRealtimeId } from './helpers';
+import { defaultZoneLabel, arincToRealtimeId, getSignConfig } from './helpers';
 
 /* eslint-disable camelcase */
 
@@ -62,7 +62,7 @@ function makeSign(
     const key = `${config.id}-${zone}`;
     const signContent = signs[key] || { sign_id: key, lines: {} };
     const realtimeId = arincToRealtimeId(key);
-    const signConfig = signConfigs[realtimeId] || { mode: 'off' };
+    const signConfig = getSignConfig(signConfigs, config.id, zone);
     const signGroupKey = signsToGroups[realtimeId];
     const signGroup = signGroupKey ? signGroups[signGroupKey] : undefined;
     const ungroupMe = signGroupKey ? () => ungroupSign(realtimeId) : undefined;

--- a/assets/js/helpers.ts
+++ b/assets/js/helpers.ts
@@ -1,4 +1,4 @@
-import { RouteAlerts, Alerts, Zone } from './types';
+import { RouteAlerts, Alerts, Zone, SignConfigs } from './types';
 
 function choosePage(
   pages: { content: string; duration: number }[],
@@ -108,10 +108,21 @@ function arincToRealtimeId(stationZone: string): string {
   return window.arincToRealtimeIdMap[stationZone];
 }
 
+function getSignConfig(
+  signConfigs: SignConfigs,
+  stationId: string,
+  zone: string,
+) {
+  return (
+    signConfigs[arincToRealtimeId(`${stationId}-${zone}`)] || { mode: 'auto' }
+  );
+}
+
 export {
   choosePage,
   alertsForLine,
   formatTime,
   defaultZoneLabel,
   arincToRealtimeId,
+  getSignConfig,
 };

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -205,10 +205,7 @@ test('Does not show "Mixed" batch mode buttons when one mode is chosen', () => {
 
   const currentTime = now + 2000;
   const line = 'Red';
-  const signConfigs: SignConfigs = {
-    red_south_station_northbound: { expires: null, mode: 'headway' },
-    central_southbound: { expires: null, mode: 'headway' },
-  };
+  const signConfigs: SignConfigs = {}; // default all to auto
   const setConfigs = () => true;
   const readOnly = false;
   const configuredHeadways = {};
@@ -299,7 +296,7 @@ test('Batch mode buttons clear sign groups, too', async () => {
         currentTime: Date.now() + 2000,
         line: 'Red',
         signConfigs: {
-          alewife_center_southbound: {
+          davis_northbound: {
             mode: 'off',
           },
         },
@@ -478,7 +475,10 @@ test('Sign config is not affected by batch updates if sign does not support mode
 
   const currentTime = now + 2000;
   const line = 'Red';
-  const signConfigs: SignConfigs = {};
+  const signConfigs: SignConfigs = {
+    davis_northbound: { mode: 'auto' },
+    davis_southbound: { mode: 'off', expires: null },
+  };
   const setConfigs = jest.fn(() => true);
   const setConfiguredHeadways = () => true;
   const readOnly = false;
@@ -706,7 +706,6 @@ test('does not show chelsea bridge toggle if in read-only mode', () => {
   expect(
     screen.getByText('Chelsea Drawbridge Announcements:'),
   ).toBeInTheDocument();
-  expect(screen.getByText('Auto')).toBeInTheDocument();
   expect(
     screen.queryByLabelText('Chelsea Drawbridge Announcements'),
   ).toBeNull();

--- a/assets/test/SignPanel.test.ts
+++ b/assets/test/SignPanel.test.ts
@@ -288,105 +288,57 @@ test('does show select when not in read-only mode', () => {
 });
 
 test.each([
-  [
-    { auto: true },
-    {
-      auto: true,
-      static_text: false,
-      headway: false,
-      off: false,
-    },
-  ],
-  [
-    { auto: true, headway: true },
-    {
-      auto: true,
-      static_text: false,
-      headway: true,
-      off: false,
-    },
-  ],
-  [
-    { custom: true },
-    {
-      auto: false,
-      static_text: true,
-      headway: false,
-      off: false,
-    },
-  ],
-  [
-    { off: true },
-    {
-      auto: false,
-      static_text: false,
-      headway: false,
-      off: true,
-    },
-  ],
-])(
-  'shows configured mode select options',
-  (
-    modesOverride,
-    expected: {
-      auto: boolean;
-      static_text: boolean;
-      headway: boolean;
-      off: boolean;
-    },
-  ) => {
-    const now = new Date('2019-01-15T20:15:00Z').valueOf();
-    const fresh = new Date(now + 5000).toLocaleString();
-    const currentTime = now + 2000;
-    const signId = 'RDAV-n';
-    const line = 'Red';
-    const signConfig: SignConfig = { mode: 'auto' };
-    const signContent = signContentWithExpirations(fresh, fresh);
-    const setConfig = () => true;
-    const realtimeId = 'id';
-    const readOnly = false;
-    const modes: ZoneConfig['modes'] = {
-      auto: false,
-      headway: false,
-      custom: false,
-      off: false,
-      ...modesOverride,
-    };
+  ['auto', { auto: true }, ['auto']],
+  ['auto', { auto: true, headway: true }, ['auto', 'headway']],
+  ['static_text', { custom: true }, ['static_text']],
+  ['off', { off: true }, ['off']],
+  ['auto', { off: true }, ['auto', 'off']],
+])('shows configured mode select options', (mode, modesOverride, expected) => {
+  const now = new Date('2019-01-15T20:15:00Z').valueOf();
+  const fresh = new Date(now + 5000).toLocaleString();
+  const currentTime = now + 2000;
+  const signId = 'RDAV-n';
+  const line = 'Red';
+  const signConfig: SignConfig = { mode: mode as SignConfig['mode'] };
+  const signContent = signContentWithExpirations(fresh, fresh);
+  const setConfig = () => true;
+  const realtimeId = 'id';
+  const readOnly = false;
+  const modes: ZoneConfig['modes'] = {
+    auto: false,
+    headway: false,
+    custom: false,
+    off: false,
+    ...modesOverride,
+  };
 
-    render(
-      React.createElement(
-        SignPanel,
-        {
-          alerts: {},
-          signId,
-          signContent,
-          currentTime,
-          line,
-          signConfig,
-          setConfig,
-          realtimeId,
-          readOnly,
-          modes,
-        },
-        null,
-      ),
-    );
+  render(
+    React.createElement(
+      SignPanel,
+      {
+        alerts: {},
+        signId,
+        signContent,
+        currentTime,
+        line,
+        signConfig,
+        setConfig,
+        realtimeId,
+        readOnly,
+        modes,
+      },
+      null,
+    ),
+  );
 
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  expect(screen.getByRole('combobox')).toBeInTheDocument();
 
-    const options = screen
-      .getAllByRole('option')
-      .map((option) => option.getAttribute('value'));
+  const options = screen
+    .getAllByRole('option')
+    .map((option) => option.getAttribute('value'));
 
-    (Object.keys(expected) as Array<SignModeOptions>).forEach((mode) => {
-      if (expected[mode] && expected[mode] === true) {
-        expect(options.includes(mode)).toBeTruthy();
-      } else {
-        expect(options.includes(mode)).toBeFalsy();
-      }
-    });
-  },
-);
+  expect(options).toEqual(expected);
+});
 
 test('can enable/disable a sign', async () => {
   const user = userEvent.setup();


### PR DESCRIPTION
#### Summary of changes

This changes the default mode from 'off' to 'auto', if there is no explicit configuration for a sign, in order to match the behavior of realtime_signs. Practically, this only affects local development, since the deployed environments already have fully-populated configuration files, but it's still good for consistency.