### PR TITLE
break out line content in logs

### DIFF
--- a/lib/signs_ui_web/channels/sign_groups_channel.ex
+++ b/lib/signs_ui_web/channels/sign_groups_channel.ex
@@ -14,7 +14,17 @@ defmodule SignsUiWeb.SignGroupsChannel do
   @impl Phoenix.Channel
   def handle_in("changeSignGroups", %{"data" => changes}, socket) do
     with_admin_access(socket, fn ->
-      Logger.info(["changeSignGroups: ", inspect(changes), ", from: ", inspect(socket)])
+      entry = Map.values(changes) |> List.first(%{})
+
+      Utilities.Common.log(
+        "sign_groups_changed",
+        user: Guardian.Phoenix.Socket.current_resource(socket),
+        sign_ids: entry["sign_ids"] && inspect(entry["sign_ids"]),
+        line1: entry["line1"] && inspect(entry["line1"]),
+        line2: entry["line2"] && inspect(entry["line2"]),
+        expires: entry["expires"],
+        changes: inspect(changes)
+      )
 
       {:ok, _} =
         changes

--- a/lib/utilities/common.ex
+++ b/lib/utilities/common.ex
@@ -1,6 +1,8 @@
 defmodule Utilities.Common do
   @moduledoc false
 
+  require Logger
+
   def parse_station_and_zones(station_and_zones) do
     {station, zone_map} = String.split_at(station_and_zones, -6)
 
@@ -16,4 +18,11 @@ defmodule Utilities.Common do
   def parse_av_type("0"), do: :audio_visual
   def parse_av_type("1"), do: :audio
   def parse_av_type("2"), do: :visual
+
+  def log(token, extras) do
+    fields =
+      Enum.filter(extras, fn {_, v} -> v end) |> Enum.map_join(" ", fn {k, v} -> "#{k}=#{v}" end)
+
+    Logger.info("#{token}: #{fields}")
+  end
 end

--- a/test/signs_ui_web/channels/sign_groups_channel_test.exs
+++ b/test/signs_ui_web/channels/sign_groups_channel_test.exs
@@ -36,7 +36,7 @@ defmodule SignsUiWeb.SignGroupsChannelTest do
                    SignsUiWeb.SignGroupsChannel.handle_in("changeSignGroups", changes, socket)
         end)
 
-      assert log =~ "changeSignGroups"
+      assert log =~ "sign_groups_changed"
       assert log =~ "foo@mbta.com"
 
       assert_broadcast(


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Signs UI Splunk alert emails are human readable for quick scanning](https://app.asana.com/0/1201753694073608/1204643930705428/f)

This modifies the logging of `sign_changed` and `changeSignGroups` to allow easier parsing and displaying in splunk and downstream tools.
* Breaks out sign ids, line content, mode, and expiration into top-level fields when present.
* Renames `changeSignGroups` to `sign_groups_changed`, along with a substantial overhaul to the format for that log.