### PR TITLE
disable/remove ungrouping buttons in read-only mode

### DIFF
--- a/assets/js/SignGroupItem.tsx
+++ b/assets/js/SignGroupItem.tsx
@@ -39,6 +39,7 @@ export default function SignGroupItem({
           Edit
         </button>
         <button
+          disabled={readOnly}
           onClick={() => setSignGroups(line, { [groupKey]: {} })}
           type="button"
           className="btn btn-primary"

--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -331,16 +331,18 @@ function SignPanel({
                 <SignGroupExpirationDetails group={signGroup} />
               </div>
 
-              <div>
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={() => setConfirmingUngroup(true)}
-                  disabled={confirmingUngroup}
-                >
-                  Ungroup
-                </button>
-              </div>
+              {!readOnly && (
+                <div>
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={() => setConfirmingUngroup(true)}
+                    disabled={confirmingUngroup}
+                  >
+                    Ungroup
+                  </button>
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix "Ungroup" button present on view/read-only mode](https://app.asana.com/0/1201753694073608/1205077966832802/f)

This removes access to the "Ungroup" and "Return to auto" buttons when in read-only mode. Note that I followed the rough pattern of removing the button entirely on the main page, and just disabling it within the dropdown form.