### PR TITLE
Add new headway groups for both GLX branches

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -57,6 +57,14 @@ const branchConfig: { [key: string]: { id: string; name: string }[] } = {
       id: 'green_e',
       name: 'Green - E',
     },
+    {
+      id: 'glx_union',
+      name: 'GLX - Union',
+    },
+    {
+      id: 'glx_medford',
+      name: 'GLX - Medford',
+    },
   ],
   Mattapan: [
     {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Expand Signs UI bulk headway section to separate E branch from GLX](https://app.asana.com/0/1201753694073608/1205175176761938/f)

After this is deployed to prod, the headway config won't actually exist in the file in S3 until someone writes the value through Signs UI. We should ask OIOs to do this in prod before we deploy the subsequent RTS changes to avoid any chance for headway mode on GLX signs to break.