### PR TITLE
Allow Screenplay dev-green to render countdown clocks

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,7 +9,7 @@ end
 screenplay_base_url =
   if System.get_env("ENVIRONMENT_NAME") == "prod",
     do: "https://screenplay.mbta.com/",
-    else: "localhost:4000/ https://screenplay-dev.mbtace.com/"
+    else: "localhost:4000/ https://screenplay-dev.mbtace.com/ https://screenplay-dev-green.mbtace.com"
 
 config :signs_ui, SignsUiWeb.Endpoint,
     screenplay_base_url: screenplay_base_url

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,7 +9,7 @@ end
 screenplay_base_url =
   if System.get_env("ENVIRONMENT_NAME") == "prod",
     do: "https://screenplay.mbta.com/",
-    else: "localhost:4000/ https://screenplay-dev.mbtace.com/ https://screenplay-dev-green.mbtace.com"
+    else: "localhost:4000/ https://screenplay-dev.mbtace.com/ https://screenplay-dev-green.mbtace.com/"
 
 config :signs_ui, SignsUiWeb.Endpoint,
     screenplay_base_url: screenplay_base_url


### PR DESCRIPTION
#### Summary of changes
Ad-hoc

Screenplay dev-green currently won't render countdown clocks in iframes because it's not an allowed frame ancestor
