### PR TITLE
Move "deploy to ECS" workflow file and change input type to choice

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        type: environment
+        type: choice
         required: true
         default: dev
         options:


### PR DESCRIPTION
#### Summary of changes
I accidentally added the generalized "deploy to ECS" workflow to the top level of `/.github` and not to `/.github/workflows`. This PR moves the file to where it should have been added.

When I did this, an error appeared from the GH Actions extension saying that the `type: environment` was invalid. This seemed to check out based on the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype)