### PR TITLE
Enable auto mode for Union Sq Signs

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2180,7 +2180,7 @@ const stationConfig: {
           e: {
             label: 'Track 1',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               headway: true,
               off: true,
@@ -2189,7 +2189,7 @@ const stationConfig: {
           w: {
             label: 'Track 2',
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               headway: true,
               off: true,
@@ -2197,7 +2197,7 @@ const stationConfig: {
           },
           m: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               headway: true,
               off: true,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add stop IDs for new GL terminal predictions](https://app.asana.com/0/1185117109217413/1205396140780846/f)

Related to the task linked above. The Union Sq sign zones don't have auto mode enabled (an artifact of when we initially added these zones to Signs UI for GLX opening). Now that GL terminal predictions at Union Sq are coming soon, theses signs will soon need to be set to auto mode in order to display the predictions.
