### PR TITLE
write per-stop prediction flagging data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log
 /config/*.secret.exs
 test/mock_write.json
 /priv/config.json
+/priv/stops-config.json
 
 # local direnv configuration
 /.envrc

--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -40,6 +40,7 @@ defmodule SignsUi.Application do
   defp set_runtime_config do
     Config.update_env(:aws_signs_bucket, System.get_env("AWS_SIGNS_BUCKET"))
     Config.update_env(:aws_signs_path, System.get_env("AWS_SIGNS_PATH"))
+    Config.update_env(:aws_signs_stops_path, System.get_env("AWS_SIGNS_STOPS_PATH"))
     Config.update_env(:messages_api_keys, System.get_env("MESSAGES_API_KEYS"))
     Config.update_env(:sentry, :dsn, System.get_env("SENTRY_DSN"))
     Config.update_env(:sentry, :environment_name, System.get_env("SENTRY_ENV"))

--- a/lib/signs_ui/config/local.ex
+++ b/lib/signs_ui/config/local.ex
@@ -7,6 +7,11 @@ defmodule SignsUi.Config.Local do
   end
 
   # sobelow_skip ["Traversal"]
+  def write_stops(content) do
+    :code.priv_dir(:signs_ui) |> Path.join("stops-config.json") |> File.write!(content)
+  end
+
+  # sobelow_skip ["Traversal"]
   def read do
     case File.read(path()) do
       {:ok, content} -> content

--- a/lib/signs_ui/config/s3.ex
+++ b/lib/signs_ui/config/s3.ex
@@ -7,6 +7,11 @@ defmodule SignsUi.Config.S3 do
     {:ok, _} = ExAws.S3.put_object(bucket_name(), path_name(), content) |> ExAws.request()
   end
 
+  def write_stops(content) do
+    path = Application.get_env(:signs_ui, :aws_signs_stops_path)
+    {:ok, _} = ExAws.S3.put_object(bucket_name(), path, content) |> ExAws.request()
+  end
+
   def read do
     {:ok, %{body: content}} = ExAws.S3.get_object(bucket_name(), path_name()) |> ExAws.request()
     content

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -15,7 +15,8 @@ defmodule SignsUi.Config.State do
           signs: %{Config.Sign.id() => Config.Sign.t()},
           configured_headways: ConfiguredHeadways.t(),
           chelsea_bridge_announcements: String.t(),
-          sign_groups: SignGroups.t()
+          sign_groups: SignGroups.t(),
+          sign_stops: map()
         }
 
   def start_link(opts \\ []) do
@@ -86,7 +87,8 @@ defmodule SignsUi.Config.State do
         |> Map.get("configured_headways", %{})
         |> ConfiguredHeadways.parse_configured_headways_json(),
       chelsea_bridge_announcements: Map.get(response, "chelsea_bridge_announcements", "off"),
-      sign_groups: response |> Map.get("sign_groups", %{}) |> SignGroups.from_json()
+      sign_groups: response |> Map.get("sign_groups", %{}) |> SignGroups.from_json(),
+      sign_stops: parse_signs_json()
     }
 
     {:ok, state}
@@ -194,7 +196,8 @@ defmodule SignsUi.Config.State do
          signs: signs,
          configured_headways: configured_headways,
          chelsea_bridge_announcements: chelsea_bridge_announcements,
-         sign_groups: sign_groups
+         sign_groups: sign_groups,
+         sign_stops: sign_stops
        }) do
     config_store = Application.get_env(:signs_ui, :config_store)
 
@@ -209,6 +212,50 @@ defmodule SignsUi.Config.State do
       pretty: true
     )
     |> config_store.write()
+
+    for {%{stop_id: stop_id, route_id: route_id, direction_id: direction_id}, ids} <- sign_stops do
+      %{
+        stop_id: stop_id,
+        route_id: route_id,
+        direction_id: direction_id,
+        predictions:
+          if Enum.any?(ids, fn id ->
+               case signs[id] do
+                 nil -> false
+                 sign -> sign.config.mode == :headway
+               end
+             end) do
+            "flagged"
+          else
+            "normal"
+          end
+      }
+    end
+    |> then(&%{"stops" => &1})
+    |> Jason.encode!(pretty: true)
+    |> config_store.write_stops()
+  end
+
+  # sobelow_skip ["Traversal"]
+  defp parse_signs_json() do
+    signs_json =
+      :code.priv_dir(:signs_ui)
+      |> Path.join("signs.json")
+      |> File.read!()
+      |> Jason.decode!(keys: :atoms)
+
+    for %{id: id, source_config: %{sources: sources}} <- signs_json,
+        %{stop_id: stop_id, routes: routes, direction_id: direction_id} <- sources,
+        route_id <- routes,
+        reduce: %{} do
+      acc ->
+        Map.update(
+          acc,
+          %{stop_id: stop_id, route_id: route_id, direction_id: direction_id},
+          [id],
+          &[id | &1]
+        )
+    end
   end
 
   defp schedule_clean(pid, ms) do

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -237,7 +237,7 @@ defmodule SignsUi.Config.State do
   end
 
   # sobelow_skip ["Traversal"]
-  defp parse_signs_json() do
+  defp parse_signs_json do
     signs_json =
       :code.priv_dir(:signs_ui)
       |> Path.join("signs.json")

--- a/lib/signs_ui/mock/config_store.ex
+++ b/lib/signs_ui/mock/config_store.ex
@@ -4,6 +4,8 @@ defmodule SignsUi.Mock.ConfigStore do
   def write(_) do
   end
 
+  def write_stops(_), do: nil
+
   def read do
     %{
       "signs" => %{

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1,0 +1,9774 @@
+[
+  {
+    "id": "cedar_grove_outbound",
+    "type": "realtime",
+    "pa_ess_loc": "MCED",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
+        {
+          "stop_id": "70263",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "cedar_grove_inbound",
+    "type": "realtime",
+    "pa_ess_loc": "MCED",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70264",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "butler_center",
+    "type": "realtime",
+    "pa_ess_loc": "MBUT",
+    "read_loop_offset": 150,
+    "text_zone": "c",
+    "audio_zones": [
+      "c"
+    ],
+    "source_config": [
+      {
+        "headway_group": "mattapan_trunk",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70266",
+            "routes": [
+              "Mattapan"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "mattapan_trunk",
+        "headway_direction_name": "Mattapan",
+        "sources": [
+          {
+            "stop_id": "70265",
+            "routes": [
+              "Mattapan"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "milton_outbound",
+    "type": "realtime",
+    "pa_ess_loc": "MMIL",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
+        {
+          "stop_id": "70267",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "milton_inbound",
+    "type": "realtime",
+    "pa_ess_loc": "MMIL",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70268",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "central_avenue_outbound",
+    "type": "realtime",
+    "pa_ess_loc": "MCEN",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
+        {
+          "stop_id": "70269",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "central_avenue_inbound",
+    "type": "realtime",
+    "pa_ess_loc": "MCEN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70270",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "valley_road_outbound",
+    "type": "realtime",
+    "pa_ess_loc": "MVAL",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
+        {
+          "stop_id": "70271",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "valley_road_inbound",
+    "type": "realtime",
+    "pa_ess_loc": "MVAL",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70272",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "capen_street_inbound",
+    "type": "realtime",
+    "pa_ess_loc": "MCAP",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70274",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "wonderland_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BWON",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70059",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "wonderland_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BWON",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70059",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "revere_beach_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BREV",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70058",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "revere_beach_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BREV",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70058",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70057",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "revere_beach_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BREV",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70057",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "beachmont_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BBEA",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70056",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "beachmont_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BBEA",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70055",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "suffolk_downs_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BSUF",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70054",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "suffolk_downs_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BSUF",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70053",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orient_heights_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BORH",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70052",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orient_heights_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BORH",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70052",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70051",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "orient_heights_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BORH",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70051",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "wood_island_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BWOO",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70050",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "wood_island_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BWOO",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70050",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70049",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "wood_island_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BWOO",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70049",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "airport_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BAIR",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70048",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "airport_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BAIR",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70047",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "maverick_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BMAV",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70046",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "maverick_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BMAV",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70045",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "aquarium_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BAQU",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70044",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "aquarium_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BAQU",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70044",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70043",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "aquarium_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BAQU",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70043",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "state_blue_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BSTA",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70042",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "state_blue_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BSTA",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70042",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70041",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "state_blue_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BSTA",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70041",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "government_center_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BGOV",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70040",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "government_center_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BGOV",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70040",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70039",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "government_center_westbound",
+    "type": "realtime",
+    "pa_ess_loc": "BGOV",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
+        {
+          "stop_id": "70039",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "bowdoin_eastbound",
+    "type": "realtime",
+    "pa_ess_loc": "BBOW",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70038",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "bowdoin_drop_off",
+    "type": "realtime",
+    "pa_ess_loc": "BBOW",
+    "read_loop_offset": 60,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70038",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "bowdoin_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "BBOW",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70038",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "oak_grove_mezzanine_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OOAK",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70036",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Oak Grove-01",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Oak Grove-02",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "oak_grove_east_busway",
+    "type": "realtime",
+    "pa_ess_loc": "OOAK",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70036",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Oak Grove-01",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Oak Grove-02",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "oak_grove_platform",
+    "type": "realtime",
+    "pa_ess_loc": "OOAK",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70036",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Oak Grove-01",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Oak Grove-02",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "malden_lobby",
+    "type": "realtime",
+    "pa_ess_loc": "OMAL",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70035",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70034",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "malden_center_platform",
+    "type": "realtime",
+    "pa_ess_loc": "OMAL",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70035",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70034",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "wellington_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OWEL",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70033",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70032",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "wellington_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OWEL",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70033",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "wellington_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OWEL",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70032",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70032",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "assembly_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OASQ",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70279",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70278",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "assembly_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OASQ",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70279",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "assembly_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OASQ",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70278",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "sullivan_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OSUL",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70031",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70030",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "sullivan_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OSUL",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70031",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "sullivan_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OSUL",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70030",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "community_college_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OCOM",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70029",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70028",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "community_college_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OCOM",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70029",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "community_college_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OCOM",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70028",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_north_station_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "ONST",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70027",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_north_station_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "ONST",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70026",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_north_station_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "ONST",
+    "read_loop_offset": 150,
+    "text_zone": "c",
+    "audio_zones": [
+      "c"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70027",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70026",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "orange_north_station_commuter_rail_exit",
+    "type": "realtime",
+    "pa_ess_loc": "ONST",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70027",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70026",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "orange_haymarket_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OHAY",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70025",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70024",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "orange_haymarket_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OHAY",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70025",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_haymarket_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OHAY",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70024",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_state_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OSTN",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70023",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70022",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "orange_state_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OSTN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70023",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_state_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OSTS",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70022",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_downtown_crossing_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "ODTN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70021",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "orange_downtown_crossing_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "ODTS",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70020",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "chinatown_northbound_lobby",
+    "type": "realtime",
+    "pa_ess_loc": "OCHN",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70019",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "chinatown_southbound_lobby",
+    "type": "realtime",
+    "pa_ess_loc": "OCHS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70018",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "chinatown_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OCHN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70019",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "chinatown_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OCHS",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70018",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "tufts_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "ONEM",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70017",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70016",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "tufts_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "ONEM",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70017",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "tufts_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "ONEM",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70016",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "back_bay_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OBAC",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70015",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70014",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "back_bay_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OBAC",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70015",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "back_bay_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OBAC",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70014",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "mass_ave_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OMAS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70013",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70012",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "mass_ave_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OMAS",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70013",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "mass_ave_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OMAS",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70012",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "ruggles_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "ORUG",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70011",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "ruggles_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "ORUG",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70010",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "ruggles_center",
+    "type": "realtime",
+    "pa_ess_loc": "ORUG",
+    "read_loop_offset": 150,
+    "text_zone": "c",
+    "audio_zones": [
+      "c"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70011",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70010",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ruggles_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "ORUG",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70011",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70010",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "roxbury_crossing_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OROX",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70009",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70008",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "roxbury_crossing_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OROX",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70009",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "roxbury_crossing_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OROX",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70008",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "jackson_square_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OJAC",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70007",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70006",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "jackson_square_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OJAC",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70007",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "jackson_square_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OJAC",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70006",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "stony_brook_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OSTO",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70005",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70004",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "stony_brook_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OSTO",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70005",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "stony_brook_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OSTO",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70004",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_street_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "OGRE",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70003",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70002",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "green_street_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "OGRE",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70003",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_street_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "OGRE",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
+        {
+          "stop_id": "70002",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "forest_hills_main_lobby",
+    "type": "realtime",
+    "pa_ess_loc": "OFOR",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70001",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Forest Hills-01",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Forest Hills-02",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "forest_hills_platform",
+    "type": "realtime",
+    "pa_ess_loc": "OFOR",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70001",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Forest Hills-01",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Forest Hills-02",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "forest_hills_entrances_from_busways",
+    "type": "realtime",
+    "pa_ess_loc": "SFOR",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
+        {
+          "stop_id": "70001",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Forest Hills-01",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Forest Hills-02",
+          "routes": [
+            "Orange"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "ruggles_upper_busway",
+    "type": "realtime",
+    "pa_ess_loc": "SRUG",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70011",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70010",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "alewife_center_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RALE",
+    "read_loop_offset": 150,
+    "text_zone": "c",
+    "audio_zones": [
+      "c"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70061",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Alewife-01",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Alewife-02",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "alewife_mezzanine_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RALE",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70061",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Alewife-01",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Alewife-02",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "davis_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RDAV",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70064",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70063",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "davis_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RDAV",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70064",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "davis_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RDAV",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70063",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "porter_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RPOR",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70066",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70065",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "porter_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RPOR",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70066",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "porter_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RPOR",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70065",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "harvard_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RHAR",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70068",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70067",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "harvard_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RHAR",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70068",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "harvard_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RHAR",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70067",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "central_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RCEN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70070",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "central_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RCEN",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70069",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kendall_mit_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RKEN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70072",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kendall_mit_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RKEN",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70071",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "charles_mgh_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RMGH",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70074",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "charles_mgh_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RMGH",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70073",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_park_st_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RPRK",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n",
+      "c"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70076",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_park_st_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RPRK",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s",
+      "c"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70075",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_park_st_center",
+    "type": "realtime",
+    "pa_ess_loc": "RPRK",
+    "read_loop_offset": 150,
+    "text_zone": "c",
+    "audio_zones": [],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70076",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70075",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "red_downtown_crossing_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RDTC",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70078",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_downtown_crossing_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RDTC",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70077",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_south_station_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RSOU",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70080",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70079",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "red_south_station_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RSOU",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70080",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_south_station_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RSOU",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70079",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "south_station_silver_line_arrival_platform",
+    "type": "realtime",
+    "pa_ess_loc": "SSOU",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70080",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70079",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "broadway_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RBRO",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70082",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70081",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "broadway_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RBRO",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70082",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "broadway_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RBRO",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70081",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "andrew_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RAND",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70084",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70083",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "andrew_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RAND",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70084",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "andrew_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RAND",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
+        {
+          "stop_id": "70083",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "savin_hill_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RSAV",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70088",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70087",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "savin_hill_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RSAV",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70088",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "savin_hill_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RSAV",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70087",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "fields_corner_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RFIE",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70090",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70089",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fields_corner_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RFIE",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70090",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "fields_corner_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RFIE",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70089",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "shawmut_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RSHA",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70092",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70091",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "shawmut_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RSHA",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70092",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "shawmut_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RSHA",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70091",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "ashmont_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RASH",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70094",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": true,
+            "announce_arriving": false,
+            "announce_boarding": true
+          }
+        ]
+      },
+      {
+        "headway_group": "mattapan_trunk",
+        "headway_direction_name": "Mattapan",
+        "sources": [
+          {
+            "stop_id": "70261",
+            "routes": [
+              "Mattapan"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": true,
+            "announce_arriving": true,
+            "announce_boarding": true
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "red_ashmont_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RASH",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70094",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "red_ashmont_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RASH",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
+        {
+          "stop_id": "70261",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": true,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "north_quincy_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RNQU",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70098",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70097",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "north_quincy_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RNQU",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70098",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "north_quincy_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RNQU",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
+        {
+          "stop_id": "70097",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "wollaston_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RWOL",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70100",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70099",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "wollaston_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RWOL",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70100",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "wollaston_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RWOL",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
+        {
+          "stop_id": "70099",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "quincy_center_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RQUC",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70102",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70101",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "quincy_center_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RQUC",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70102",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "quincy_center_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RQUC",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
+        {
+          "stop_id": "70101",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "quincy_adams_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RQUA",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70104",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70103",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "quincy_adams_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RQUA",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70104",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "quincy_adams_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RQUA",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
+        {
+          "stop_id": "70103",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "braintree_center_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RBRA",
+    "read_loop_offset": 150,
+    "text_zone": "c",
+    "audio_zones": [
+      "c"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70105",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Braintree-01",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Braintree-02",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "braintree_mezzanine_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RBRA",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70105",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Braintree-01",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Braintree-02",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "jfk_umass_ashmont_platform_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RJFK",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
+        {
+          "stop_id": "70085",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "jfk_umass_braintree_platform_southbound",
+    "type": "realtime",
+    "pa_ess_loc": "RJFK",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
+        {
+          "stop_id": "70095",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "jfk_umass_ashmont_platform_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RJFK",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70086",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": "ashmont",
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "jfk_umass_braintree_platform_northbound",
+    "type": "realtime",
+    "pa_ess_loc": "RJFK",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
+        {
+          "stop_id": "70096",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "platform": "braintree",
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "jfk_umass_mezzanine",
+    "type": "realtime",
+    "pa_ess_loc": "RJFK",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70085",
+            "direction_id": 0,
+            "routes": [
+              "Red"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "70095",
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "routes": [
+              "Red"
+            ],
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70086",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": "ashmont",
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "70096",
+            "direction_id": 1,
+            "routes": [
+              "Red"
+            ],
+            "platform": "braintree",
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "riverside_entire_station",
+    "pa_ess_loc": "GRIV",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70160",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "woodland_eastbound",
+    "pa_ess_loc": "GWOO",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70162",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "woodland_westbound",
+    "pa_ess_loc": "GWOO",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70163",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "waban_eastbound",
+    "pa_ess_loc": "GWAB",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70164",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "waban_westbound",
+    "pa_ess_loc": "GWAB",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70165",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "eliot_eastbound",
+    "pa_ess_loc": "GELI",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70166",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "eliot_westbound",
+    "pa_ess_loc": "GELI",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70167",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "newton_highlands_eastbound",
+    "pa_ess_loc": "GNEH",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70168",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "newton_highlands_westbound",
+    "pa_ess_loc": "GNEH",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70169",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "newton_centre_eastbound",
+    "pa_ess_loc": "GNEC",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70170",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "newton_centre_westbound",
+    "pa_ess_loc": "GNEC",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70171",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "chestnut_hill_eastbound",
+    "pa_ess_loc": "GCHE",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70172",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "chestnut_hill_westbound",
+    "pa_ess_loc": "GCHE",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70173",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "reservoir_eastbound",
+    "pa_ess_loc": "GRES",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70174",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "reservoir_westbound",
+    "pa_ess_loc": "GRES",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70175",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "beaconsfield_eastbound",
+    "pa_ess_loc": "GBEA",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "uses_shuttles": false,
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70176",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "beaconsfield_westbound",
+    "pa_ess_loc": "GBEA",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "uses_shuttles": false,
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70177",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "brookline_hills_eastbound",
+    "pa_ess_loc": "GBRH",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70178",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "brookline_hills_westbound",
+    "pa_ess_loc": "GBRH",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70179",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "brookline_village_eastbound",
+    "pa_ess_loc": "GBRV",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70180",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "brookline_village_westbound",
+    "pa_ess_loc": "GBRV",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70181",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "longwood_eastbound",
+    "pa_ess_loc": "GLON",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70182",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "longwood_westbound",
+    "pa_ess_loc": "GLON",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70183",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "fenway_eastbound",
+    "pa_ess_loc": "GFEN",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
+        {
+          "stop_id": "70186",
+          "direction_id": 1,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "fenway_westbound",
+    "pa_ess_loc": "GFEN",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70187",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "babcock_st_eastbound",
+    "pa_ess_loc": "GBAB",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Government Center",
+      "sources": [
+        {
+          "stop_id": "170136",
+          "direction_id": 1,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "babcock_st_westbound",
+    "pa_ess_loc": "GBAB",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Boston College",
+      "sources": [
+        {
+          "stop_id": "170137",
+          "direction_id": 0,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "amory_st_eastbound",
+    "pa_ess_loc": "GAMO",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Government Center",
+      "sources": [
+        {
+          "stop_id": "170140",
+          "direction_id": 1,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "amory_st_westbound",
+    "pa_ess_loc": "GAMO",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Boston College",
+      "sources": [
+        {
+          "stop_id": "170141",
+          "direction_id": 0,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kenmore_b_eastbound",
+    "pa_ess_loc": "GKEN",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "71150",
+          "direction_id": 1,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kenmore_b_westbound",
+    "pa_ess_loc": "GKEN",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Boston College",
+      "sources": [
+        {
+          "stop_id": "71151",
+          "direction_id": 0,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kenmore_c_d_eastbound",
+    "pa_ess_loc": "GKEN",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70150",
+          "direction_id": 1,
+          "routes": [
+            "Green-C",
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kenmore_c_d_westbound",
+    "pa_ess_loc": "GKEN",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70151",
+          "direction_id": 0,
+          "routes": [
+            "Green-C",
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "kenmore_mezzanine",
+    "pa_ess_loc": "GKEN",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70150",
+            "direction_id": 1,
+            "routes": [
+              "Green-C",
+              "Green-D"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "71150",
+            "direction_id": 1,
+            "routes": [
+              "Green-B"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70151",
+            "direction_id": 0,
+            "routes": [
+              "Green-C",
+              "Green-D"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "71151",
+            "direction_id": 0,
+            "routes": [
+              "Green-B"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "hynes_eastbound",
+    "pa_ess_loc": "GAUD",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70152",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "hynes_westbound",
+    "pa_ess_loc": "GAUD",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70153",
+          "direction_id": 0,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "hynes_mezzanine",
+    "pa_ess_loc": "GAUD",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70152",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70153",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "copley_eastbound",
+    "pa_ess_loc": "GCOP",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70154",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "copley_westbound",
+    "pa_ess_loc": "GCOP",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70155",
+          "direction_id": 0,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "arlington_eastbound",
+    "pa_ess_loc": "GARL",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70156",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "arlington_westbound",
+    "pa_ess_loc": "GARL",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70157",
+          "direction_id": 0,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "arlington_mezzanine",
+    "pa_ess_loc": "GARL",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70156",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70157",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "boylston_eastbound",
+    "pa_ess_loc": "GBOY",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70158",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "boylston_westbound",
+    "pa_ess_loc": "GBOY",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70159",
+          "direction_id": 0,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "symphony_eastbound",
+    "pa_ess_loc": "GSYM",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
+        {
+          "stop_id": "70242",
+          "direction_id": 1,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "symphony_westbound",
+    "pa_ess_loc": "GSYM",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70241",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "prudential_eastbound",
+    "pa_ess_loc": "GPRU",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
+        {
+          "stop_id": "70240",
+          "direction_id": 1,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "prudential_westbound",
+    "pa_ess_loc": "GPRU",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70239",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "prudential_mezzanine",
+    "pa_ess_loc": "GPRU",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70240",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70239",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "park_st_eastbound",
+    "pa_ess_loc": "GPRKE",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "71199",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70200",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "park_st_winter_st_concourse",
+    "pa_ess_loc": "GPRKE",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "71199",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70200",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "park_st_westbound_wall_track",
+    "pa_ess_loc": "GPRKW",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70198",
+          "direction_id": 0,
+          "platform": null,
+          "routes": [
+            "Green-D"
+          ],
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true,
+          "multi_berth": true
+        },
+        {
+          "stop_id": "70199",
+          "direction_id": 0,
+          "platform": null,
+          "routes": [
+            "Green-E"
+          ],
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true,
+          "multi_berth": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "park_st_westbound_fence_track",
+    "pa_ess_loc": "GPRKW",
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70196",
+          "direction_id": 0,
+          "routes": [
+            "Green-B"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true,
+          "multi_berth": true
+        },
+        {
+          "stop_id": "70197",
+          "direction_id": 0,
+          "routes": [
+            "Green-C"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true,
+          "multi_berth": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_government_center_eastbound",
+    "pa_ess_loc": "GGOV",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70201",
+          "direction_id": 1,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_government_center_westbound",
+    "pa_ess_loc": "GGOV",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70202",
+          "direction_id": 0,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_government_center_mezzanine",
+    "pa_ess_loc": "GGOV",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70201",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70202",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "green_haymarket_eastbound",
+    "pa_ess_loc": "GHAY",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
+        {
+          "stop_id": "70203",
+          "direction_id": 1,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_haymarket_westbound",
+    "pa_ess_loc": "GHAY",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
+        {
+          "stop_id": "70204",
+          "direction_id": 0,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_north_station_eastbound",
+    "pa_ess_loc": "GNST",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Outbound",
+      "sources": [
+        {
+          "stop_id": "70205",
+          "direction_id": 1,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_north_station_westbound",
+    "pa_ess_loc": "GNST",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Inbound",
+      "sources": [
+        {
+          "stop_id": "70206",
+          "direction_id": 0,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "green_north_station_commuter_rail_exit",
+    "pa_ess_loc": "GNST",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Outbound",
+        "sources": [
+          {
+            "stop_id": "70205",
+            "direction_id": 1,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": false,
+            "announce_boarding": true
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Inbound",
+        "sources": [
+          {
+            "stop_id": "70206",
+            "direction_id": 0,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": false,
+            "announce_boarding": true
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "science_park_eastbound",
+    "pa_ess_loc": "GSCI",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Outbound",
+      "sources": [
+        {
+          "stop_id": "70207",
+          "direction_id": 1,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "science_park_westbound",
+    "pa_ess_loc": "GSCI",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Inbound",
+      "sources": [
+        {
+          "stop_id": "70208",
+          "direction_id": 0,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "science_park_mezzanine",
+    "pa_ess_loc": "GSCI",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Outbound",
+        "sources": [
+          {
+            "stop_id": "70207",
+            "direction_id": 1,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Inbound",
+        "sources": [
+          {
+            "stop_id": "70208",
+            "direction_id": 0,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "lechmere_green_line_eastbound",
+    "pa_ess_loc": "GLEC",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Outbound",
+      "sources": [
+        {
+          "stop_id": "70501",
+          "direction_id": 1,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "lechmere_green_line_westbound",
+    "pa_ess_loc": "GLEC",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Inbound",
+      "sources": [
+        {
+          "stop_id": "70502",
+          "direction_id": 0,
+          "routes": [
+            "Green-D",
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "lechmere_green_line_mezzanine",
+    "pa_ess_loc": "GLEC",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Outbound",
+        "sources": [
+          {
+            "stop_id": "70501",
+            "direction_id": 1,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Inbound",
+        "sources": [
+          {
+            "stop_id": "70502",
+            "direction_id": 0,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "union_sq_track_one",
+    "pa_ess_loc": "GUNS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_union",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70504",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-01",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-02",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "union_sq_track_two",
+    "pa_ess_loc": "GUNS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_union",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70504",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-01",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-02",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "union_sq_mezzanine",
+    "pa_ess_loc": "GUNS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "e",
+      "w",
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_union",
+      "headway_direction_name": "Riverside",
+      "sources": [
+        {
+          "stop_id": "70504",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-01",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-02",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "east_somerville_eastbound",
+    "pa_ess_loc": "GESS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
+        {
+          "stop_id": "70513",
+          "direction_id": 1,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "east_somerville_westbound",
+    "pa_ess_loc": "GESS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70514",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "east_somerville_mezzanine",
+    "pa_ess_loc": "GESS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70513",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70514",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "gilman_square_eastbound",
+    "pa_ess_loc": "GGSS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
+        {
+          "stop_id": "70505",
+          "direction_id": 1,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "gilman_square_westbound",
+    "pa_ess_loc": "GGSS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70506",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "gilman_square_mezzanine",
+    "pa_ess_loc": "GGSS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70505",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70506",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "magoun_square_eastbound",
+    "pa_ess_loc": "GMSS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
+        {
+          "stop_id": "70507",
+          "direction_id": 1,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "magoun_square_westbound",
+    "pa_ess_loc": "GMSS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70508",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "magoun_square_mezzanine",
+    "pa_ess_loc": "GMSS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70507",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70508",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ball_square_eastbound",
+    "pa_ess_loc": "GBSS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
+        {
+          "stop_id": "70509",
+          "direction_id": 1,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "ball_square_westbound",
+    "pa_ess_loc": "GBSS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70510",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "ball_square_mezzanine",
+    "pa_ess_loc": "GBSS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": [
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70509",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "glx_medford",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70510",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "college_ave_eastbound",
+    "pa_ess_loc": "GCOS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": [],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70512",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "college_ave_westbound",
+    "pa_ess_loc": "GCOS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": [],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70512",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    }
+  },
+  {
+    "id": "college_ave_mezzanine",
+    "pa_ess_loc": "GCOS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "e",
+      "w",
+      "m"
+    ],
+    "type": "realtime",
+    "source_config": {
+      "headway_group": "glx_medford",
+      "headway_direction_name": "Heath Street",
+      "sources": [
+        {
+          "stop_id": "70512",
+          "direction_id": 0,
+          "routes": [
+            "Green-E"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "Silver_Line.South_Station_EB",
+    "pa_ess_loc": "SSOU",
+    "read_loop_interval": 360,
+    "read_loop_offset": 0,
+    "text_zone": "e",
+    "audio_zones": [
+      "m",
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74611",
+            "route_id": "741",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74611",
+            "route_id": "742",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74611",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74611",
+            "route_id": "746",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.Courthouse_WB",
+    "pa_ess_loc": "SCOU",
+    "read_loop_interval": 360,
+    "read_loop_offset": 60,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74616",
+            "route_id": "741",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74616",
+            "route_id": "742",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74616",
+            "route_id": "743",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74616",
+            "route_id": "746",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.Courthouse_EB",
+    "pa_ess_loc": "SCOU",
+    "read_loop_interval": 360,
+    "read_loop_offset": 60,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74612",
+            "route_id": "741",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74612",
+            "route_id": "742",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74612",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74612",
+            "route_id": "746",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.Courthouse_mezz",
+    "pa_ess_loc": "SCOU",
+    "read_loop_interval": 360,
+    "read_loop_offset": 60,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74616",
+            "route_id": "741",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74616",
+            "route_id": "742",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74616",
+            "route_id": "743",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74616",
+            "route_id": "746",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.World_Trade_Ctr_WB",
+    "pa_ess_loc": "SWTC",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74615",
+            "route_id": "741",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74615",
+            "route_id": "742",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74615",
+            "route_id": "743",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74615",
+            "route_id": "746",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.World_Trade_Ctr_EB",
+    "pa_ess_loc": "SWTC",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "741",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "742",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "746",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.World_Trade_Ctr_mezz",
+    "pa_ess_loc": "SWTC",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "bus",
+    "top_configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74615",
+            "route_id": "741",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74615",
+            "route_id": "742",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74615",
+            "route_id": "743",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "74615",
+            "route_id": "746",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "bottom_configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "741",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "742",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "74613",
+            "route_id": "746",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio",
+    "max_minutes": 30
+  },
+  {
+    "id": "Silver_Line.Eastern_Ave_OB",
+    "pa_ess_loc": "SEAV",
+    "read_loop_interval": 360,
+    "read_loop_offset": 60,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74637",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "Silver_Line.Eastern_Ave_IB",
+    "pa_ess_loc": "SEAV",
+    "read_loop_interval": 360,
+    "read_loop_offset": 60,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74636",
+            "route_id": "743",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "Silver_Line.Box_District_OB",
+    "pa_ess_loc": "SBOX",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74635",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "Silver_Line.Box_District_IB",
+    "pa_ess_loc": "SBOX",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74634",
+            "route_id": "743",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "Silver_Line.Bellingham_Square_OB",
+    "pa_ess_loc": "SBSQ",
+    "read_loop_interval": 360,
+    "read_loop_offset": 180,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74633",
+            "route_id": "743",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "Silver_Line.Bellingham_Square_IB",
+    "pa_ess_loc": "SBSQ",
+    "read_loop_interval": 360,
+    "read_loop_offset": 180,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74632",
+            "route_id": "743",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "Silver_Line.Chelsea_IB",
+    "pa_ess_loc": "SCHS",
+    "read_loop_interval": 360,
+    "read_loop_offset": 240,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74630",
+            "route_id": "743",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "chelsea_bridge": "audio_visual",
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Nubian_Platform_A",
+    "pa_ess_loc": "SDUD",
+    "read_loop_interval": 420,
+    "read_loop_offset": 180,
+    "text_zone": "w",
+    "audio_zones": [
+      "c"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "15",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "64000",
+            "route_id": "23",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "64000",
+            "route_id": "28",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "64000",
+            "route_id": "44",
+            "direction_id": 1
+          },
+          {
+            "stop_id": "64000",
+            "route_id": "45",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Nubian_Platform_C",
+    "pa_ess_loc": "SDUD",
+    "read_loop_interval": 420,
+    "read_loop_offset": 240,
+    "text_zone": "s",
+    "audio_zones": [
+      "c"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "14",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "41",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "42",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "66",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Nubian_Platform_D",
+    "pa_ess_loc": "SDUD",
+    "read_loop_interval": 420,
+    "read_loop_offset": 0,
+    "text_zone": "e",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "15",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "41",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "45",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Nubian_Platform_E_east",
+    "pa_ess_loc": "SDUD",
+    "read_loop_interval": 420,
+    "read_loop_offset": 60,
+    "text_zone": "c",
+    "audio_zones": [
+      "w"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "170",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "171",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "749",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "751",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "extra_audio_configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "14",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "19",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "23",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "28",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "44",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Nubian_Platform_E_west",
+    "pa_ess_loc": "SDUD",
+    "read_loop_interval": 420,
+    "read_loop_offset": 60,
+    "text_zone": "m",
+    "audio_zones": [],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "14",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "19",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "23",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "28",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64000",
+            "route_id": "44",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Nubian_Platform_F",
+    "pa_ess_loc": "SDUD",
+    "read_loop_interval": 420,
+    "read_loop_offset": 120,
+    "text_zone": "n",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "1",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "19",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "47",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "47",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "8",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "64",
+            "route_id": "8",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Lechmere_inner",
+    "pa_ess_loc": "SLEC",
+    "read_loop_interval": 360,
+    "read_loop_offset": 180,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "69",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "80",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "extra_audio_configs": [
+      { 
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "87",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "88",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+
+  },
+  {
+    "id": "bus.Lechmere_outer",
+    "pa_ess_loc": "SLEC",
+    "read_loop_interval": 360,
+    "read_loop_offset": 0,
+    "text_zone": "c",
+    "audio_zones": [],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "87",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "88",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Harvard_upper",
+    "pa_ess_loc": "SHAR",
+    "read_loop_interval": 360,
+    "read_loop_offset": 240,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "71",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "72",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "73",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "74",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "75",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "77",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "78",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "86",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "20761",
+            "route_id": "96",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Harvard_lower",
+    "pa_ess_loc": "SHAR",
+    "read_loop_interval": 360,
+    "read_loop_offset": 60,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "2076",
+            "route_id": "71",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "2076",
+            "route_id": "73",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Mattapan_north",
+    "pa_ess_loc": "MMAT",
+    "read_loop_interval": 420,
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "24",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "24",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "2427",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "2427",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "245",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "27",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "30",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "33",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Mattapan_south",
+    "pa_ess_loc": "MMAT",
+    "read_loop_interval": 420,
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "18511",
+            "route_id": "28",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "18511",
+            "route_id": "29",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "18511",
+            "route_id": "31",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Davis",
+    "pa_ess_loc": "SDAV",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "87",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "88",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "89",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "89",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "90",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "94",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "5104",
+            "route_id": "96",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Forest_Hills_upper_island",
+    "pa_ess_loc": "SFOR",
+    "read_loop_interval": 420,
+    "read_loop_offset": 180,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "30",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "35",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "36",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "37",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "51",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Forest_Hills_upper_fence",
+    "pa_ess_loc": "SFOR",
+    "read_loop_interval": 420,
+    "read_loop_offset": 0,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "34",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "34E",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "38",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "39",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "40",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "10642",
+            "route_id": "50",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Braintree",
+    "pa_ess_loc": "RBRA",
+    "read_loop_interval": 360,
+    "read_loop_offset": 240,
+    "text_zone": "n",
+    "audio_zones": [
+      "n"
+    ],
+    "type": "bus",
+    "configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "38671",
+            "route_id": "226",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "38671",
+            "route_id": "230",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "38671",
+            "route_id": "230",
+            "direction_id": 1
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "38671",
+            "route_id": "236",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "38671",
+            "route_id": "236",
+            "direction_id": 1
+          }
+        ]
+      }
+    ],
+    "max_minutes": 75
+  }
+]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Support Concentrate consuming Signs UI headway config](https://app.asana.com/0/1185117109217413/1206385849658208/f)

This writes a new file during state saving, which contains a list of stops and whether predictions are "flagged" at that stop. This corresponds to whether headway mode was selected for a platform sign serving that stop. This computation requires the mapping from the `signs.json` file from RTS, so a copy is included. The intention is that the RTS copy is the primary record, and this copy will be manually synced when there are changes.

Note: this change depends on https://github.com/mbta/devops/pull/1572 being merged, to add the environment variable.