### PR TITLE
feat: SL Headway Mode

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,6 +1,6 @@
 # URL and access key for the V3 API. Required. Leaving the key unset will work, but access will be
 # subject to strict rate limits, so it is recommended to request a proper key.
-export API_V3_URL=https://api-dev-green.mbtace.com
+export API_V3_ORIGIN=https://api-dev-green.mbtace.com
 #export API_V3_KEY=
 
 # Access key for allowing updates from external applications, e.g. realtime_signs. Optional.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Web interface for MBTA countdown signs. Acts as an emulator for the physical har
 ## Development
 
 * Run `asdf install` from the repository root.
+  <!-- Remove this if upgrading the Erlang/OTP version beyond 25 -->
+  * Note: If running macOS Sonoma on an Apple Silicon (ARM) machine, use `KERL_CONFIGURE_OPTIONS="--disable-jit" asdf install`[^1]
 * Install Elixir dependencies with `mix deps.get`
 * Install JS dependencies with `pushd assets && npm install && popd`
 * Copy `.envrc.template` to `.envrc`, then edit `.envrc` and make sure all required environment variables are set. When finished, run `direnv allow` to activate them.
@@ -20,3 +22,5 @@ Now you can visit [`localhost:5000`](http://localhost:5000) from your browser.
 ### Developing locally with [realtime_signs](https://github.com/mbta/realtime_signs)
 
 See the realtime_signs README for instructions.
+
+[^1]: The way memory is allocated for the JIT in OTP 25 is prohibited in macOS Sonomoa. [Disabling the JIT fixes the issue](https://github.com/erlang/otp/issues/7687#issuecomment-1737184968). This has [been fixed in OTP-25.3.2.7](https://github.com/erlang/otp/commit/ac591a599b09b48b45a7125aa30ec5419ba3cc2f) and beyond.

--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2074,7 +2074,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2107,7 +2107,7 @@ const stationConfig: {
             modes: {
               auto: false,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: false,
             },

--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -2029,7 +2029,7 @@ const stationConfig: {
   Silver: {
     batchModes: {
       auto: true,
-      headway: false,
+      headway: true,
       off: true,
     },
     stations: [
@@ -2041,7 +2041,7 @@ const stationConfig: {
             modes: {
               auto: false,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: false,
             },
@@ -2056,7 +2056,7 @@ const stationConfig: {
             modes: {
               auto: false,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: false,
             },
@@ -2065,7 +2065,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2074,7 +2074,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2089,7 +2089,7 @@ const stationConfig: {
             modes: {
               auto: false,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: false,
             },
@@ -2098,7 +2098,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2107,7 +2107,7 @@ const stationConfig: {
             modes: {
               auto: false,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: false,
             },
@@ -2123,7 +2123,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2133,7 +2133,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2149,7 +2149,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2159,7 +2159,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2175,7 +2175,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2185,7 +2185,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2201,7 +2201,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -115,46 +115,81 @@ test('Shows batch mode buttons when not read-only', () => {
   expect(screen.getByText('All to off')).toBeInTheDocument();
 });
 
-test.each([['Silver'], ['Busway']])(
-  'Does not show headway batch mode button',
-  (line) => {
-    const now = Date.now();
-    const signs = {};
+test('Does not show headway batch mode button', () => {
+  const now = Date.now();
+  const signs = {};
 
-    const currentTime = now + 2000;
-    const signConfigs = {};
-    const setConfigs = () => true;
-    const readOnly = false;
-    const configuredHeadways = {};
-    const setConfiguredHeadways = () => true;
+  const currentTime = now + 2000;
+  const signConfigs = {};
+  const setConfigs = () => true;
+  const readOnly = false;
+  const configuredHeadways = {};
+  const setConfiguredHeadways = () => true;
 
-    render(
-      React.createElement(
-        Line,
-        {
-          alerts: {},
-          signs,
-          currentTime,
-          line,
-          signConfigs,
-          setConfigs,
-          readOnly,
-          configuredHeadways,
-          setConfiguredHeadways,
-          chelseaBridgeAnnouncements: 'off',
-          setChelseaBridgeAnnouncements: () => {},
-          signGroups: {},
-          setSignGroups: () => {},
-        },
-        null,
-      ),
-    );
+  render(
+    React.createElement(
+      Line,
+      {
+        alerts: {},
+        signs,
+        currentTime,
+        line: 'Busway',
+        signConfigs,
+        setConfigs,
+        readOnly,
+        configuredHeadways,
+        setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
+        signGroups: {},
+        setSignGroups: () => {},
+      },
+      null,
+    ),
+  );
 
-    expect(screen.getByText('All to auto')).toBeInTheDocument();
-    expect(screen.queryByText('All to headway')).toBeNull();
-    expect(screen.getByText('All to off')).toBeInTheDocument();
-  },
-);
+  expect(screen.getByText('All to auto')).toBeInTheDocument();
+  expect(screen.queryByText('All to headway')).toBeNull();
+  expect(screen.getByText('All to off')).toBeInTheDocument();
+});
+
+test('Shows headway batch mode button', () => {
+  const now = Date.now();
+  const signs = {};
+
+  const currentTime = now + 2000;
+  const signConfigs = {};
+  const setConfigs = () => true;
+  const readOnly = false;
+  const configuredHeadways = {};
+  const setConfiguredHeadways = () => true;
+
+  render(
+    React.createElement(
+      Line,
+      {
+        alerts: {},
+        signs,
+        currentTime,
+        line: 'Silver',
+        signConfigs,
+        setConfigs,
+        readOnly,
+        configuredHeadways,
+        setConfiguredHeadways,
+        chelseaBridgeAnnouncements: 'off',
+        setChelseaBridgeAnnouncements: () => {},
+        signGroups: {},
+        setSignGroups: () => {},
+      },
+      null,
+    ),
+  );
+
+  expect(screen.getByText('All to auto')).toBeInTheDocument();
+  expect(screen.queryByText('All to headway')).toBeInTheDocument();
+  expect(screen.getByText('All to off')).toBeInTheDocument();
+});
 
 test('Shows "Mixed" batch mode buttons when multiple modes are chosen', () => {
   const now = Date.now();

--- a/assets/test/Line.test.ts
+++ b/assets/test/Line.test.ts
@@ -115,7 +115,7 @@ test('Shows batch mode buttons when not read-only', () => {
   expect(screen.getByText('All to off')).toBeInTheDocument();
 });
 
-test('Does not show headway batch mode button', () => {
+test('Does not show headway batch mode button for busways', () => {
   const now = Date.now();
   const signs = {};
 
@@ -153,7 +153,7 @@ test('Does not show headway batch mode button', () => {
   expect(screen.getByText('All to off')).toBeInTheDocument();
 });
 
-test('Shows headway batch mode button', () => {
+test('Shows headway batch mode button for Silver Line', () => {
   const now = Date.now();
   const signs = {};
 

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -265,13 +265,8 @@ defmodule SignsUi.Config.State do
       |> Jason.decode!(keys: :atoms)
 
     sl_sign_stops =
-      for %{id: id} = sign <- signs_json,
-          config_list when is_list(config_list) <- [
-            sign[:configs],
-            sign[:top_configs],
-            sign[:bottom_configs]
-          ],
-          %{sources: sources} <- config_list,
+      for %{id: id, configs: configs} <- signs_json,
+          %{sources: sources} <- configs,
           %{stop_id: stop_id, route_id: route_id, direction_id: direction_id}
           when route_id in @sl_waterfront_route_ids <- sources,
           reduce: %{} do

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -266,8 +266,11 @@ defmodule SignsUi.Config.State do
 
     sl_sign_stops =
       for %{id: id} = sign <- signs_json,
-          config_list <- [sign[:configs], sign[:top_configs], sign[:bottom_configs]],
-          config_list,
+          config_list when is_list(config_list) <- [
+            sign[:configs],
+            sign[:top_configs],
+            sign[:bottom_configs]
+          ],
           %{sources: sources} <- config_list,
           %{stop_id: stop_id, route_id: route_id, direction_id: direction_id}
           when route_id in @sl_waterfront_route_ids <- sources,

--- a/lib/signs_ui/config/state.ex
+++ b/lib/signs_ui/config/state.ex
@@ -11,6 +11,8 @@ defmodule SignsUi.Config.State do
   alias SignsUi.Config.SignGroups
   alias SignsUi.Config.Utilities
 
+  @sl_waterfront_route_ids ["741", "742", "743", "746"]
+
   @type t :: %{
           signs: %{Config.Sign.id() => Config.Sign.t()},
           configured_headways: ConfiguredHeadways.t(),
@@ -263,11 +265,12 @@ defmodule SignsUi.Config.State do
       |> Jason.decode!(keys: :atoms)
 
     sl_sign_stops =
-      for %{id: "Silver_Line." <> _ = id} = sign <- signs_json,
+      for %{id: id} = sign <- signs_json,
           config_list <- [sign[:configs], sign[:top_configs], sign[:bottom_configs]],
           config_list,
           %{sources: sources} <- config_list,
-          %{stop_id: stop_id, route_id: route_id, direction_id: direction_id} <- sources,
+          %{stop_id: stop_id, route_id: route_id, direction_id: direction_id}
+          when route_id in @sl_waterfront_route_ids <- sources,
           reduce: %{} do
         acc ->
           Map.update(


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add headway mode for Silver Line signs](https://app.asana.com/0/1185117109217413/1207396498133396/f)

This PR gives users the ability to set headway mode on SL signs. Headway mode for SL is just for suppressing predictions. Visually, headway is the same as off.

To be merged with: https://github.com/mbta/realtime_signs/pull/780

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
