### PR TITLE
implement Scully compatible endpoints

### DIFF
--- a/lib/signs_ui/application.ex
+++ b/lib/signs_ui/application.ex
@@ -12,6 +12,7 @@ defmodule SignsUi.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: SignsUi.PubSub},
       SignsUiWeb.Endpoint,
+      SignsUi.Signs.Lookup,
       SignsUi.Config.State,
       SignsUi.Config.Writer,
       {SignsUi.Signs.State, [name: SignsUi.Signs.State]},

--- a/lib/signs_ui/signs/lookup.ex
+++ b/lib/signs_ui/signs/lookup.ex
@@ -1,0 +1,26 @@
+defmodule SignsUi.Signs.Lookup do
+  @moduledoc """
+  Utility process for looking things up via signs.json
+  """
+  use Agent
+
+  # sobelow_skip ["Traversal"]
+  def start_link([]) do
+    Agent.start_link(
+      fn ->
+        :code.priv_dir(:signs_ui)
+        |> Path.join("signs.json")
+        |> File.read!()
+        |> Jason.decode!(keys: :atoms)
+        |> Map.new(fn %{scu_id: scu_id, text_zone: text_zone, pa_ess_loc: pa_ess_loc} ->
+          {{scu_id, text_zone}, pa_ess_loc}
+        end)
+      end,
+      name: __MODULE__
+    )
+  end
+
+  def lookup_station_code(scu_id, zone) do
+    Agent.get(__MODULE__, &Map.get(&1, {scu_id, zone}))
+  end
+end

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -92,12 +92,8 @@ defmodule SignsUiWeb.MessagesController do
     with {:ok, visual_zones} <- parse_zones(conn, "visual_zones"),
          {:ok, visual_data} <- parse_visual_data(conn),
          {:ok, expiration} <- parse_expiration(conn) do
-      scu_id =
-        Enum.find_value(conn.req_headers, fn {key, value} ->
-          if(key == "x-scu-id", do: value)
-        end)
-
-      zone = MapSet.to_list(visual_zones) |> hd()
+      [scu_id] = Plug.Conn.get_req_header(conn, "x-scu-id")
+      zone = Enum.at(visual_zones, 0)
       station = SignsUi.Signs.Lookup.lookup_station_code(scu_id, zone)
       expiration_time = DateTime.utc_now() |> DateTime.add(expiration)
 

--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -87,4 +87,97 @@ defmodule SignsUiWeb.MessagesController do
   def create(conn, _params) do
     send_resp(conn, 201, "Ignoring unknown message.")
   end
+
+  def background(conn, _params) do
+    with {:ok, visual_zones} <- parse_zones(conn, "visual_zones"),
+         {:ok, visual_data} <- parse_visual_data(conn),
+         {:ok, expiration} <- parse_expiration(conn) do
+      scu_id =
+        Enum.find_value(conn.req_headers, fn {key, value} ->
+          if(key == "x-scu-id", do: value)
+        end)
+
+      zone = MapSet.to_list(visual_zones) |> hd()
+      station = SignsUi.Signs.Lookup.lookup_station_code(scu_id, zone)
+      expiration_time = DateTime.utc_now() |> DateTime.add(expiration)
+
+      Enum.each([{:top, 1}, {:bottom, 2}], fn {key, line} ->
+        :ok =
+          %SignContent{
+            station: station,
+            zone: zone,
+            line_number: line,
+            expiration: expiration_time,
+            pages: Enum.map(visual_data.pages, &{&1[key], &1.duration})
+          }
+          |> State.process_message()
+      end)
+
+      send_resp(conn, 200, "")
+    else
+      # sobelow_skip ["XSS"]
+      {:error, message} -> send_resp(conn, 400, message)
+    end
+  end
+
+  def play(conn, _params) do
+    # Ignore active messages for now
+    send_resp(conn, 200, "")
+  end
+
+  defp parse_zones(conn, key) do
+    case Map.get(conn.params, key, []) do
+      nil ->
+        {:ok, MapSet.new()}
+
+      zones when is_list(zones) ->
+        if Enum.all?(zones, &is_binary/1) do
+          {:ok, MapSet.new(zones)}
+        else
+          {:error, "invalid #{key}"}
+        end
+
+      _ ->
+        {:error, "invalid #{key}"}
+    end
+  end
+
+  defp parse_visual_data(conn) do
+    case conn.params["visual_data"] do
+      nil ->
+        {:ok, nil}
+
+      %{"pages" => pages} when is_list(pages) ->
+        with {:ok, pages} <-
+               Enum.reduce_while(pages, {:ok, []}, fn page, {:ok, pages} ->
+                 case parse_page(page) do
+                   {:ok, page} -> {:cont, {:ok, pages ++ [page]}}
+                   {:error, message} -> {:halt, {:error, message}}
+                 end
+               end) do
+          {:ok, %{pages: pages}}
+        end
+
+      _ ->
+        {:error, "invalid visual_data"}
+    end
+  end
+
+  defp parse_page(page) do
+    case page do
+      %{"top" => top, "bottom" => bottom, "duration" => duration}
+      when is_binary(top) and is_binary(bottom) and is_integer(duration) ->
+        {:ok, %{top: top, bottom: bottom, duration: duration}}
+
+      _ ->
+        {:error, "invalid page"}
+    end
+  end
+
+  defp parse_expiration(conn) do
+    case conn.params["expiration"] do
+      num when is_integer(num) -> {:ok, num}
+      _ -> {:error, "invalid expiration"}
+    end
+  end
 end

--- a/lib/signs_ui_web/router.ex
+++ b/lib/signs_ui_web/router.ex
@@ -74,6 +74,8 @@ defmodule SignsUiWeb.Router do
   scope "/", SignsUiWeb do
     pipe_through([:api])
     post("/messages", MessagesController, :create)
+    post("/background", MessagesController, :background)
+    post("/message", MessagesController, :play)
   end
 
   # Other scopes may use custom stacks.

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1,5 +1,53 @@
 [
   {
+    "id": "lab_test",
+    "type": "realtime",
+    "pa_ess_loc": "201",
+    "scu_id": "TBR01",
+    "default_mode": "auto",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": [
+      "m"
+    ],
+    "source_config": [
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70042",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70041",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "cedar_grove_outbound",
     "type": "realtime",
     "pa_ess_loc": "MCED",
@@ -5757,7 +5805,7 @@
             "Green-D"
           ],
           "platform": null,
-          "terminal": false,
+          "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -9735,6 +9783,15 @@
           {
             "stop_id": "185",
             "route_id": "33",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "185",
+            "route_id": "716",
             "direction_id": 0
           }
         ]

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -123,6 +123,24 @@ defmodule SignsUiWeb.MessagesControllerTest do
 
       assert_broadcast("sign_update", %{audios: [%{station: "RDAV", zones: ["s"]}]})
     end
+
+    test "background", %{conn: conn} do
+      subscribe_and_join!(socket(), SignsUiWeb.SignsChannel, "signs:all", %{})
+
+      conn
+      |> add_api_req_header()
+      |> put_req_header("x-scu-id", "BAIRSCU001")
+      |> post(messages_path(conn, :background), %{
+        "visual_zones" => ["e"],
+        "visual_data" => %{"pages" => [%{"top" => "top", "bottom" => "bottom", "duration" => 6}]},
+        "expiration" => 180
+      })
+
+      assert_broadcast("sign_update", %{
+        lines: %{1 => %{text: [%{content: "top"}]}, 2 => %{text: [%{content: "bottom"}]}},
+        sign_id: "BAIR-e"
+      })
+    end
   end
 
   defp add_api_req_header(conn) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Enable proof-of-play for new MW](https://app.asana.com/0/1205160229510941/1206767937311880/f)

This implements Scully-compatible endpoints, so messages targeting migrated SCUs show up correctly.

Note that the mapping that disambiguates multiple zones with the same name on the same SCU is not yet encoded, so this will display messages on the wrong sign in a few cases. This only affects migrated SCUs, and will be remedied before we migrate anything in production.

Also updates `signs.json` to the latest content from RTS.