### PR TITLE
chore: Bump @sentry/browser and @sentry/react from 6.4.0 to 8.22.0 in /assets

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,7 +10,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@hookform/resolvers": "^3.1.0",
         "@sentry/browser": "^6.4.0",
-        "@sentry/react": "^6.4.0",
+        "@sentry/react": "^8.22.0",
         "@types/dateformat": "^5.0.0",
         "@types/jest": "^29.5.1",
         "@types/phoenix": "^1.5.6",
@@ -1459,6 +1459,184 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.22.0.tgz",
+      "integrity": "sha512-R0u8KPaSivueIwUOhmYxcisKaJq3gx+I0xOcWoluDB3OI1Ds/QOSP/vmTsMg/mjwG/nUJ8RRM8pj0s8vlqCrjg==",
+      "dependencies": {
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+      "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+      "dependencies": {
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/types": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+      "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+      "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+      "dependencies": {
+        "@sentry/types": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.22.0.tgz",
+      "integrity": "sha512-Sy2+v0xBmVnZ5LQ48603CvLy5vVQvAZ+hc9xQSAHexts07NkvApMU1qv26YNwxlAWfDha1wXiW6ryd4YDzaoVA==",
+      "dependencies": {
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+      "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+      "dependencies": {
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+      "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+      "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+      "dependencies": {
+        "@sentry/types": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.22.0.tgz",
+      "integrity": "sha512-sF8RyMPJP1fSIyyBDAbtybvKCu0dy8ZAfMwLP7ZqEnWrhZqktVuqM7/++EAFMlD5YaWJXm1IDuOXjgSQjUtSIQ==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.22.0.tgz",
+      "integrity": "sha512-/gV8qN3JqWw0LXTMuCGB8RDI8Bx1VESNRBdh/7Cmc5+hxYBfcketuix3S8mHWcE/JO+Ed9g1Abzys6GphTB9LA==",
+      "dependencies": {
+        "@sentry-internal/replay": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+      "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+      "dependencies": {
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+      "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+      "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+      "dependencies": {
+        "@sentry/types": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+      "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+      "dependencies": {
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/types": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+      "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+      "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+      "dependencies": {
+        "@sentry/types": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/browser": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.0.tgz",
@@ -1515,22 +1693,69 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.4.0.tgz",
-      "integrity": "sha512-xfss/0QMWFQfGkP6aahBJ8534FpCsbx7N1zELYWzE3EnuGXxiZox6GMSvLRhNUVm8ltluvEMULg9vL+Uox5RZg==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.22.0.tgz",
+      "integrity": "sha512-LcO8SPfjYsx3Zvg1mQwjreVvtriVxde+6njIJyXU9TArB0e8bFexvd4MGXdBExgW9aY449hNaStgKRWMNHeVHQ==",
       "dependencies": {
-        "@sentry/browser": "6.4.0",
-        "@sentry/minimal": "6.4.0",
-        "@sentry/types": "6.4.0",
-        "@sentry/utils": "6.4.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
+        "@sentry/browser": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0",
+        "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       },
       "peerDependencies": {
-        "react": "15.x || 16.x || 17.x"
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/browser": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.22.0.tgz",
+      "integrity": "sha512-t3b+/9WWcP9SQTWwrHrB57B33ENgmUjyFlW2+JSlCXkSJBSmAoquPZ/GPjOuPaSr3HIA0mu9uEr4A41d5diASQ==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.22.0",
+        "@sentry-internal/feedback": "8.22.0",
+        "@sentry-internal/replay": "8.22.0",
+        "@sentry-internal/replay-canvas": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/core": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+      "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+      "dependencies": {
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/types": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+      "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+      "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+      "dependencies": {
+        "@sentry/types": "8.22.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/types": {
@@ -11394,6 +11619,144 @@
         "rc-util": "^5.29.2"
       }
     },
+    "@sentry-internal/browser-utils": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.22.0.tgz",
+      "integrity": "sha512-R0u8KPaSivueIwUOhmYxcisKaJq3gx+I0xOcWoluDB3OI1Ds/QOSP/vmTsMg/mjwG/nUJ8RRM8pj0s8vlqCrjg==",
+      "requires": {
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+          "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+          "requires": {
+            "@sentry/types": "8.22.0",
+            "@sentry/utils": "8.22.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+          "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g=="
+        },
+        "@sentry/utils": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+          "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+          "requires": {
+            "@sentry/types": "8.22.0"
+          }
+        }
+      }
+    },
+    "@sentry-internal/feedback": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.22.0.tgz",
+      "integrity": "sha512-Sy2+v0xBmVnZ5LQ48603CvLy5vVQvAZ+hc9xQSAHexts07NkvApMU1qv26YNwxlAWfDha1wXiW6ryd4YDzaoVA==",
+      "requires": {
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+          "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+          "requires": {
+            "@sentry/types": "8.22.0",
+            "@sentry/utils": "8.22.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+          "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g=="
+        },
+        "@sentry/utils": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+          "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+          "requires": {
+            "@sentry/types": "8.22.0"
+          }
+        }
+      }
+    },
+    "@sentry-internal/replay": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.22.0.tgz",
+      "integrity": "sha512-sF8RyMPJP1fSIyyBDAbtybvKCu0dy8ZAfMwLP7ZqEnWrhZqktVuqM7/++EAFMlD5YaWJXm1IDuOXjgSQjUtSIQ==",
+      "requires": {
+        "@sentry-internal/browser-utils": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+          "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+          "requires": {
+            "@sentry/types": "8.22.0",
+            "@sentry/utils": "8.22.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+          "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g=="
+        },
+        "@sentry/utils": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+          "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+          "requires": {
+            "@sentry/types": "8.22.0"
+          }
+        }
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.22.0.tgz",
+      "integrity": "sha512-/gV8qN3JqWw0LXTMuCGB8RDI8Bx1VESNRBdh/7Cmc5+hxYBfcketuix3S8mHWcE/JO+Ed9g1Abzys6GphTB9LA==",
+      "requires": {
+        "@sentry-internal/replay": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+          "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+          "requires": {
+            "@sentry/types": "8.22.0",
+            "@sentry/utils": "8.22.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+          "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g=="
+        },
+        "@sentry/utils": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+          "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+          "requires": {
+            "@sentry/types": "8.22.0"
+          }
+        }
+      }
+    },
     "@sentry/browser": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.0.tgz",
@@ -11438,16 +11801,53 @@
       }
     },
     "@sentry/react": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.4.0.tgz",
-      "integrity": "sha512-xfss/0QMWFQfGkP6aahBJ8534FpCsbx7N1zELYWzE3EnuGXxiZox6GMSvLRhNUVm8ltluvEMULg9vL+Uox5RZg==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.22.0.tgz",
+      "integrity": "sha512-LcO8SPfjYsx3Zvg1mQwjreVvtriVxde+6njIJyXU9TArB0e8bFexvd4MGXdBExgW9aY449hNaStgKRWMNHeVHQ==",
       "requires": {
-        "@sentry/browser": "6.4.0",
-        "@sentry/minimal": "6.4.0",
-        "@sentry/types": "6.4.0",
-        "@sentry/utils": "6.4.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
+        "@sentry/browser": "8.22.0",
+        "@sentry/core": "8.22.0",
+        "@sentry/types": "8.22.0",
+        "@sentry/utils": "8.22.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "dependencies": {
+        "@sentry/browser": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.22.0.tgz",
+          "integrity": "sha512-t3b+/9WWcP9SQTWwrHrB57B33ENgmUjyFlW2+JSlCXkSJBSmAoquPZ/GPjOuPaSr3HIA0mu9uEr4A41d5diASQ==",
+          "requires": {
+            "@sentry-internal/browser-utils": "8.22.0",
+            "@sentry-internal/feedback": "8.22.0",
+            "@sentry-internal/replay": "8.22.0",
+            "@sentry-internal/replay-canvas": "8.22.0",
+            "@sentry/core": "8.22.0",
+            "@sentry/types": "8.22.0",
+            "@sentry/utils": "8.22.0"
+          }
+        },
+        "@sentry/core": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.22.0.tgz",
+          "integrity": "sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==",
+          "requires": {
+            "@sentry/types": "8.22.0",
+            "@sentry/utils": "8.22.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.22.0.tgz",
+          "integrity": "sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g=="
+        },
+        "@sentry/utils": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.22.0.tgz",
+          "integrity": "sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==",
+          "requires": {
+            "@sentry/types": "8.22.0"
+          }
+        }
       }
     },
     "@sentry/types": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -37,7 +37,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@hookform/resolvers": "^3.1.0",
     "@sentry/browser": "^6.4.0",
-    "@sentry/react": "^6.4.0",
+    "@sentry/react": "^8.22.0",
     "@types/dateformat": "^5.0.0",
     "@types/jest": "^29.5.1",
     "@types/phoenix": "^1.5.6",


### PR DESCRIPTION
Merges the two sentry dependabot upgrades (https://github.com/mbta/signs_ui/pull/1378, https://github.com/mbta/signs_ui/pull/1379) and resolves conflicts in `package.json` and `package-lock.json`.

Also ran sentry's upgrade codemod which didn't require any changes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207827249837885