### PR TITLE
config: add new child stops to harvard busway config

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -9666,6 +9666,78 @@
             "direction_id": 0
           }
         ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76121,
+            "route_id": 77,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76122,
+            "route_id": 96,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76123,
+            "route_id": 66,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76123,
+            "route_id": 71,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76123,
+            "route_id": 73,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76124,
+            "route_id": 74,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76124,
+            "route_id": 78,
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": 76125,
+            "route_id": 75,
+            "direction_id": 0
+          }
+        ]
       }
     ],
     "max_minutes": 60


### PR DESCRIPTION
#### Summary of changes

The Harvard busway has been split into multiple child stops as of the 8/25/2024 rating. This adds those new child stops to the sources config of the Harvard upper busway sign.

**Asana Ticket:** [(RTS) New child stops added to Harvard Busway for 8/25 rating start](https://app.asana.com/0/1185117109217413/1208105531228653/f)

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] ~~Any new or changed functions have typespecs~~
- [ ] ~~Tests were added for any new functionality (don't just rely on coverage statistics)~~
- [x] `signs.json` changes were also made in [realtime_signs](https://github.com/mbta/realtime_signs/blob/main/priv/signs.json)
    - https://github.com/mbta/realtime_signs/pull/809
- [ ] ~~Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay~~
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
