### PR TITLE
adjust headway periods

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -9,7 +9,17 @@ const timePeriodConfig = [
   {
     id: 'off_peak',
     name: 'Off Peak Hours',
-    description: 'weekends and weekdays, excluding peak hours',
+    description: 'weekdays, excluding peak hours',
+  },
+  {
+    id: 'saturday',
+    name: 'Saturday',
+    description: 'all day Saturday',
+  },
+  {
+    id: 'sunday',
+    name: 'Sunday',
+    description: 'all day Sunday',
   },
 ];
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change signs UI to have 4 sections (Weekday peak, Weekday off-peak, Sat, Sun)](https://app.asana.com/0/1185117109217413/1208512927678680/f)

This supersedes #1435 after we realized that the requirements weren't quite right. Updates the headway time periods with Saturday and Sunday categories.