### PR TITLE
Changed the North Station CP label to MZ

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -317,6 +317,7 @@ const stationConfig: {
             },
           },
           c: {
+            label: 'MZ',
             modes: {
               auto: true,
               custom: true,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change North Station OL CP zone to MZ](https://app.asana.com/0/1185117109217413/1209300345133230)

- In the mbta.ts config, the 'm'/'c' labels were swapped for CR exit and the 'c' sign, letting the defaultLabel be MZ for the appropriate sign (since we're overriding the other one anyway)
- Will note that the sign order is different now, but it seems like it's like that in other places

I'm HOPING this is a pretty easy UI change, but I saw that we had custom labels too (if we wanted to keep the group the same but change the label itself). Are there big differences to the 'm' 'c' etc groups other than the default label? 

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
