### PR TITLE
Disable headway mode for many center/mezz signs

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -188,7 +188,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -221,7 +221,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -254,7 +254,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -287,7 +287,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -321,7 +321,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -331,7 +331,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -364,7 +364,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -388,7 +388,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -516,7 +516,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -549,7 +549,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -582,7 +582,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -615,7 +615,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -624,7 +624,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -639,7 +639,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -672,7 +672,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -705,7 +705,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -738,7 +738,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -771,7 +771,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -878,7 +878,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -911,7 +911,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -944,7 +944,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1049,7 +1049,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1106,7 +1106,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1122,7 +1122,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1155,7 +1155,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1188,7 +1188,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1243,7 +1243,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1276,7 +1276,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1309,7 +1309,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1342,7 +1342,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1366,7 +1366,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1409,7 +1409,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1442,7 +1442,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1475,7 +1475,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1508,7 +1508,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1598,7 +1598,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1679,7 +1679,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1712,7 +1712,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1793,7 +1793,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1826,7 +1826,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -1859,7 +1859,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2085,7 +2085,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: false,
+              headway: true,
               off: true,
               temporary_terminal: true,
             },
@@ -2291,7 +2291,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2326,7 +2326,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2361,7 +2361,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2396,7 +2396,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2465,7 +2465,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2498,7 +2498,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2532,7 +2532,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               temporary_terminal: true,
               off: true,
             },
@@ -2589,7 +2589,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2697,7 +2697,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2754,7 +2754,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2811,7 +2811,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },
@@ -2866,7 +2866,7 @@ const stationConfig: {
             modes: {
               auto: true,
               custom: true,
-              headway: true,
+              headway: false,
               off: true,
               temporary_terminal: true,
             },


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Remove headway mode from certain PA/ESS zones](https://app.asana.com/0/1185117109217413/1209072493448522)

Disabling headway mode for a bunch of mezzanine/center signs. 

The mezzanine signs changed are:

- Government Center
- Tufts
- Porter
- Magoun Square
- Shawmut
- North Quincy
- Kenmore
- Ruggles
- North Station Green Line CR Exit
- North Station Orange Line CR Exit and MZ
- Assembly
- Broadway
- JFK/UMass
- Ball Square
- Aquarium
- State
- Oak Grove
- Wellington
- Quincy Adams
- Haymarket
- Quincy Center
- Mass Ave
- Savin Hill
- Hynes
- Arlington
- Science Park
- South Station
- Fields Corner
- Wood Island
- Back Bay
- Ashmont
- Green Street
- Jackson Square
- Gilman Square
- Prudential
- Lechmere
- Community College
- Park St
- Stony Brook
- Harvard
- Roxbury Crossing
- East Somerville
- Revere Beach
- Andrew
- Davis
- Sullivan
- Wollaston
- Orient Heights
- South Station Silver Line Arrival Platform

Notably not changed are Malden and Butler

This list was pulled effectively from `include_all_bidirectional_signs` from `state.ex`. 

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
