### PR TITLE
feat: Add headway groups for Chelsea and Seaport

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -88,10 +88,10 @@ const branchConfig: { [key: string]: { id: string; name: string }[] } = {
       name: 'Chelsea',
     },
     {
-      id: "silver_seaport",
-      name: "Seaport"
-    }
-  ]
+      id: 'silver_seaport',
+      name: 'Seaport',
+    },
+  ],
 };
 
 const stationConfig: {

--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -82,6 +82,16 @@ const branchConfig: { [key: string]: { id: string; name: string }[] } = {
       name: 'Mattapan Line',
     },
   ],
+  Silver: [
+    {
+      id: 'silver_chelsea',
+      name: 'Chelsea',
+    },
+    {
+      id: "silver_seaport",
+      name: "Seaport"
+    }
+  ]
 };
 
 const stationConfig: {


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Add headway groups for Silver Line signs in Signs UI](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1208439914406740?focus=true)

Adds two new headway groups for Silver Line routes, for Chelsea and Seaport stops. Bulk of the actual work here will be using this new configuration in `realtime-signs`.

Deployed and tested in dev-green. Successfully able to add headway times that are written to the config in S3.

<img width="698" alt="image" src="https://github.com/user-attachments/assets/85ecb5b0-6a0b-4a42-ad95-2135d3fa8c60" />

#### Reviewer Checklist
