### PR TITLE
fix scully zone api

### DIFF
--- a/lib/signs_ui/messages/audio.ex
+++ b/lib/signs_ui/messages/audio.ex
@@ -3,14 +3,14 @@ defmodule SignsUi.Messages.Audio do
   Audio message, with optional visual content
   """
 
-  @enforce_keys [:timestamp, :visual_data, :visual_zones, :station, :expiration]
+  @enforce_keys [:timestamp, :visual_data, :zones, :station, :expiration]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           timestamp: integer(),
           visual_data:
             %{pages: [%{top: String.t(), bottom: String.t(), duration: non_neg_integer()}]} | nil,
-          visual_zones: MapSet.t(String.t()),
+          zones: MapSet.t(String.t()),
           station: String.t(),
           expiration: integer()
         }

--- a/lib/signs_ui/signs/config.ex
+++ b/lib/signs_ui/signs/config.ex
@@ -9,16 +9,5 @@ defmodule SignsUi.Signs.Config do
   @config @config_path |> File.read!() |> Jason.decode!(keys: :atoms)
   @external_resource @config_path
 
-  @station_codes Map.new(@config, fn %{
-                                       scu_id: scu_id,
-                                       text_zone: text_zone,
-                                       pa_ess_loc: pa_ess_loc
-                                     } ->
-                   {{scu_id, text_zone}, pa_ess_loc}
-                 end)
-
   def get, do: @config
-
-  @spec station_code(String.t(), String.t()) :: String.t() | nil
-  def station_code(scu_id, zone), do: Map.get(@station_codes, {scu_id, zone})
 end

--- a/lib/signs_ui/signs/sign.ex
+++ b/lib/signs_ui/signs/sign.ex
@@ -35,7 +35,7 @@ defmodule SignsUi.Signs.Sign do
         end),
       audios:
         Enum.map(sign.audios, fn audio ->
-          Map.from_struct(audio) |> Map.update!(:visual_zones, &MapSet.to_list/1)
+          Map.from_struct(audio) |> Map.update!(:zones, &MapSet.to_list/1)
         end)
     }
   end

--- a/lib/signs_ui/signs/state.ex
+++ b/lib/signs_ui/signs/state.ex
@@ -94,7 +94,7 @@ defmodule SignsUi.Signs.State do
   defp insert_audio(state, audio) do
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
-    Enum.reduce(audio.visual_zones, state, fn zone, acc ->
+    Enum.reduce(audio.zones, state, fn zone, acc ->
       update_sign(acc, audio.station, zone, fn sign ->
         Map.update!(sign, :audios, fn audios ->
           # Filter out expired audios. Note that this only happens when a new audio is being

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -130,9 +130,8 @@ defmodule SignsUiWeb.MessagesControllerTest do
 
       conn
       |> add_api_req_header()
-      |> put_req_header("x-scu-id", "BAIRSCU001")
       |> post(messages_path(conn, :background), %{
-        "visual_zones" => ["e"],
+        "zones" => ["BAIR-e"],
         "visual_data" => %{"pages" => [%{"top" => "top", "bottom" => "bottom", "duration" => 6}]},
         "expiration" => 180
       })


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Signs UI render for SL Chelsea inconsistent](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1210880111859053?focus=true)

This modifies the API to restore compatibility with recent changes to the Scully API in how zones are specified. This fixes the display of migrated stations.

Interestingly, with the new zone format, we no longer need to look up the station code, since it's included in the compound zone name.