### PR TITLE
ci: fix Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 # first, get the elixir dependencies within an elixir container
-FROM hexpm/elixir:1.17.3-erlang-27.3.4-debian-buster-20240612-slim as elixir-builder
+FROM hexpm/elixir:1.17.3-erlang-27.3.4-debian-bookworm-20250520-slim AS elixir-builder
 ENV LANG="C.UTF-8" MIX_ENV="prod"
 
 WORKDIR /root
 ADD . .
 
 # Install git so we can install dependencies from GitHub
-RUN apt-get update --allow-releaseinfo-change && \
+RUN apt-get update && \
   apt-get install -y --no-install-recommends git ca-certificates
 
 RUN mix do local.hex --force, local.rebar --force, deps.get --only prod
 
 # next, build the frontend assets within a node.js container
-FROM node:18.12.1 as assets-builder
+FROM node:18.12.1 AS assets-builder
 
 WORKDIR /root
 ADD . .
@@ -23,7 +23,7 @@ COPY --from=elixir-builder /root/deps ./deps
 RUN npm ci --prefix assets && npm run deploy --prefix assets
 
 # now, build the application back in the elixir container
-FROM elixir-builder as app-builder
+FROM elixir-builder AS app-builder
 
 WORKDIR /root
 
@@ -33,7 +33,7 @@ COPY --from=assets-builder /root/priv/static ./priv/static
 RUN mix do compile --force, phx.digest, release
 
 # the one the elixir image was built with
-FROM hexpm/erlang:27.3.4-debian-buster-20240612-slim
+FROM hexpm/erlang:27.3.4-debian-bookworm-20250520-slim
 
 WORKDIR /root
 EXPOSE 4000


### PR DESCRIPTION
Debian Buster went EOL a year ago, and its package repositories have started returning 404 errors. Update to the latest stable release of Debian for our Docker builds.

**Asana Ticket:** https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210919292775759