### PR TITLE
chore: update Node.js version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.17.3-otp-27
 erlang 27.3.4
-nodejs 18.12.1
+nodejs 22.18.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 RUN mix do local.hex --force, local.rebar --force, deps.get --only prod
 
 # next, build the frontend assets within a node.js container
-FROM node:18.12.1 AS assets-builder
+FROM node:22.18.0 AS assets-builder
 
 WORKDIR /root
 ADD . .


### PR DESCRIPTION
Node 18 reached End Of Life in April 2025 and no longer receives security updates. Update to Node 22, the current LTS release, which will be supported until mid-2027.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211023063494549