### PR TITLE
fix: enable Auto mode for SL outbound signs

### DIFF
--- a/assets/js/mbta.ts
+++ b/assets/js/mbta.ts
@@ -1860,7 +1860,7 @@ const stationConfig: { [key: string]: { stations: StationConfig[] } } = {
         zones: {
           e: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               off: true,
               temporary_terminal: false,
@@ -1874,7 +1874,7 @@ const stationConfig: { [key: string]: { stations: StationConfig[] } } = {
         zones: {
           e: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               off: true,
               temporary_terminal: false,
@@ -1904,7 +1904,7 @@ const stationConfig: { [key: string]: { stations: StationConfig[] } } = {
         zones: {
           e: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               off: true,
               temporary_terminal: false,
@@ -1920,7 +1920,7 @@ const stationConfig: { [key: string]: { stations: StationConfig[] } } = {
           },
           m: {
             modes: {
-              auto: false,
+              auto: true,
               custom: true,
               off: true,
               temporary_terminal: false,


### PR DESCRIPTION
In production these signs were set to Headway mode. We'd like to set them to Auto so they will continue showing headways after the removal of Headway mode in 0a7d923, but Auto was disabled for these signs (oops).