### PR TITLE
Change parser in page_text to allow dashes (`-`) for sign messages

### DIFF
--- a/assets/js/SignTextInput.tsx
+++ b/assets/js/SignTextInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 function isValidText(text: string) {
-  return !/[^a-zA-Z0-9,/!@()': +]/.test(text);
+  return !/[^a-zA-Z0-9,/!@()': +-]/.test(text);
 }
 
 interface SignTextInputProps {
@@ -49,7 +49,7 @@ function SignTextInput({
     <div>
       {showTipText && (
         <small className="custom_text_input--error-text">
-          You may use letters, numbers, and: /,!@():&quot;
+          You may use letters, numbers, and: /,!@():-&quot;
         </small>
       )}
       <div>

--- a/lib/signs_ui/messages/sign_content.ex
+++ b/lib/signs_ui/messages/sign_content.ex
@@ -23,7 +23,7 @@ defmodule SignsUi.Messages.SignContent do
   page_text =
     ignore(string("-"))
     |> ignore(string("\""))
-    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+, ?(, ?), ?:], min: 0)
+    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+, ?(, ?), ?:, ?-], min: 0)
     |> ignore(string("\""))
     |> optional(
       ignore(string("."))


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Headways on Short Signs (e.g. Courthouse MZ)](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211230313790259?focus=true)

- https://github.com/mbta/realtime_signs/pull/966
- In order to support new headway text (e.g. `11-15m`) we needed to modify the parser to allow for dashes. This just adds the dash as part of the allowed ascii strings to get parsed.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
