### PR TITLE
Revert "Change parser in page_text to allow dashes (`-`) for sign messages"

### DIFF
--- a/assets/js/SignTextInput.tsx
+++ b/assets/js/SignTextInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 function isValidText(text: string) {
-  return !/[^a-zA-Z0-9,/!@()': +-]/.test(text);
+  return !/[^a-zA-Z0-9,/!@()': +]/.test(text);
 }
 
 interface SignTextInputProps {
@@ -49,7 +49,7 @@ function SignTextInput({
     <div>
       {showTipText && (
         <small className="custom_text_input--error-text">
-          You may use letters, numbers, and: /,!@():-&quot;
+          You may use letters, numbers, and: /,!@():&quot;
         </small>
       )}
       <div>

--- a/lib/signs_ui/messages/sign_content.ex
+++ b/lib/signs_ui/messages/sign_content.ex
@@ -23,7 +23,7 @@ defmodule SignsUi.Messages.SignContent do
   page_text =
     ignore(string("-"))
     |> ignore(string("\""))
-    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+, ?(, ?), ?:, ?-], min: 0)
+    |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?/, ?', ?\s, ?,, ?!, ?@, ?+, ?(, ?), ?:], min: 0)
     |> ignore(string("\""))
     |> optional(
       ignore(string("."))


### PR DESCRIPTION
Reverts mbta/signs_ui#1495

Signs actually don't accept the `-` character, reverting this change until we properly support the character with our own work.