### PR TITLE
add short sign indicator for Courthouse

### DIFF
--- a/assets/css/sign_text.css
+++ b/assets/css/sign_text.css
@@ -2,11 +2,11 @@
   background-color: rgb(45, 45, 45);
   padding-left: 0.5em;
   position: relative;
+  font-family: monospace;
 }
 
 .sign_text--line {
   color: rgb(251, 220, 75);
-  font-family: monospace;
   height: 40px;
   padding-top: 8px;
   white-space: pre;
@@ -19,7 +19,7 @@
 
 .sign_text--divider {
   position: absolute;
-  left: 186px;
+  left: calc(18.5ch + 0.5em);
   height: 100%;
   border-left: 1px dashed rgb(206, 206, 206);
 }

--- a/assets/css/sign_text.css
+++ b/assets/css/sign_text.css
@@ -1,6 +1,7 @@
 .sign_text--container {
   background-color: rgb(45, 45, 45);
   padding-left: 0.5em;
+  position: relative;
 }
 
 .sign_text--line {
@@ -14,4 +15,11 @@
 
 .sign_text--line.centered {
   text-align: center;
+}
+
+.sign_text--divider {
+  position: absolute;
+  left: 186px;
+  height: 100%;
+  border-left: 1px dashed rgb(206, 206, 206);
 }

--- a/assets/js/SignDisplay.tsx
+++ b/assets/js/SignDisplay.tsx
@@ -6,6 +6,7 @@ import { lineDisplayText } from './helpers';
 interface SignDisplayProps {
   content: SingleSignContent;
   currentTime: number;
+  short?: boolean;
 }
 
 type VisualEvent = {
@@ -13,7 +14,7 @@ type VisualEvent = {
   value: { top: string; bottom: string; duration: number } | null;
 };
 
-function SignDisplay({ currentTime, content }: SignDisplayProps) {
+function SignDisplay({ currentTime, content, short }: SignDisplayProps) {
   const [initialTime] = React.useState(currentTime);
 
   const sequenceAudio = (audio: Audio, startTimestamp: number) => {
@@ -58,6 +59,7 @@ function SignDisplay({ currentTime, content }: SignDisplayProps) {
       line2={line2}
       time={currentTime}
       announcement={!!currentPage}
+      short={short}
     />
   );
 }

--- a/assets/js/SignPanel.tsx
+++ b/assets/js/SignPanel.tsx
@@ -103,6 +103,7 @@ interface SignPanelProps {
   signGroup?: SignGroup;
   ungroupSign?: () => void;
   readOnly: boolean;
+  short?: boolean;
 }
 
 function SignPanel({
@@ -123,6 +124,7 @@ function SignPanel({
   signGroup,
   ungroupSign,
   readOnly,
+  short,
 }: SignPanelProps): JSX.Element {
   const [signConfig, setSignConfig] = React.useState(initialSignConfig);
   const [hasCustomChanges, setHasCustomChanges] = React.useState(false);
@@ -199,7 +201,11 @@ function SignPanel({
           )}
         </div>
         <div className="viewer--sign_text">
-          <SignDisplay content={signContent} currentTime={currentTime} />
+          <SignDisplay
+            content={signContent}
+            currentTime={currentTime}
+            short={short}
+          />
         </div>
       </div>
 

--- a/assets/js/SignText.tsx
+++ b/assets/js/SignText.tsx
@@ -16,6 +16,7 @@ interface SignTextProps {
   line1: string;
   line2: string;
   announcement?: boolean;
+  short?: boolean;
 }
 
 function SignText({
@@ -23,9 +24,11 @@ function SignText({
   line1,
   line2,
   announcement,
+  short,
 }: SignTextProps): JSX.Element | null {
   return (
     <div className="sign_text--container">
+      {short && !announcement && <span className="sign_text--divider" />}
       <div className={cx('sign_text--line', { centered: !!announcement })}>
         {announcement ? line1 : padToClock(line1, time)}
       </div>

--- a/assets/js/SingleSign.tsx
+++ b/assets/js/SingleSign.tsx
@@ -54,6 +54,7 @@ function SingleSign({ signContent }: SingleSignProps): JSX.Element {
       <SignDisplay
         content={currentSignContent}
         currentTime={currentTime + serverTimeOffset}
+        short={signContent.sign_id.startsWith('SCOU-')}
       />
     </div>
   );

--- a/assets/js/Station.tsx
+++ b/assets/js/Station.tsx
@@ -71,6 +71,7 @@ function makeSign(
         signGroup={signGroup}
         ungroupSign={ungroupMe}
         readOnly={readOnly}
+        short={config.id === 'SCOU'}
       />
     );
   }


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Shorter Sign Support in Signs UI](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211438661673784?focus=true)

This adds a visual indicator to Courthouse signs to represent the fact that there are a mix of short and full-length signs in each zone.