### PR TITLE
fix blocking alert updates

### DIFF
--- a/lib/signs_ui/alerts/state.ex
+++ b/lib/signs_ui/alerts/state.ex
@@ -19,32 +19,21 @@ defmodule SignsUi.Alerts.State do
     GenServer.start_link(__MODULE__, [], opts)
   end
 
-  @spec active_alert_ids(SignsUi.Alerts.State) :: MapSet.t(Alert.id())
-  def active_alert_ids(pid \\ __MODULE__) do
-    GenServer.call(pid, :active_alert_ids)
+  @spec active_alert_ids(:ets.table()) :: MapSet.t(Alert.id())
+  def active_alert_ids(table \\ :alerts) do
+    get_alerts(table) |> Map.keys() |> MapSet.new()
   end
 
-  @spec all(SignsUi.Alerts.State) :: Display.t()
-  def all(pid \\ __MODULE__) do
-    GenServer.call(pid, :all)
+  @spec all(:ets.table()) :: Display.t()
+  def all(table \\ :alerts) do
+    get_alerts(table) |> Display.format_state()
   end
 
   @impl GenServer
   def init(_) do
+    :ets.new(:alerts, [:named_table, read_concurrency: true])
     send(self(), :update)
-    {:ok, %{}}
-  end
-
-  @impl GenServer
-  def handle_call(:active_alert_ids, _from, state) do
-    alert_ids = state |> Map.keys() |> MapSet.new()
-
-    {:reply, alert_ids, state}
-  end
-
-  @impl GenServer
-  def handle_call(:all, _from, state) do
-    {:reply, Display.format_state(state), state}
+    {:ok, %{table: :alerts, last_modified: nil}}
   end
 
   @impl GenServer
@@ -52,12 +41,15 @@ defmodule SignsUi.Alerts.State do
     v3_api = Application.get_env(:signs_ui, :v3_api)
 
     state =
-      case v3_api.fetch_alerts() do
-        {:ok, []} ->
+      case v3_api.fetch_alerts(state.last_modified) do
+        {:ok, :not_modified} ->
+          state
+
+        {:ok, [], _last_modified} ->
           Logger.info("empty_alerts_response: keeping current state.")
           state
 
-        {:ok, alerts} ->
+        {:ok, alerts, last_modified} ->
           new_state =
             for alert <- alerts,
                 valid_route_type?(alert),
@@ -73,7 +65,8 @@ defmodule SignsUi.Alerts.State do
           )
 
           Logger.info(["alert_state_updated ", inspect(new_state)])
-          new_state
+          :ets.insert(state.table, {:value, new_state})
+          %{state | last_modified: last_modified}
 
         :error ->
           state
@@ -140,5 +133,12 @@ defmodule SignsUi.Alerts.State do
 
   defp schedule_update(pid, ms) do
     Process.send_after(pid, :update, ms)
+  end
+
+  defp get_alerts(table) do
+    case :ets.lookup(table, :value) do
+      [{:value, value}] -> value
+      _ -> %{}
+    end
   end
 end

--- a/lib/signs_ui/alerts/state.ex
+++ b/lib/signs_ui/alerts/state.ex
@@ -50,7 +50,7 @@ defmodule SignsUi.Alerts.State do
           state
 
         {:ok, alerts, last_modified} ->
-          new_state =
+          new_value =
             for alert <- alerts,
                 valid_route_type?(alert),
                 parsed_alert = parse_alert(alert),
@@ -61,11 +61,11 @@ defmodule SignsUi.Alerts.State do
           SignsUiWeb.Endpoint.broadcast!(
             "alerts:all",
             "new_alert_state",
-            Display.format_state(new_state)
+            Display.format_state(new_value)
           )
 
-          Logger.info(["alert_state_updated ", inspect(new_state)])
-          :ets.insert(state.table, {:value, new_state})
+          Logger.info(["alert_state_updated ", inspect(new_value)])
+          :ets.insert(state.table, {:value, new_value})
           %{state | last_modified: last_modified}
 
         :error ->

--- a/lib/signs_ui/v3_api.ex
+++ b/lib/signs_ui/v3_api.ex
@@ -5,15 +5,22 @@ defmodule SignsUi.V3Api do
 
   require Logger
 
-  @spec fetch_alerts :: {:ok, [map()]} | :error
-  def fetch_alerts do
+  @spec fetch_alerts(String.t() | nil) :: {:ok, [map()]} | :error
+  def fetch_alerts(last_modified) do
     url = "#{Application.get_env(:signs_ui, :api_v3_url)}/alerts"
-    headers = [{"x-api-key", Application.get_env(:signs_ui, :api_v3_key)}]
+
+    headers =
+      [{"x-api-key", Application.get_env(:signs_ui, :api_v3_key)}] ++
+        if(last_modified, do: [{"if-modified-since", last_modified}], else: [])
+
     params = [params: %{"filter[datetime]" => "NOW"}]
 
     case HTTPoison.get(url, headers, params) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, Jason.decode!(body) |> Map.get("data", [])}
+      {:ok, %HTTPoison.Response{status_code: 200, body: body, headers: headers}} ->
+        {:ok, Jason.decode!(body) |> Map.get("data", []), Map.new(headers)["last-modified"]}
+
+      {:ok, %HTTPoison.Response{status_code: 304}} ->
+        {:ok, :not_modified}
 
       {:ok, %HTTPoison.Response{status_code: status_code}} ->
         Logger.error("HTTP error, status=#{status_code}")

--- a/test/signs_ui/alerts/state_test.exs
+++ b/test/signs_ui/alerts/state_test.exs
@@ -3,14 +3,6 @@ defmodule SignsUi.Alerts.StateTest do
   use ExUnit.Case, async: true
   use SignsUiWeb.ChannelCase
 
-  setup do
-    on_exit(fn ->
-      SignsUi.V3ApiStub.reset()
-    end)
-
-    :ok
-  end
-
   @initial_state %{
     "201759" => %{
       id: "201759",
@@ -26,41 +18,33 @@ defmodule SignsUi.Alerts.StateTest do
     }
   }
 
-  describe "handle_call :active_alert_ids" do
-    test "returns the alert_ids out of the state" do
-      state = %{
-        "alert_id1" => %{affected_routes: MapSet.new(["Red"])},
-        "alert_id2" => %{affected_routes: MapSet.new(["Red"])},
-        "alert_id3" => %{affected_routes: MapSet.new(["Blue"])}
-      }
+  setup do
+    on_exit(fn ->
+      SignsUi.V3ApiStub.reset()
+    end)
 
-      assert SignsUi.Alerts.State.handle_call(:active_alert_ids, self(), state) ==
-               {:reply, MapSet.new(["alert_id1", "alert_id2", "alert_id3"]), state}
-    end
-
-    test "safely returns an empty map set if there are no alerts" do
-      state = %{}
-
-      assert SignsUi.Alerts.State.handle_call(:active_alert_ids, self(), state) ==
-               {:reply, MapSet.new(), state}
-    end
+    table = :ets.new(:alerts_test, read_concurrency: true)
+    :ets.insert(table, {:value, @initial_state})
+    %{table: table}
   end
 
   describe "active_alert_ids/0" do
-    test "returns a result without crashing" do
-      assert SignsUi.Alerts.State.handle_call(:active_alert_ids, self(), @initial_state) ==
-               {:reply, MapSet.new(["201759", "201803"]), @initial_state}
+    test "returns correct values", %{table: table} do
+      assert SignsUi.Alerts.State.active_alert_ids(table) ==
+               MapSet.new(["201759", "201803"])
     end
   end
 
-  describe "fetch_alerts/0" do
-    test "does not update alerts state on empty response" do
-      {:noreply, new_state} = SignsUi.Alerts.State.handle_info(:update, @initial_state)
+  describe ":update" do
+    test "does not update alerts state on empty response", %{table: table} do
+      {:noreply, _} =
+        SignsUi.Alerts.State.handle_info(:update, %{table: table, last_modified: nil})
 
-      assert new_state == @initial_state
+      assert SignsUi.Alerts.State.active_alert_ids(table) ==
+               MapSet.new(["201759", "201803"])
     end
 
-    test "updates alerts state when something is returned" do
+    test "updates alerts state when something is returned", %{table: table} do
       SignsUi.V3ApiStub.will_return([
         %{
           "id" => "123456",
@@ -76,18 +60,19 @@ defmodule SignsUi.Alerts.StateTest do
 
       @endpoint.subscribe("alerts:all")
 
-      {:noreply, new_state} = SignsUi.Alerts.State.handle_info(:update, @initial_state)
+      {:noreply, _} =
+        SignsUi.Alerts.State.handle_info(:update, %{table: table, last_modified: nil})
 
-      assert new_state == %{
-               "123456" => %{
-                 id: "123456",
-                 affected_routes: MapSet.new(["Red"]),
-                 created_at: ~U[2025-03-06 12:00:00Z],
-                 service_effect: "Red Line Delay"
-               }
-             }
-
-      expected = Display.format_state(new_state)
+      expected =
+        %{
+          "123456" => %{
+            id: "123456",
+            affected_routes: MapSet.new(["Red"]),
+            created_at: ~U[2025-03-06 12:00:00Z],
+            service_effect: "Red Line Delay"
+          }
+        }
+        |> Display.format_state()
 
       assert_broadcast "new_alert_state", ^expected, 500
     end

--- a/test/support/v3_api_stub.ex
+++ b/test/support/v3_api_stub.ex
@@ -4,9 +4,9 @@ defmodule SignsUi.V3ApiStub do
   Configurable to return different responses.
   """
 
-  def fetch_alerts do
+  def fetch_alerts(_) do
     case Process.get(:v3_api_stub_response) do
-      nil -> {:ok, []}
+      nil -> {:ok, [], nil}
       response -> response
     end
   end
@@ -15,7 +15,7 @@ defmodule SignsUi.V3ApiStub do
   Configure the stub to return specific alerts data.
   """
   def will_return(alerts_data) do
-    Process.put(:v3_api_stub_response, {:ok, alerts_data})
+    Process.put(:v3_api_stub_response, {:ok, alerts_data, nil})
   end
 
   @doc """


### PR DESCRIPTION
#### Summary of changes

This moves the alert data from process state into ETS, in order to avoid an issue where slow HTTP calls could block the process and cause readers to time out. Also uses "last modified" headers to reduce traffic slightly.