### PR TITLE
fix parsing of messages with no zones

### DIFF
--- a/lib/signs_ui_web/controllers/messages_controller.ex
+++ b/lib/signs_ui_web/controllers/messages_controller.ex
@@ -172,8 +172,14 @@ defmodule SignsUiWeb.MessagesController do
   end
 
   defp decode_zones(zones) do
-    {Enum.at(zones, 0) |> String.split("-") |> List.first(),
-     MapSet.new(zones, &(String.split(&1, "-") |> List.last()))}
+    case Enum.at(zones, 0) do
+      nil ->
+        {nil, MapSet.new()}
+
+      zone ->
+        {String.split(zone, "-") |> List.first(),
+         MapSet.new(zones, &(String.split(&1, "-") |> List.last()))}
+    end
   end
 
   defp parse_visual_data(conn) do

--- a/test/signs_ui_web/controllers/messages_controller_test.exs
+++ b/test/signs_ui_web/controllers/messages_controller_test.exs
@@ -141,6 +141,48 @@ defmodule SignsUiWeb.MessagesControllerTest do
         sign_id: "BAIR-e"
       })
     end
+
+    test "play", %{conn: conn} do
+      subscribe_and_join!(socket(), SignsUiWeb.SignsChannel, "signs:all", %{})
+
+      conn
+      |> add_api_req_header()
+      |> post(messages_path(conn, :play), %{
+        "zones" => ["BAIR-e"],
+        "visual_data" => %{
+          "pages" => [%{"top" => "top", "bottom" => "bottom", "duration" => 6}]
+        },
+        "audio_data" => [%{"type" => "chime"}],
+        "expiration" => 180
+      })
+
+      assert_broadcast("sign_update", %{
+        audios: [
+          %{
+            station: "BAIR",
+            zones: ["e"],
+            visual_data: %{pages: [%{top: "top", bottom: "bottom", duration: 6}]}
+          }
+        ],
+        sign_id: "BAIR-e"
+      })
+    end
+
+    test "ignores messages with no zones", %{conn: conn} do
+      subscribe_and_join!(socket(), SignsUiWeb.SignsChannel, "signs:all", %{})
+
+      assert %{status: 200} =
+               conn
+               |> add_api_req_header()
+               |> post(messages_path(conn, :play), %{
+                 "zones" => [],
+                 "visual_data" => nil,
+                 "audio_data" => [%{"type" => "chime"}],
+                 "expiration" => 180
+               })
+
+      refute_broadcast("sign_update", %{})
+    end
   end
 
   defp add_api_req_header(conn) do


### PR DESCRIPTION
#### Summary of changes

This fixes a parsing error when receiving messages with an empty zone list, which happens sometimes because of some sign configs. After the message is parsed this way, the downstream logic will correctly end up treating it as a no-op.