### PR TITLE
chore: ignore major `@types/node` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
   cooldown:
     default-days: 7
   open-pull-requests-limit: 5
+  ignore:
+    # This package should only be upgraded to a new major version together
+    # with the actual Node version used by the project.
+    - dependency-name: "@types/node"
+      update-types: [ "version-update:semver-major" ]
   groups:
     npm-minor:
       update-types:

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -35,7 +35,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "^25.9.3",
+        "@types/node": "^22.20.0",
         "esbuild": "^0.28.1",
         "eslint": "^9.39.2",
         "eslint-plugin-import": "^2.32.0",
@@ -2309,11 +2309,12 @@
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/phoenix": {
@@ -9055,9 +9056,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -11025,11 +11027,11 @@
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
     },
     "@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "requires": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/phoenix": {
@@ -15590,9 +15592,9 @@
       }
     },
     "undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "unrs-resolver": {
       "version": "1.12.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^25.9.3",
+    "@types/node": "^22.20.0",
     "esbuild": "^0.28.1",
     "eslint": "^9.39.2",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** N/A

Align the version of `@types/node` to v22.y, which is declared in the project's `.tool-verions` file/is used by our current version of Phoenix. Update `dependabot.yml` to prevent additional bumps, similar to how we do for the Screens repo.

#### Notes for Reviewers

The impetus for this PR is Dependabot's creation of https://github.com/mbta/signs_ui/pull/1658, which would bump us to the typings for Node v26. To avoid skew and potential typing mismatches, the desire here is to pin the typings to the major version we're on, similar to what we're doing in Screens:
- [Dependabot (screens)](https://github.com/mbta/screens/blob/6dbb665ae3695ef647fcf9e81caad94bbf40beb0/.github/dependabot.yml#L34-L38)
- [Typings (screens)](https://github.com/mbta/screens/blob/6dbb665ae3695ef647fcf9e81caad94bbf40beb0/assets/package.json#L46)

This PR will make https://github.com/mbta/signs_ui/pull/1658 obsolete (for now, until we upgrade to a newer version of Node)

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
