### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
   cooldown:
     default-days: 7
   open-pull-requests-limit: 5
+  groups:
+    github-actions-minor:
+      update-types:
+        - "patch"
+        - "minor"
 - package-ecosystem: mix
   directory: "/"
   schedule:


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** N/A

In the 2026.07.07 retro, we commented that the number of individual PRs was getting high. This commit attempts to cut down on the noise by grouping updates of all actions for minor/patch versions, similar to other ecosystems in this repo

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
