### PR TITLE
reduce logging level for non-critical errors

### DIFF
--- a/lib/signs_ui/alerts/state.ex
+++ b/lib/signs_ui/alerts/state.ex
@@ -40,14 +40,13 @@ defmodule SignsUi.Alerts.State do
   def handle_info(:update, state) do
     v3_api = Application.get_env(:signs_ui, :v3_api)
 
-    state =
+    {result, last_modified, logs} =
       case v3_api.fetch_alerts(state.last_modified) do
         {:ok, :not_modified} ->
-          state
+          {:ok, state.last_modified, "not_modified"}
 
         {:ok, [], _last_modified} ->
-          Logger.info("empty_alerts_response: keeping current state.")
-          state
+          {:ok, state.last_modified, "empty_response"}
 
         {:ok, alerts, last_modified} ->
           new_value =
@@ -64,16 +63,16 @@ defmodule SignsUi.Alerts.State do
             Display.format_state(new_value)
           )
 
-          Logger.info(["alert_state_updated ", inspect(new_value)])
           :ets.insert(state.table, {:value, new_value})
-          %{state | last_modified: last_modified}
+          {:ok, last_modified, "alerts=#{inspect(new_value)}"}
 
-        :error ->
-          state
+        {:error, value} ->
+          {:error, state.last_modified, "value=#{inspect(value)}"}
       end
 
+    Logger.info("fetch_alerts: result=#{result} #{logs}")
     schedule_update(self(), 5_000)
-    {:noreply, state}
+    {:noreply, %{state | last_modified: last_modified}}
   end
 
   defp valid_route_type?(alert) do

--- a/lib/signs_ui/v3_api.ex
+++ b/lib/signs_ui/v3_api.ex
@@ -5,7 +5,8 @@ defmodule SignsUi.V3Api do
 
   require Logger
 
-  @spec fetch_alerts(String.t() | nil) :: {:ok, [map()]} | :error
+  @spec fetch_alerts(String.t() | nil) ::
+          {:ok, [map()], String.t()} | {:ok, :not_modified} | {:error, term()}
   def fetch_alerts(last_modified) do
     url = "#{Application.get_env(:signs_ui, :api_v3_url)}/alerts"
 
@@ -22,17 +23,8 @@ defmodule SignsUi.V3Api do
       {:ok, %HTTPoison.Response{status_code: 304}} ->
         {:ok, :not_modified}
 
-      {:ok, %HTTPoison.Response{status_code: status_code}} ->
-        Logger.error("HTTP error, status=#{status_code}")
-        :error
-
-      {:error, reason} ->
-        Logger.error([
-          "alerts_fetch_failed, reason=",
-          inspect(reason)
-        ])
-
-        :error
+      {_, result} ->
+        {:error, result}
     end
   end
 end

--- a/lib/signs_ui_web/controllers/auth_controller.ex
+++ b/lib/signs_ui_web/controllers/auth_controller.ex
@@ -33,7 +33,7 @@ defmodule SignsUiWeb.AuthController do
         %{assigns: %{ueberauth_failure: %Ueberauth.Failure{errors: errors}}} = conn,
         _params
       ) do
-    Logger.error("ueberauth_failure #{inspect(errors)}")
+    Logger.warning("ueberauth_failure #{inspect(errors)}")
 
     if error?(errors, "bad_state") do
       reauthenticate(conn)

--- a/test/signs_ui_web/controllers/auth_controller_test.exs
+++ b/test/signs_ui_web/controllers/auth_controller_test.exs
@@ -15,7 +15,7 @@ defmodule SignsUiWeb.AuthControllerTest do
 
     test "handles generic failure", %{conn: conn} do
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :warning], fn ->
           conn =
             conn
             |> assign(:ueberauth_failure, %Ueberauth.Failure{})


### PR DESCRIPTION
#### Summary of changes

This changes a few logs to use less severe levels, in order to reduce noise in our Slack alerts. The main one is the alert fetching code that sometimes encounters temporary errors or timeouts, which are actually fine as long as they don't persist. The plan is to add a new Splunk alert that will fire if we don't see a successful response for some amount of time (e.g. 1 hour).