### PR TITLE
chore: remove unused field from logger config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,7 @@ config :signs_ui, SignsUiWeb.AuthManager, secret_key: {System, :get_env, ["SIGNS
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:messages_api_user, :user_id, :request_id, :remote_ip]
+  metadata: [:messages_api_user, :request_id, :remote_ip]
 
 config :logger,
   backends: [:console, Sentry.LoggerBackend]


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** N/A

Remove the `user_id` atom from the console logger configuration, as this field does not appear to be used anymore.

#### Notes for Reviewers

This config seems to have been introduced in 2018. I don't _think_ we use it anymore, but please feel free to double check me here - I don't believe any plugs are injecting this into our logs, nor do I see a `Logger.metdata()` call containing it's usage

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
