### PR TITLE
add zizmor to repo

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -3,12 +3,16 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions: {}
+
 jobs:
   asana:
-    uses: mbta/workflows/.github/workflows/asana.yml@v5
+    uses: mbta/workflows/.github/workflows/asana.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       attach-pr: true
       trigger-phrase: "\\*\\*Asana Ticket:\\*\\*"
+    permissions:
+      pull-requests: read # Needed to read Asana ticket info from PR description
     secrets:
       asana-token: ${{ secrets.ASANA_SECRET_FOR_INSURIFY_ACTION }}
       github-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -10,37 +10,42 @@ on:
   push:
     branches: ["master"]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.event.inputs.environment || 'dev'}}
   cancel-in-progress: true
 
 jobs:
   deploy:
+    name: deploy
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     environment: ${{ github.event.inputs.environment || 'dev'}}
     env:
       ECS_CLUSTER: signs-ui
       ECS_SERVICE: signs-ui-${{ github.event.inputs.environment || 'dev'}}
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - id: metadata
-        uses: mbta/actions/commit-metadata@v2
-      - uses: mbta/actions/build-push-ecr@v2
+        uses: mbta/actions/commit-metadata@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
+      - uses: mbta/actions/build-push-ecr@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
         id: build-push
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - uses: mbta/actions/deploy-ecs@v2
+      - uses: mbta/actions/deploy-ecs@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.ECS_SERVICE }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-      - uses: mbta/actions/notify-slack-deploy@v2
+      - uses: mbta/actions/notify-slack-deploy@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
         if: ${{ !cancelled() }}
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,22 +2,30 @@ name: Elixir and JavaScript CI
 
 on: [pull_request]
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       # if we did hit the cache, set up the environment
       - name: Setup ASDF environment
@@ -37,7 +45,7 @@ jobs:
           mix local.hex --force
       - name: <elixir> Restore dependencies cache
         id: elixir-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -45,14 +53,14 @@ jobs:
         if: steps.elixir-cache.outputs.cache-hit != 'true'
         run: mix deps.get
       - name: <node> Restore dependencies cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "assets/node_modules"
           key: ${{ runner.os }}-nodejs-${{ hashFiles('assets/package-lock.json') }}
         id: node-cache
       - name: <node> Install dependencies (if needed)
         if: steps.node-cache.outputs.cache-hit != 'true'
-        run: npm install --prefix assets
+        run: npm ci --prefix assets
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
       - name: Check formatting
@@ -67,4 +75,4 @@ jobs:
         run: npm run check --prefix assets
       - name: JS tests
         run: npm run test --prefix assets
-      - uses: mbta/actions/dialyzer@v2
+      - uses: mbta/actions/dialyzer@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Check
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false
+          persona: auditor


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** [Add Zizmor to signs_ui](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216719907405008?focus=true)

This commit adds zizmor to the repo. Doing so entails to components:
1. Adding a new workflow to run zizmor when workflow files are edited
2. Updating existing workflows to be compliant with the pedantic persona provided by zizmor

For this repository, the latter consisted of:
1. Pinning actions used. Most actions were up to date already, making this action largely a no-op. Version comment strings have been updated to ensure they do not use major version only tags (e.g. `v5`), as these can cause issues should the tag move to a new version.
2. Updating permissions so actions use have the least amount of permission when running
3. Justifying permissions via comments
4. Using `npm ci` instead of `npm install` for reproducible installs
5. Adding missing concurrency settings

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on coverage statistics)
- [ ] Ask product if custom label updates in `mbta.ts` should also be made to `paess_labels.json` in Screenplay
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840769.3874970) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840745.3874956))
